### PR TITLE
Retrieve dest

### DIFF
--- a/src/app/app-config.module.ts
+++ b/src/app/app-config.module.ts
@@ -10,6 +10,11 @@ export class OAuth2Endpoint {
   authURL= "";
 }
 
+export class RetrieveDestinations {
+  option = "";
+  location?: string | null = null;
+}
+
 export class AppConfig {
   lbBaseURL = "";
   externalAuthEndpoint: string | null = null;
@@ -57,6 +62,7 @@ export class AppConfig {
   userNamePromptEnabled = false;
   loginFormEnabled = true;
   oAuth2Endpoints: OAuth2Endpoint[] = [];
+  retrieveDestinations?: RetrieveDestinations[] = [];
 }
 
 export const APP_DI_CONFIG: AppConfig = {
@@ -82,7 +88,8 @@ export const APP_DI_CONFIG: AppConfig = {
   jobsEnabled: environment.jobsEnabled ?? false,
   jsonMetadataEnabled: environment.jsonMetadataEnabled ?? false,
   logbookEnabled: environment.logbookEnabled ?? false,
-  localColumns: environment.localColumns ?? [
+  retrieveDestinations: environment["retrieveDestinations"] || [],
+  localColumns: environment["localColumns"] || [
     { name: "select", order: 0, type: "standard", enabled: true },
     { name: "datasetName", order: 1, type: "standard", enabled: true },
     { name: "runNumber", order: 2, type: "standard", enabled: true },

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed, waitForAsync } from "@angular/core/testing";
 import { MockStore, provideMockStore } from "@ngrx/store/testing";
+import { RetrieveDestinations } from "app-config.module";
 import { Dataset, Job, User } from "shared/sdk";
 import { submitJobAction } from "state-management/actions/jobs.actions";
 import {
@@ -145,4 +146,31 @@ describe("ArchivingService", () => {
       );
     });
   });
+
+  describe("#generateDestPath()", () => {
+    it("should return the generated path", () => {
+      const result = { option: "option", location: "relative" };
+      const destinations = [{ option: "option", location: "/root/" }, { option: "option2" }];
+      expect(service.generateDestPath(result, destinations)).toEqual(
+        "option:/root/relative"
+      );
+    });
+  });
+
+  describe("#retriveDialogOptions()", () => {
+    it("should return the dialog options when retrieving", () => {
+      const destinations = [new RetrieveDestinations(), new RetrieveDestinations()];
+      expect(service.retriveDialogOptions(destinations)).toEqual(
+        {
+          width: "auto",
+          data: {
+            title: "Really retrieve?",
+            question: "",
+            choice: { title: "Optionally select destination", options: destinations }
+          }
+        }
+      );
+    });
+  });
+
 });

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -53,7 +53,7 @@ describe("ArchivingService", () => {
         files: [],
       }));
       const archive = true;
-      const destinationPath = "/test/path/";
+      const destinationPath = {destinationPath: "/test/path/"};
 
       const job = service["createJob"](
         user,
@@ -135,7 +135,7 @@ describe("ArchivingService", () => {
         "archiveOrRetrieve"
       );
       const datasets = [new Dataset()];
-      const destinationPath = "/test/path/";
+      const destinationPath = {location: "/test/path/"};
 
       service.retrieve(datasets, destinationPath);
 
@@ -147,12 +147,12 @@ describe("ArchivingService", () => {
     });
   });
 
-  describe("#generateDestPath()", () => {
+  describe("#generateOptionLocation()", () => {
     it("should return the generated path", () => {
       const result = { option: "option", location: "relative" };
       const destinations = [{ option: "option", location: "/root/" }, { option: "option2" }];
-      expect(service.generateDestPath(result, destinations)).toEqual(
-        "option:/root/relative"
+      expect(service.generateOptionLocation(result, destinations)).toEqual(
+        {option: "option", location: "/root/relative"}
       );
     });
   });

--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 import { select, Store } from "@ngrx/store";
+import { RetrieveDestinations } from "app-config.module";
 
 import { combineLatest, Observable } from "rxjs";
 import { first, map } from "rxjs/operators";
@@ -66,13 +67,13 @@ export class ArchivingService {
               "No email for this user could be found, the job will not be submitted"
             );
           }
-  
+
           if (datasets.length === 0) {
             throw new Error("No datasets selected");
           }
-  
+
           const job = this.createJob(user, datasets, archive, destPath);
-  
+
           this.store.dispatch(submitJobAction({ job }));
         }
       })
