### PR TITLE
Chore/user view model selectors

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1054,10 +1054,8 @@ exports[`stricter compilation`] = {
     "src/app/users/login/login.component.spec.ts:87531066": [
       [160, 8, 71, "Expected 0 arguments, but got 1.", "3870196511"]
     ],
-    "src/app/users/user-settings/user-settings.component.spec.ts:2325442996": [
-      [95, 8, 32, "Expected 0 arguments, but got 1.", "1341113725"],
-      [97, 47, 30, "Expected 0 arguments, but got 1.", "2329020575"],
-      [117, 47, 30, "Expected 0 arguments, but got 1.", "2329020575"]
+    "src/app/users/user-settings/user-settings.component.spec.ts:235762097": [
+      [87, 47, 30, "Expected 0 arguments, but got 1.", "2329020575"]
     ]
   }`
 };

--- a/.betterer.results
+++ b/.betterer.results
@@ -1051,8 +1051,8 @@ exports[`stricter compilation`] = {
       [65, 8, 10, "Argument of type \'{ mode: null; sortField: string; skip: number; limit: number; }\' is not assignable to parameter of type \'Expected<JobFilters>\'.\\n  Type \'{ mode: null; sortField: string; skip: number; limit: number; }\' is not assignable to type \'{ mode: ExpectedRecursive<Record<string, string> | undefined>; sortField: ExpectedRecursive<string>; skip: ExpectedRecursive<number>; limit: ExpectedRecursive<...>; }\'.\\n    Types of property \'mode\' are incompatible.\\n      Type \'null\' is not assignable to type \'ExpectedRecursive<Record<string, string> | undefined>\'.", "2675413713"],
       [74, 16, 4, "Argument of type \'null\' is not assignable to parameter of type \'Expected<Record<string, string> | undefined>\'.", "2087897566"]
     ],
-    "src/app/users/login/login.component.spec.ts:590365834": [
-      [154, 8, 71, "Expected 0 arguments, but got 1.", "3870196511"]
+    "src/app/users/login/login.component.spec.ts:87531066": [
+      [160, 8, 71, "Expected 0 arguments, but got 1.", "3870196511"]
     ],
     "src/app/users/user-settings/user-settings.component.spec.ts:2325442996": [
       [95, 8, 32, "Expected 0 arguments, but got 1.", "1341113725"],

--- a/src/app/state-management/selectors/user.selectors.spec.ts
+++ b/src/app/state-management/selectors/user.selectors.spec.ts
@@ -212,4 +212,22 @@ describe("User Selectors", () => {
       ).toEqual({ isLoggedIn: false, isLoggingIn: false });
     });
   });
+
+  describe("selectUserSettingsPageViewModel", () => {
+    it("should select the user settings page view model state", () => {
+      expect(
+        fromSelectors.selectUserSettingsPageViewModel.projector(
+          initialUserState.currentUser,
+          initialUserState.profile,
+          initialUserState.catamelToken.id,
+          initialUserState.settings
+        )
+      ).toEqual({
+        user,
+        profile: userIdentity.profile,
+        catamelToken: catamelToken.id,
+        settings,
+      });
+    });
+  });
 });

--- a/src/app/state-management/selectors/user.selectors.spec.ts
+++ b/src/app/state-management/selectors/user.selectors.spec.ts
@@ -201,4 +201,15 @@ describe("User Selectors", () => {
       ]);
     });
   });
+
+  describe("selectLoginPageViewModel", () => {
+    it("should select the login page view model state", () => {
+      expect(
+        fromSelectors.selectLoginPageViewModel.projector(
+          initialUserState.isLoggedIn,
+          initialUserState.isLoggingIn
+        )
+      ).toEqual({ isLoggedIn: false, isLoggingIn: false });
+    });
+  });
 });

--- a/src/app/state-management/selectors/user.selectors.ts
+++ b/src/app/state-management/selectors/user.selectors.ts
@@ -98,3 +98,16 @@ export const selectLoginPageViewModel = createSelector(
   selectIsLoggingIn,
   (isLoggedIn, isLoggingIn) => ({ isLoggedIn, isLoggingIn })
 );
+
+export const selectUserSettingsPageViewModel = createSelector(
+  selectCurrentUser,
+  selectProfile,
+  selectCatamelToken,
+  selectSettings,
+  (user, profile, catamelToken, settings) => ({
+    user,
+    profile,
+    catamelToken,
+    settings,
+  })
+);

--- a/src/app/state-management/selectors/user.selectors.ts
+++ b/src/app/state-management/selectors/user.selectors.ts
@@ -92,3 +92,9 @@ export const selectColumns = createSelector(
   selectUserState,
   (state) => state.columns
 );
+
+export const selectLoginPageViewModel = createSelector(
+  selectIsLoggedIn,
+  selectIsLoggingIn,
+  (isLoggedIn, isLoggingIn) => ({ isLoggedIn, isLoggingIn })
+);

--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -1,4 +1,4 @@
-<div class="main-login">
+<div class="main-login" *ngIf="vm$ | async as vm">
   <div class="login-container" fxLayoutAlign="center center">
     <mat-card>
       <div fxLayout="row" class="facility-logo">
@@ -14,7 +14,7 @@
           class="oauth-login-button"
           mat-raised-button
           type="submit"
-          [ngClass]="{ loading: loading$ | async }"
+          [ngClass]="{ loading: vm.isLoggingIn }"
           (click) = "redirectOIDC(endpoint.authURL)"
         >
           <img class="oauth-login-image" *ngIf="endpoint.displayImage" [src]="endpoint.displayImage">
@@ -63,7 +63,7 @@
             class="login-button"
             type="submit"
             color="primary"
-            [ngClass]="{ loading: loading$ | async }"
+            [ngClass]="{ loading: vm.isLoggingIn }"
           >
             Log in
           </button>

--- a/src/app/users/login/login.component.spec.ts
+++ b/src/app/users/login/login.component.spec.ts
@@ -2,7 +2,7 @@ import {
   ComponentFixture,
   TestBed,
   inject,
-  waitForAsync
+  waitForAsync,
 } from "@angular/core/testing";
 import { ReactiveFormsModule, FormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -22,6 +22,8 @@ import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
+import { provideMockStore } from "@ngrx/store/testing";
+import { selectLoginPageViewModel } from "state-management/selectors/user.selectors";
 
 describe("LoginComponent", () => {
   let component: LoginComponent;
@@ -31,50 +33,60 @@ describe("LoginComponent", () => {
   let dispatchSpy;
 
   const endpoints: OAuth2Endpoint[] = [];
-  const appConfig =  {
+  const appConfig = {
     disabledDatasetColumns: [],
     archiveWorkflowEnabled: true,
     facility: "not-ESS",
     loginFormEnabled: true,
     oAuth2Endpoints: endpoints,
-    lbBaseURL: "http://foo"
+    lbBaseURL: "http://foo",
   };
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [LoginComponent],
-      imports: [
-        AppConfigModule,
-        BrowserAnimationsModule,
-        FormsModule,
-        MatButtonModule,
-        MatCardModule,
-        MatDialogModule,
-        MatCheckboxModule,
-        MatFormFieldModule,
-        MatIconModule,
-        MatInputModule,
-        ReactiveFormsModule,
-        StoreModule.forRoot({})
-      ]
-    });
-    TestBed.overrideComponent(LoginComponent, {
-      set: {
-        // These should sync up with what is in the constructor, they do NOT need to be provided in the config for the testing module
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [LoginComponent],
+        imports: [
+          AppConfigModule,
+          BrowserAnimationsModule,
+          FormsModule,
+          MatButtonModule,
+          MatCardModule,
+          MatDialogModule,
+          MatCheckboxModule,
+          MatFormFieldModule,
+          MatIconModule,
+          MatInputModule,
+          ReactiveFormsModule,
+          StoreModule.forRoot({}),
+        ],
         providers: [
-          {
-            provide: APP_CONFIG,
-            useValue: appConfig
-          },
-          { provide: ActivatedRoute, useClass: MockActivatedRoute },
-          { provide: Router, useClass: MockRouter }
-        ]
-      }
-    });
-    TestBed.compileComponents();
-
-  }));
-
+          provideMockStore({
+            selectors: [
+              {
+                selector: selectLoginPageViewModel,
+                value: { isLoggedIn: false, isLoggingIn: false },
+              },
+            ],
+          }),
+        ],
+      });
+      TestBed.overrideComponent(LoginComponent, {
+        set: {
+          // These should sync up with what is in the constructor, they do NOT need to be provided in the config for the testing module
+          providers: [
+            {
+              provide: APP_CONFIG,
+              useValue: appConfig,
+            },
+            { provide: ActivatedRoute, useClass: MockActivatedRoute },
+            { provide: Router, useClass: MockRouter },
+          ],
+        },
+      });
+      TestBed.compileComponents();
+    })
+  );
 
   beforeEach(inject([Store], (mockStore: MockStore) => {
     store = mockStore;
@@ -83,9 +95,6 @@ describe("LoginComponent", () => {
   afterEach(() => {
     fixture.destroy();
   });
-
-
-
 
   describe("component construction", () => {
     beforeEach(() => {
@@ -98,7 +107,6 @@ describe("LoginComponent", () => {
     it("should have a Document instance injected", () => {
       expect(component.document).toBeTruthy();
     });
-
   });
 
   describe("#openPrivacyDialog()", () => {
@@ -122,21 +130,19 @@ describe("LoginComponent", () => {
     });
   });
 
-  describe("not ESS", ()=> {
+  describe("not ESS", () => {
     beforeEach(() => {
       appConfig.facility = "not-ESS";
       appConfig.loginFormEnabled = true;
       fixture = TestBed.createComponent(LoginComponent);
       component = fixture.componentInstance;
       fixture.detectChanges();
-
     });
     it("should should not appear", () => {
-      const compiled = fixture.debugElement.nativeElement;  
+      const compiled = fixture.debugElement.nativeElement;
       expect(compiled.querySelector("privacy-notice")).toBeFalsy();
     });
   });
-
 
   describe("#onLogin()", () => {
     beforeEach(() => {
@@ -157,7 +163,6 @@ describe("LoginComponent", () => {
     });
   });
 
-
   describe("form not configured", () => {
     beforeEach(() => {
       appConfig.loginFormEnabled = false;
@@ -170,7 +175,6 @@ describe("LoginComponent", () => {
       const compiled = fixture.debugElement.nativeElement;
       expect(compiled.querySelector("form")).toBeNull();
     });
-
   });
 
   describe("form configured", () => {
@@ -185,7 +189,6 @@ describe("LoginComponent", () => {
       const compiled = fixture.debugElement.nativeElement;
       expect(compiled.querySelector("form")).toBeTruthy();
     });
-
   });
 
   describe("oauth2 not configurated", () => {
@@ -198,7 +201,6 @@ describe("LoginComponent", () => {
       const compiled = fixture.debugElement.nativeElement;
       expect(compiled.querySelector("oauth-login-button")).toBeFalsy();
     });
-
   });
 
   describe("oauth2 configurated", () => {
@@ -206,7 +208,10 @@ describe("LoginComponent", () => {
       fixture = TestBed.createComponent(LoginComponent);
       component = fixture.componentInstance;
       fixture.detectChanges();
-      const endpoint: OAuth2Endpoint = {displayText: "oauth provider", authURL: "/auth/foo"};
+      const endpoint: OAuth2Endpoint = {
+        displayText: "oauth provider",
+        authURL: "/auth/foo",
+      };
       appConfig.oAuth2Endpoints = [endpoint];
     });
     it("should display OAuth2 provider", () => {
@@ -219,6 +224,5 @@ describe("LoginComponent", () => {
       console.log(`!!!!!     ${component.document.location.href}`);
       // expect(component.document.location.href).toEqual(`${appConfig.lbBaseURL}/auth/foo`);
     });
-
   });
 });

--- a/src/app/users/user-settings/user-settings.component.html
+++ b/src/app/users/user-settings/user-settings.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="row" fxLayout.xs="column" *ngIf="user$ | async as user">
+<div fxLayout="row" fxLayout.xs="column" *ngIf="vm$ | async as vm">
   <div fxFlex="80">
     <mat-card>
       <mat-card-header class="general-header">
@@ -8,31 +8,43 @@
         User Information
       </mat-card-header>
 
-      <img
-        class="profile-image"
-        src="{{ profileImage$ | async }}"
-        height="65px"
-        alt="profile photo"
-      />
+      <ng-container
+        *ngIf="vm.profile && vm.profile.thumbnailPhoto; else noPhoto"
+      >
+        <img
+          class="profile-image"
+          src="{{ vm.profile.thumbnailPhoto }}"
+          height="65px"
+          alt="profile photo"
+        />
+      </ng-container>
+      <ng-template #noPhoto>
+        <img
+          class="profile-image"
+          src="assets/images/user.png"
+          height="65px"
+          alt="profile photo"
+        />
+      </ng-template>
 
       <table>
-        <tr *ngIf="displayName$ | async as value">
+        <tr *ngIf="vm.profile && vm.profile.displayName">
           <th>Name</th>
-          <td>{{ value }}</td>
+          <td>{{ vm.profile.displayName }}</td>
         </tr>
-        <tr *ngIf="user['email'] as value">
+        <tr *ngIf="vm.user && vm.user.email">
           <th>Email</th>
-          <td>{{ value }}</td>
+          <td>{{ vm.user.email }}</td>
         </tr>
-        <tr *ngIf="user.id as value">
+        <tr *ngIf="vm.user && vm.user.id">
           <th>Id</th>
-          <td>{{ value }}</td>
+          <td>{{ vm.user.id }}</td>
         </tr>
-        <tr *ngIf="accessGroups$ | async as value">
+        <tr *ngIf="vm.profile && vm.profile.accessGroups">
           <th>Groups</th>
-          <td>{{ value }}</td>
+          <td>{{ vm.profile.accessGroups }}</td>
         </tr>
-        <tr *ngIf="catamelToken$ | async as value">
+        <tr *ngIf="vm.catamelToken as value">
           <th>Catamel Token</th>
           <td>
             {{ value }}
@@ -44,7 +56,7 @@
       </table>
     </mat-card>
 
-    <mat-card *ngIf="settings$ | async as settings">
+    <mat-card *ngIf="vm.settings as settings">
       <mat-card-header class="settings-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> settings </mat-icon>

--- a/src/app/users/user-settings/user-settings.component.html
+++ b/src/app/users/user-settings/user-settings.component.html
@@ -9,7 +9,12 @@
       </mat-card-header>
 
       <ng-container
-        *ngIf="vm.profile && vm.profile.thumbnailPhoto; else noPhoto"
+        *ngIf="
+          vm.profile &&
+            vm.profile.thumbnailPhoto &&
+            vm.profile.thumbnailPhoto.startsWith('data:image/');
+          else noPhoto
+        "
       >
         <img
           class="profile-image"

--- a/src/app/users/user-settings/user-settings.component.spec.ts
+++ b/src/app/users/user-settings/user-settings.component.spec.ts
@@ -13,10 +13,7 @@ import { ConfigService } from "shared/services";
 import { UserSettingsComponent } from "./user-settings.component";
 import { SharedCatanieModule } from "shared/shared.module";
 import { Message, MessageType, Settings } from "state-management/models";
-import {
-  saveSettingsAction,
-  showMessageAction,
-} from "state-management/actions/user.actions";
+import { showMessageAction } from "state-management/actions/user.actions";
 import { FlexLayoutModule } from "@angular/flex-layout";
 import { MatCardModule } from "@angular/material/card";
 import { MatIconModule } from "@angular/material/icon";
@@ -70,33 +67,6 @@ describe("UserSettingsComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
-  });
-
-  describe("#onSubmit()", () => {
-    it("should dispatch a saveSettingsAction and a showMessageAction", () => {
-      dispatchSpy = spyOn(store, "dispatch");
-
-      const message = new Message(
-        "Settings saved locally",
-        MessageType.Success,
-        5000
-      );
-
-      const settings: Settings = {
-        tapeCopies: "one",
-        datasetCount: 25,
-        jobCount: 25,
-        darkTheme: false,
-      };
-
-      component.onSubmit(settings);
-
-      expect(dispatchSpy).toHaveBeenCalledTimes(2);
-      expect(dispatchSpy).toHaveBeenCalledWith(
-        saveSettingsAction({ settings })
-      );
-      expect(dispatchSpy).toHaveBeenCalledWith(showMessageAction({ message }));
-    });
   });
 
   describe("#onCopy()", () => {

--- a/src/app/users/user-settings/user-settings.component.ts
+++ b/src/app/users/user-settings/user-settings.component.ts
@@ -7,12 +7,7 @@ import {
   fetchCatamelTokenAction,
 } from "state-management/actions/user.actions";
 import { Message, MessageType, Settings } from "state-management/models";
-import {
-  selectSettings,
-  selectProfile,
-  selectCurrentUser,
-  selectCatamelToken,
-} from "state-management/selectors/user.selectors";
+import { selectUserSettingsPageViewModel } from "state-management/selectors/user.selectors";
 import { DOCUMENT } from "@angular/common";
 import { map } from "rxjs/operators";
 
@@ -22,23 +17,7 @@ import { map } from "rxjs/operators";
   styleUrls: ["./user-settings.component.scss"],
 })
 export class UserSettingsComponent implements OnInit {
-  user$ = this.store.select(selectCurrentUser);
-  profile$ = this.store.select(selectProfile);
-  displayName$ = this.profile$.pipe(
-    map((profile) => (profile ? profile.displayName : undefined))
-  );
-  accessGroups$ = this.profile$.pipe(
-    map((profile) => (profile ? profile.accessGroups : undefined))
-  );
-  profileImage$ = this.profile$.pipe(
-    map((profile) =>
-      profile && profile.thumbnailPhoto.startsWith("data")
-        ? profile.thumbnailPhoto
-        : "assets/images/user.png"
-    )
-  );
-  catamelToken$ = this.store.select(selectCatamelToken);
-  settings$ = this.store.select(selectSettings);
+  vm$ = this.store.select(selectUserSettingsPageViewModel);
 
   constructor(
     @Inject(DOCUMENT) private document: Document,

--- a/src/app/users/user-settings/user-settings.component.ts
+++ b/src/app/users/user-settings/user-settings.component.ts
@@ -1,15 +1,13 @@
 import { Component, OnInit, Inject } from "@angular/core";
 import { Store } from "@ngrx/store";
 import {
-  saveSettingsAction,
   showMessageAction,
   fetchCurrentUserAction,
   fetchCatamelTokenAction,
 } from "state-management/actions/user.actions";
-import { Message, MessageType, Settings } from "state-management/models";
+import { Message, MessageType } from "state-management/models";
 import { selectUserSettingsPageViewModel } from "state-management/selectors/user.selectors";
 import { DOCUMENT } from "@angular/common";
-import { map } from "rxjs/operators";
 
 @Component({
   selector: "app-user-settings",
@@ -29,19 +27,6 @@ export class UserSettingsComponent implements OnInit {
   ngOnInit() {
     this.store.dispatch(fetchCurrentUserAction());
     this.store.dispatch(fetchCatamelTokenAction());
-  }
-
-  onSubmit(values: Settings) {
-    // TODO validate here
-    console.log(values);
-    // values['darkTheme'] = (values['darkTheme'].toLowerCase() === 'true')
-    this.store.dispatch(saveSettingsAction({ settings: values }));
-    const message = new Message(
-      "Settings saved locally",
-      MessageType.Success,
-      5000
-    );
-    this.store.dispatch(showMessageAction({ message }));
   }
 
   onCopy(token: string) {


### PR DESCRIPTION
## Description

Replaces individual selectors in the user module with view model selectors. Plan is to do this for every component in the app.

## Motivation

Each view will now just make a single call to the store to get data. Easier to work with and easier to test as there will only be one async variable in each view.

## Changes:

* Create selectLoginPageViewModel and selectUserSettingsPageViewModel selectors
* Replace individual selectors in login component with selectLoginPageViewModel selector
* Replace individual selectors in user settings component with selectUserSettingsPageViewModel selector
* Remove unused onSubmit method from user settings component

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

