### PR TITLE
Add PSI Dockerfile to enable current deployment

### DIFF
--- a/CI/PSI/Dockerfile
+++ b/CI/PSI/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx 
+
+ARG env=production
+# RUN ./node_modules/@angular/cli/bin/ng build --prod
+COPY scripts/nginx.conf /etc/nginx/nginx.conf
+COPY dist/${env} /usr/share/nginx/html  
+
+EXPOSE 80


### PR DESCRIPTION
## Description
Restore old Dockerfile and move to CI/PSI/
## Motivation
To restore the current way of deployment to a working version, the old Dockerfile is added for now to CI/PSI and used during build (at PSI)

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