@@ -88,5 +89,36 @@ export class ArchivingService {
     destinationPath: string
   ): Observable<void> {
     return this.archiveOrRetrieve(datasets, false, destinationPath);
+  }
+
+  public generateDestPath(
+    result: RetrieveDestinations,
+    retrieveDestinations: RetrieveDestinations[] = []
+  ): string {
+    const prefix = retrieveDestinations.filter(
+      element => element.option == result.option
+    );
+    let location = prefix.length > 0 ? ":" + prefix[0].location + result.location : "";
+    let destPath = result.option + location || "/archive/retrieve";
+    if (!result.option &&
+      typeof retrieveDestinations !== "undefined" &&
+      retrieveDestinations.length > 0) {
+      location = retrieveDestinations[0].location ? ":" + retrieveDestinations[0].location : "";
+      destPath = retrieveDestinations[0].option + location;
+    }
+    return destPath;
+  }
+
+  public retriveDialogOptions(
+    retrieveDestinations: RetrieveDestinations[] = []
+  ): object {
+    return {
+      width: "auto",
+      data: {
+        title: "Really retrieve?",
+        question: "",
+        choice: { title: "Optionally select destination", options: retrieveDestinations }
+      }
+    };
   }
 }

--- a/src/app/datasets/batch-view/batch-view.component.ts
+++ b/src/app/datasets/batch-view/batch-view.component.ts
@@ -110,10 +110,12 @@ export class BatchViewComponent implements OnInit, OnDestroy {
   onRetrieve() {
     let dialogOptions = this.archivingSrv.retriveDialogOptions(this.appConfig.retrieveDestinations);
     const dialogRef = this.dialog.open(DialogComponent, dialogOptions);
+    const destPath = {destinationPath: "/archive/retrieve"};
     dialogRef.afterClosed().subscribe(result => {
       if (result && this.datasetList) {
-        const destPath = this.archivingSrv.generateDestPath(result, this.appConfig.retrieveDestinations);
-        this.archivingSrv.retrieve(this.datasetList, destPath).subscribe(
+        const locationOption = this.archivingSrv.generateOptionLocation(result, this.appConfig.retrieveDestinations);
+        const extra = {...destPath, ...locationOption};
+        this.archivingSrv.retrieve(this.datasetList, extra).subscribe(
           () => this.clearBatch(),
           err =>
             this.store.dispatch(

--- a/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
+++ b/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
@@ -107,17 +107,11 @@ export class DatasetTableActionsComponent implements OnInit, OnDestroy {
    * @memberof DashboardComponent
    */
   retrieveClickHandle(): void {
-    const destPath = "/archive/retrieve";
-    const dialogRef = this.dialog.open(DialogComponent, {
-      width: "auto",
-      data: {
-        title: "Really retrieve?",
-        question: ""
-      }
-    });
-
+    let dialogOptions = this.archivingSrv.retriveDialogOptions(this.appConfig.retrieveDestinations);
+    const dialogRef = this.dialog.open(DialogComponent, dialogOptions);
     dialogRef.afterClosed().subscribe(result => {
       if (result && this.selectedSets) {
+        const destPath = this.archivingSrv.generateDestPath(result, this.appConfig.retrieveDestinations);
         this.archivingSrv.retrieve(this.selectedSets, destPath).subscribe(
           () => this.store.dispatch(clearSelectionAction()),
           err =>

--- a/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
+++ b/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
@@ -107,12 +107,14 @@ export class DatasetTableActionsComponent implements OnInit, OnDestroy {
    * @memberof DashboardComponent
    */
   retrieveClickHandle(): void {
+    const destPath = {destinationPath: "/archive/retrieve"};
     let dialogOptions = this.archivingSrv.retriveDialogOptions(this.appConfig.retrieveDestinations);
     const dialogRef = this.dialog.open(DialogComponent, dialogOptions);
     dialogRef.afterClosed().subscribe(result => {
       if (result && this.selectedSets) {
-        const destPath = this.archivingSrv.generateDestPath(result, this.appConfig.retrieveDestinations);
-        this.archivingSrv.retrieve(this.selectedSets, destPath).subscribe(
+        const locationOption = this.archivingSrv.generateOptionLocation(result, this.appConfig.retrieveDestinations);
+        const extra = {...destPath, ...locationOption};
+        this.archivingSrv.retrieve(this.selectedSets, extra).subscribe(
           () => this.store.dispatch(clearSelectionAction()),
           err =>
             this.store.dispatch(

--- a/src/app/shared/modules/dialog/dialog.component.html
+++ b/src/app/shared/modules/dialog/dialog.component.html
@@ -4,6 +4,24 @@
   <mat-form-field *ngIf="data.input">
     <input matInput tabindex="1" [(ngModel)]="data.input">
   </mat-form-field>
+  <div *ngIf="data.choice?.options?.length > 0">
+    <mat-form-field>
+      <mat-label>{{data.choice.title}}</mat-label>
+      <mat-select [(ngModel)]="data.option">
+        <mat-option *ngFor="let choice of data.choice.options"
+          [value]="choice.option">{{choice.option}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <span *ngFor="let choice of data.choice.options">
+      <mat-form-field
+        *ngIf="choice.option === data.option && choice.location">
+        <span matPrefix>{{choice.location}}&nbsp;</span>
+        <input [(ngModel)]="data.location" matInput placeholder="Relative path">
+      </mat-form-field>
+    </span>
+  </div>
+
 </div>
 <div mat-dialog-actions>
   <button mat-button [mat-dialog-close]="data" tabindex="2">Ok</button>

--- a/src/app/shared/modules/dialog/dialog.component.html
+++ b/src/app/shared/modules/dialog/dialog.component.html
@@ -4,25 +4,26 @@
   <mat-form-field *ngIf="data.input">
     <input matInput tabindex="1" [(ngModel)]="data.input">
   </mat-form-field>
-  <div *ngIf="data.choice?.options?.length > 0">
-    <mat-form-field>
-      <mat-label>{{data.choice.title}}</mat-label>
-      <mat-select [(ngModel)]="data.option">
-        <mat-option *ngFor="let choice of data.choice.options"
-          [value]="choice.option">{{choice.option}}</mat-option>
-      </mat-select>
-    </mat-form-field>
-
-    <span *ngFor="let choice of data.choice.options">
-      <mat-form-field
-        *ngIf="choice.option === data.option && choice.location">
-        <span matPrefix>{{choice.location}}&nbsp;</span>
-        <input [(ngModel)]="data.location" matInput placeholder="Relative path">
-      </mat-form-field>
-    </span>
-  </div>
-
 </div>
+
+<div *ngIf="data.choice?.options?.length > 0">
+  <mat-form-field>
+    <mat-label>{{data.choice.title}}</mat-label>
+    <mat-select [(ngModel)]="data.option">
+      <mat-option *ngFor="let choice of data.choice.options"
+        [value]="choice.option">{{choice.option}}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <span *ngFor="let choice of data.choice.options">
+    <mat-form-field
+      *ngIf="choice.option === data.option && choice.location">
+      <span matPrefix>{{choice.location}}&nbsp;</span>
+      <input [(ngModel)]="data.location" matInput placeholder="Relative path">
+    </mat-form-field>
+  </span>
+</div>
+
 <div mat-dialog-actions>
   <button mat-button [mat-dialog-close]="data" tabindex="2">Ok</button>
   <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>

--- a/src/app/shared/modules/dialog/dialog.component.scss
+++ b/src/app/shared/modules/dialog/dialog.component.scss
@@ -1,0 +1,4 @@
+.mat-input-element {    
+    margin: -6px 0px -3px 0px;
+    vertical-align: middle;
+}

--- a/src/app/shared/modules/dialog/dialog.module.ts
+++ b/src/app/shared/modules/dialog/dialog.module.ts
@@ -7,11 +7,14 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
+
 @NgModule({
   imports: [
     CommonModule,
     MatDialogModule,
     MatInputModule,
+    MatSelectModule,
     MatButtonModule,
     MatFormFieldModule,
     FormsModule,

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -9,6 +9,7 @@ export const environment = {
   production: true,
   lbBaseURL: "https://dacat-development.psi.ch",
   archiveWorkflowEnabled: true,
+  retrieveDestinations: [{option: "PSI", location: "/home/out"}, {option:"CSCS (Testphase)"}],
   externalAuthEndpoint: "/auth/msad",
   editMetadataEnabled: true,
   editSampleEnabled: true,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -15,6 +15,7 @@ export const environment = {
   externalAuthEndpoint: "/auth/msad",
   addDatasetEnabled: false,
   archiveWorkflowEnabled: true,
+  retrieveDestinations: [{option: "PSI", location: "/home/out"}, {option:"CSCS (Testphase)"}],
   columnSelectEnabled: true,
   datasetReduceEnabled: false,
   disabledDatasetColumns: [],

--- a/src/environments/environment.qa.ts
+++ b/src/environments/environment.qa.ts
@@ -15,6 +15,7 @@ export const environment = {
   externalAuthEndpoint: "/auth/msad",
   addDatasetEnabled: false,
   archiveWorkflowEnabled: true,
+  retrieveDestinations: [{option: "PSI", location: "/home/out"}, {option:"CSCS (Testphase)"}],
   columnSelectEnabled: true,
   datasetReduceEnabled: false,
   disabledDatasetColumns: [],

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -65,5 +65,6 @@ export const environment = {
   userNamePromptEnabled: true,
   userProfileImageEnabled: true,
   oAuth2Endpoints: [],
-  loginFormEnabled: true
+  loginFormEnabled: true,
+  retrieveDestinations: []
 };


### PR DESCRIPTION
## Description

Enable option to choose between different retrieve destinations. If specified, enable the selection of the path on the retrieve location. 

The option can be set by adding the `retrieveDestinations` option to the environment.ts file This is optional, and there is no need to add an empty list in case of no use. E.g.:
```
  retrieveDestinations: [{option: "PSI", location: "/home/out"}, {option:"CSCS (Testphase)"}]
```

Expected behaviour when enabling `retrieveDestinations`: 
* The user selects the option from a dropdown list, if the `location` field is non-empty for the selected option, a new field is shown, where she can select the location path, relative to the one in the `retrieveDestinations[i].location`.
* if no `location`, no further field will be shown
* two new fields are added in the job model, under `jobParams.location` and `jobParams.option`. If there is no `location in the `retrieveDestinations` option selected by the user, no  `jobParams.location` field is added to Job.

Below is an example:

1a. ![image](https://user-images.githubusercontent.com/50220438/145630024-c528df58-6096-480b-9baf-31eb98bb1676.png)
2a. ![image](https://user-images.githubusercontent.com/50220438/145630090-69e28613-40a9-4d81-acea-bda67d8c67e0.png)
3a. ![image](https://user-images.githubusercontent.com/50220438/145630182-0ec7158a-ef05-4f67-b00e-235e17d75b7b.png)
1b. ![image](https://user-images.githubusercontent.com/50220438/145630306-b9282134-0c33-49f8-9c4f-680fc7ae9ef3.png)

and the corresponding results stored in the DB:
a. ![image](https://user-images.githubusercontent.com/50220438/145630490-aabbe1c3-4aeb-4720-b777-559db1393ab5.png)
b.![image](https://user-images.githubusercontent.com/50220438/145630538-35798402-5324-4ff5-a444-6d0c10be8956.png)

## Motivation

At PSI we need to support such a use-case. Users will be able to retrieve data to PSI or via email or to cscs

## Changes:

* archiving-service-spec -> change the archiving logic to store two more info in the job model (option and location)
* dataset-table-actions -> make use of retrieval option when selecting datasets in dataset table
* batch-view  -> make use of retrieval option when adding to cart
* dialog-component -> enable the user to choose between different options

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [x] Toggle added for new features?
- [ ] Requires update of catamel API?

