### PR TITLE
Chore/sample view model selectors

### DIFF
--- a/src/app/samples/sample-dashboard/sample-dashboard.component.html
+++ b/src/app/samples/sample-dashboard/sample-dashboard.component.html
@@ -1,82 +1,96 @@
-<div fxLayout="row" fxLayout.lt-lg="column">
-  <div fxFlex="14" fxFlex.lt-xl="20">
-    <ng-template [ngIf]="appConfig.editSampleEnabled">
-      <button
-        mat-stroked-button
-        class="small-edit-sample"
-        (click)="openDialog()"
-      >
-        <mat-icon>add_circle</mat-icon> Create Sample
-      </button>
-    </ng-template>
-    <ng-template [ngIf]="appConfig.searchSamples">
-      <mat-card class="big-search">
-        <div class="title">Search</div>
-        <app-search-bar
-          [prefilledValue]="textFilter$ | async"
-          (search)="onTextSearchChange($event)"
-          (searchBarFocus)="onTextSearchChange($event)"
-        ></app-search-bar>
-        <div *ngIf="appConfig.scienceSearchEnabled">
-          <button mat-button color="primary" (click)="openSearchParametersDialog()">
-            <mat-icon>add</mat-icon> Add Characteristic
-          </button>
+<ng-container *ngIf="vm$ | async as vm">
+  <div fxLayout="row" fxLayout.lt-lg="column">
+    <div fxFlex="14" fxFlex.lt-xl="20">
+      <ng-template [ngIf]="appConfig.editSampleEnabled">
+        <button
+          mat-stroked-button
+          class="small-edit-sample"
+          (click)="openDialog()"
+        >
+          <mat-icon>add_circle</mat-icon> Create Sample
+        </button>
+      </ng-template>
+      <ng-template [ngIf]="appConfig.searchSamples">
+        <mat-card class="big-search">
+          <div class="title">Search</div>
+          <app-search-bar
+            [prefilledValue]="vm.textFilter"
+            (search)="onTextSearchChange($event)"
+            (searchBarFocus)="onTextSearchChange($event)"
+          ></app-search-bar>
+          <div *ngIf="appConfig.scienceSearchEnabled">
+            <button
+              mat-button
+              color="primary"
+              (click)="openSearchParametersDialog()"
+            >
+              <mat-icon>add</mat-icon> Add Characteristic
+            </button>
 
-          <mat-chip-list class="characteristic-chips" aria-orientation="vertical">
-            <mat-chip *ngFor="let characteristic of characteristics$ | async; index as i">
-              {{characteristic.lhs}}
-              <ng-container [ngSwitch]="characteristic.relation">
-                <ng-container *ngSwitchCase="'EQUAL_TO_NUMERIC'">
-                  &nbsp;=&nbsp;
+            <mat-chip-list
+              class="characteristic-chips"
+              aria-orientation="vertical"
+            >
+              <mat-chip
+                *ngFor="
+                  let characteristic of vm.characteristicsFilter;
+                  index as i
+                "
+              >
+                {{ characteristic.lhs }}
+                <ng-container [ngSwitch]="characteristic.relation">
+                  <ng-container *ngSwitchCase="'EQUAL_TO_NUMERIC'">
+                    &nbsp;=&nbsp;
+                  </ng-container>
+                  <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
+                    &nbsp;=&nbsp;
+                  </ng-container>
+                  <ng-container *ngSwitchCase="'LESS_THAN'">
+                    &nbsp;&lt;&nbsp;
+                  </ng-container>
+                  <ng-container *ngSwitchCase="'GREATER_THAN'">
+                    &nbsp;&gt;&nbsp;
+                  </ng-container>
                 </ng-container>
-                <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
-                  &nbsp;=&nbsp;
-                </ng-container>
-                <ng-container *ngSwitchCase="'LESS_THAN'">
-                  &nbsp;&lt;&nbsp;
-                </ng-container>
-                <ng-container *ngSwitchCase="'GREATER_THAN'">
-                  &nbsp;&gt;&nbsp;
-                </ng-container>
-              </ng-container>
-              {{
-                characteristic.relation === "EQUAL_TO_STRING"
-                  ? '"' + characteristic.rhs + '"'
-                  : characteristic.rhs
-              }}
-              {{ characteristic.unit | prettyUnit }}
-              <mat-icon matChipRemove (click)="removeCharacteristic(i)">
-                cancel
-              </mat-icon>
-            </mat-chip>
-          </mat-chip-list>
+                {{
+                  characteristic.relation === "EQUAL_TO_STRING"
+                    ? '"' + characteristic.rhs + '"'
+                    : characteristic.rhs
+                }}
+                {{ characteristic.unit | prettyUnit }}
+                <mat-icon matChipRemove (click)="removeCharacteristic(i)">
+                  cancel
+                </mat-icon>
+              </mat-chip>
+            </mat-chip-list>
+          </div>
+        </mat-card>
+        <div class="small-search" fxFlexOrder="2">
+          <app-search-bar
+            [prefilledValue]="vm.textFilter"
+            (search)="onTextSearchChange($event)"
+            (searchBarFocus)="onTextSearchChange($event)"
+          ></app-search-bar>
         </div>
-      </mat-card>
-      <div class="small-search" fxFlexOrder="2">
-        <app-search-bar
-          [prefilledValue]="textFilter$ | async"
-          (search)="onTextSearchChange($event)"
-          (searchBarFocus)="onTextSearchChange($event)"
-        ></app-search-bar>
-      </div>
-    </ng-template>
-    <ng-template [ngIf]="appConfig.editSampleEnabled">
-      <mat-card class="big-edit-sample" (click)="openDialog()">
-        <mat-icon>add_circle</mat-icon> Create Sample
-      </mat-card>
-    </ng-template>
+      </ng-template>
+      <ng-template [ngIf]="appConfig.editSampleEnabled">
+        <mat-card class="big-edit-sample" (click)="openDialog()">
+          <mat-icon>add_circle</mat-icon> Create Sample
+        </mat-card>
+      </ng-template>
+    </div>
+    <div fxFlex="63" fxFlex.lt-xl="80">
+      <app-table
+        [data]="tableData"
+        [columns]="tableColumns"
+        [paginate]="tablePaginate"
+        [currentPage]="vm.samplesPagination.currentPage"
+        [dataCount]="vm.samplesPagination.samplesCount"
+        [dataPerPage]="vm.samplesPagination.samplesPerPage"
+        (pageChange)="onPageChange($event)"
+        (sortChange)="onSortChange($event)"
+        (rowClick)="onRowClick($event)"
+      ></app-table>
+    </div>
   </div>
-  <div fxFlex="63" fxFlex.lt-xl="80">
-    <app-table
-      [data]="tableData"
-      [columns]="tableColumns"
-      [paginate]="tablePaginate"
-      [currentPage]="currentPage$ | async"
-      [dataCount]="sampleCount$ | async"
-      [dataPerPage]="samplesPerPage$ | async"
-      (pageChange)="onPageChange($event)"
-      (sortChange)="onSortChange($event)"
-      (rowClick)="onRowClick($event)"
-    ></app-table>
-  </div>
-</div>
+</ng-container>

--- a/src/app/samples/sample-detail/sample-detail.component.html
+++ b/src/app/samples/sample-detail/sample-detail.component.html
@@ -1,4 +1,4 @@
-<mat-tab-group *ngIf="sample">
+<mat-tab-group *ngIf="vm$ | async as vm">
   <mat-tab>
     <ng-template mat-tab-label>
       <mat-icon> details </mat-icon> Details
@@ -108,7 +108,7 @@
         </mat-card>
       </div>
 
-      <div fxFlex="30%" *ngIf="attachments$ | async as attachments">
+      <div fxFlex="30%" *ngIf="vm.attachments as attachments">
         <ng-container *ngFor="let attachment of attachments">
           <mat-card>
             <img mat-card-image src="{{ attachment.thumbnail }}" />
@@ -119,7 +119,7 @@
     </div>
   </mat-tab>
 
-  <mat-tab *ngIf="attachments$ | async as attachments">
+  <mat-tab *ngIf="vm.attachments as attachments">
     <ng-template mat-tab-label>
       <mat-icon> insert_photo </mat-icon> Attachments
     </ng-template>
@@ -144,9 +144,9 @@
         [data]="tableData"
         [columns]="tableColumns"
         [paginate]="tablePaginate"
-        [currentPage]="datasetsPage$ | async"
-        [dataCount]="datasetsCount$ | async"
-        [dataPerPage]="datasetsPerPage$ | async"
+        [currentPage]="vm.datasetsPage"
+        [dataCount]="vm.datasetsCount"
+        [dataPerPage]="vm.datasetsPerPage"
         (pageChange)="onPageChange($event)"
         (rowClick)="onRowClick($event)"
       ></app-table>

--- a/src/app/samples/sample-detail/sample-detail.component.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.ts
@@ -2,14 +2,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { Component, OnDestroy, OnInit, Inject } from "@angular/core";
 import { Subscription } from "rxjs";
 import { Sample, Attachment, User, Dataset } from "shared/sdk/models";
-import {
-  selectCurrentSample,
-  selectDatasets,
-  selectDatasetsPerPage,
-  selectDatasetsPage,
-  selectDatasetsCount,
-  selectCurrentAttachments,
-} from "../../state-management/selectors/samples.selectors";
+import { selectSampleDetailPageViewModel } from "../../state-management/selectors/samples.selectors";
 import { Store } from "@ngrx/store";
 import {
   fetchSampleAction,
@@ -31,7 +24,6 @@ import {
   PickedFile,
   SubmitCaptionEvent,
 } from "shared/modules/file-uploader/file-uploader.component";
-import { selectCurrentUser } from "state-management/selectors/user.selectors";
 
 export interface TableData {
   pid: string;
@@ -49,10 +41,7 @@ export interface TableData {
   styleUrls: ["./sample-detail.component.scss"],
 })
 export class SampleDetailComponent implements OnInit, OnDestroy {
-  attachments$ = this.store.select(selectCurrentAttachments);
-  datasetsPerPage$ = this.store.select(selectDatasetsPerPage);
-  datasetsPage$ = this.store.select(selectDatasetsPage);
-  datasetsCount$ = this.store.select(selectDatasetsCount);
+  vm$ = this.store.select(selectSampleDetailPageViewModel);
 
   sample: Sample = new Sample();
   user: User = new User();
@@ -165,23 +154,23 @@ export class SampleDetailComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.subscriptions.push(
-      this.store.select(selectCurrentSample).subscribe((sample) => {
-        if (sample) {
-          this.sample = sample;
+      this.vm$.subscribe((vm) => {
+        if (vm.sample) {
+          this.sample = vm.sample;
         }
       })
     );
 
     this.subscriptions.push(
-      this.store.select(selectDatasets).subscribe((datasets) => {
-        this.tableData = this.formatTableData(datasets);
+      this.vm$.subscribe((vm) => {
+        this.tableData = this.formatTableData(vm.datasets);
       })
     );
 
     this.subscriptions.push(
-      this.store.select(selectCurrentUser).subscribe((user) => {
-        if (user) {
-          this.user = user;
+      this.vm$.subscribe((vm) => {
+        if (vm.user) {
+          this.user = vm.user;
         }
       })
     );

--- a/src/app/samples/sample-dialog/sample-dialog.component.ts
+++ b/src/app/samples/sample-dialog/sample-dialog.component.ts
@@ -8,7 +8,7 @@ import {
   addSampleAction,
   fetchSamplesAction,
 } from "state-management/actions/samples.actions";
-import { selectSampleDialogViewModel } from "state-management/selectors/user.selectors";
+import { selectSampleDialogPageViewModel } from "state-management/selectors/user.selectors";
 import { Subscription } from "rxjs";
 
 import * as shortid from "shortid";
@@ -19,7 +19,7 @@ import * as shortid from "shortid";
   styleUrls: ["./sample-dialog.component.scss"],
 })
 export class SampleDialogComponent implements OnInit, OnDestroy {
-  private vm$ = this.store.select(selectSampleDialogViewModel);
+  private vm$ = this.store.select(selectSampleDialogPageViewModel);
   public form: FormGroup;
   description: string;
   sample: Sample = new Sample();

--- a/src/app/samples/sample-dialog/sample-dialog.component.ts
+++ b/src/app/samples/sample-dialog/sample-dialog.component.ts
@@ -8,10 +8,7 @@ import {
   addSampleAction,
   fetchSamplesAction,
 } from "state-management/actions/samples.actions";
-import {
-  selectCurrentUser,
-  selectProfile,
-} from "state-management/selectors/user.selectors";
+import { selectSampleDialogViewModel } from "state-management/selectors/user.selectors";
 import { Subscription } from "rxjs";
 
 import * as shortid from "shortid";
@@ -22,6 +19,7 @@ import * as shortid from "shortid";
   styleUrls: ["./sample-dialog.component.scss"],
 })
 export class SampleDialogComponent implements OnInit, OnDestroy {
+  private vm$ = this.store.select(selectSampleDialogViewModel);
   public form: FormGroup;
   description: string;
   sample: Sample = new Sample();
@@ -80,17 +78,17 @@ export class SampleDialogComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.subscriptions.push(
-      this.store.select(selectCurrentUser).subscribe((user) => {
-        if (user) {
-          this.username = user.username;
+      this.vm$.subscribe((vm) => {
+        if (vm.user) {
+          this.username = vm.user.username;
         }
       })
     );
 
     this.subscriptions.push(
-      this.store.select(selectProfile).subscribe((profile) => {
-        if (profile) {
-          this.userGroups = profile.accessGroups;
+      this.vm$.subscribe((vm) => {
+        if (vm.profile) {
+          this.userGroups = vm.profile.accessGroups;
         }
       })
     );

--- a/src/app/state-management/selectors/samples.selectors.spec.ts
+++ b/src/app/state-management/selectors/samples.selectors.spec.ts
@@ -1,6 +1,7 @@
 import * as fromSelectors from "./samples.selectors";
 import { SampleState } from "state-management/state/samples.store";
 import { SampleInterface, Sample } from "shared/sdk";
+import { initialUserState } from "state-management/state/user.store";
 
 const data: SampleInterface = {
   sampleId: "testId",
@@ -210,6 +211,34 @@ describe("Sample Selectors", () => {
         textFilter: "test",
         metadataKeys: [],
         characteristicsFilter: [],
+      });
+    });
+  });
+
+  describe("selectSampleDetailPageViewModel", () => {
+    it("should select sample detail page view model state", () => {
+      expect(
+        fromSelectors.selectSampleDetailPageViewModel.projector(
+          initialSampleState.currentSample,
+          initialSampleState.datasets,
+          initialSampleState.datasetFilters.limit,
+          fromSelectors.selectDatasetsPage.projector(
+            initialSampleState.datasetFilters
+          ),
+          initialSampleState.datasetsCount,
+          fromSelectors.selectCurrentAttachments.projector(
+            initialSampleState.currentSample
+          ),
+          initialUserState.currentUser
+        )
+      ).toEqual({
+        sample,
+        datasets: [],
+        datasetsPerPage: 25,
+        datasetsPage: 0,
+        datasetsCount: 0,
+        attachments: [],
+        user: undefined,
       });
     });
   });

--- a/src/app/state-management/selectors/samples.selectors.spec.ts
+++ b/src/app/state-management/selectors/samples.selectors.spec.ts
@@ -170,6 +170,50 @@ describe("Sample Selectors", () => {
     });
   });
 
+  describe("selectSamplesPagination", () => {
+    it("should select pagination state", () => {
+      expect(
+        fromSelectors.selectSamplesPagination.projector(
+          initialSampleState.samplesCount,
+          initialSampleState.sampleFilters.limit,
+          fromSelectors.selectPage.projector(initialSampleState.sampleFilters)
+        )
+      ).toEqual({ samplesCount: 0, samplesPerPage: 25, currentPage: 0 });
+    });
+  });
+
+  describe("selectSampleDashboardPageViewModel", () => {
+    it("should select sample dashboard page view model state", () => {
+      expect(
+        fromSelectors.selectSampleDashboardPageViewModel.projector(
+          initialSampleState.samples,
+          fromSelectors.selectSamplesPagination.projector(
+            initialSampleState.samplesCount,
+            initialSampleState.sampleFilters.limit,
+            fromSelectors.selectPage.projector(initialSampleState.sampleFilters)
+          ),
+          initialSampleState.sampleFilters,
+          initialSampleState.hasPrefilledFilters,
+          initialSampleState.sampleFilters.text,
+          initialSampleState.metadataKeys,
+          initialSampleState.sampleFilters.characteristics
+        )
+      ).toEqual({
+        samples: [],
+        samplesPagination: {
+          samplesCount: 0,
+          samplesPerPage: 25,
+          currentPage: 0,
+        },
+        filters: initialSampleState.sampleFilters,
+        hasPrefilledFilters: false,
+        textFilter: "test",
+        metadataKeys: [],
+        characteristicsFilter: [],
+      });
+    });
+  });
+
   describe("selectFullqueryParams", () => {
     it("should select the fullquery params", () => {
       const fullqueryKeys = Object.keys(

--- a/src/app/state-management/selectors/samples.selectors.ts
+++ b/src/app/state-management/selectors/samples.selectors.ts
@@ -86,6 +86,44 @@ export const selectDatasetsPerPage = createSelector(
   (filters) => filters.limit
 );
 
+export const selectSamplesPagination = createSelector(
+  selectSamplesCount,
+  selectSamplesPerPage,
+  selectPage,
+  (samplesCount, samplesPerPage, currentPage) => ({
+    samplesCount,
+    samplesPerPage,
+    currentPage,
+  })
+);
+
+export const selectSampleDashboardPageViewModel = createSelector(
+  selectSamples,
+  selectSamplesPagination,
+  selectFilters,
+  selectHasPrefilledFilters,
+  selectTextFilter,
+  selectMetadataKeys,
+  selectCharacteristicsFilter,
+  (
+    samples,
+    samplesPagination,
+    filters,
+    hasPrefilledFilters,
+    textFilter,
+    metadataKeys,
+    characteristicsFilter
+  ) => ({
+    samples,
+    samplesPagination,
+    filters,
+    hasPrefilledFilters,
+    textFilter,
+    metadataKeys,
+    characteristicsFilter,
+  })
+);
+
 export const selectFullqueryParams = createSelector(
   selectFilters,
   (filters) => {

--- a/src/app/state-management/selectors/samples.selectors.ts
+++ b/src/app/state-management/selectors/samples.selectors.ts
@@ -1,5 +1,6 @@
 import { createFeatureSelector, createSelector } from "@ngrx/store";
 import { SampleState } from "state-management/state/samples.store";
+import { selectCurrentUser } from "./user.selectors";
 
 const selectSampleState = createFeatureSelector<SampleState>("samples");
 
@@ -121,6 +122,33 @@ export const selectSampleDashboardPageViewModel = createSelector(
     textFilter,
     metadataKeys,
     characteristicsFilter,
+  })
+);
+
+export const selectSampleDetailPageViewModel = createSelector(
+  selectCurrentSample,
+  selectDatasets,
+  selectDatasetsPerPage,
+  selectDatasetsPage,
+  selectDatasetsCount,
+  selectCurrentAttachments,
+  selectCurrentUser,
+  (
+    sample,
+    datasets,
+    datasetsPerPage,
+    datasetsPage,
+    datasetsCount,
+    attachments,
+    user
+  ) => ({
+    sample,
+    datasets,
+    datasetsPerPage,
+    datasetsPage,
+    datasetsCount,
+    attachments,
+    user,
   })
 );
 

--- a/src/app/state-management/selectors/user.selectors.spec.ts
+++ b/src/app/state-management/selectors/user.selectors.spec.ts
@@ -210,6 +210,8 @@ describe("User Selectors", () => {
           initialUserState.profile
         )
       ).toEqual({ user, profile: userIdentity.profile });
+    });
+  });
 
   describe("selectLoginPageViewModel", () => {
     it("should select the login page view model state", () => {

--- a/src/app/state-management/selectors/user.selectors.spec.ts
+++ b/src/app/state-management/selectors/user.selectors.spec.ts
@@ -201,4 +201,15 @@ describe("User Selectors", () => {
       ]);
     });
   });
+
+  describe("selectSampleDialogViewModel", () => {
+    it("should select sample dialog page view model state", () => {
+      expect(
+        fromSelectors.selectSampleDialogViewModel.projector(
+          initialUserState.currentUser,
+          initialUserState.profile
+        )
+      ).toEqual({ user, profile: userIdentity.profile });
+    });
+  });
 });

--- a/src/app/state-management/selectors/user.selectors.spec.ts
+++ b/src/app/state-management/selectors/user.selectors.spec.ts
@@ -202,10 +202,10 @@ describe("User Selectors", () => {
     });
   });
 
-  describe("selectSampleDialogViewModel", () => {
+  describe("selectSampleDialogPageViewModel", () => {
     it("should select sample dialog page view model state", () => {
       expect(
-        fromSelectors.selectSampleDialogViewModel.projector(
+        fromSelectors.selectSampleDialogPageViewModel.projector(
           initialUserState.currentUser,
           initialUserState.profile
         )

--- a/src/app/state-management/selectors/user.selectors.ts
+++ b/src/app/state-management/selectors/user.selectors.ts
@@ -93,7 +93,7 @@ export const selectColumns = createSelector(
   (state) => state.columns
 );
 
-export const selectSampleDialogViewModel = createSelector(
+export const selectSampleDialogPageViewModel = createSelector(
   selectCurrentUser,
   selectProfile,
   (user, profile) => ({ user, profile })

--- a/src/app/state-management/selectors/user.selectors.ts
+++ b/src/app/state-management/selectors/user.selectors.ts
@@ -92,3 +92,9 @@ export const selectColumns = createSelector(
   selectUserState,
   (state) => state.columns
 );
+
+export const selectSampleDialogViewModel = createSelector(
+  selectCurrentUser,
+  selectProfile,
+  (user, profile) => ({ user, profile })
+);


### PR DESCRIPTION
## Description

Replaces individual selectors in the samples module with view model selectors. Plan is to do this for every component in the app.

## Motivation

Each view will now just make a single call to the store to get data. Easier to work with and easier to test as there will only be one async variable in each view.

## Changes:

* Create selectSamplesPagination, selectSampleDashboardPageViewModel, selectSampleDetailPageViewModel and selectSampleDialogPageViewModel selectors
* Replace individual selectors in sample dashboard component with selectSampleDashboardPageViewModel selector
* Replace individual selectors in sample detail component with selectSampleDetailPageViewModel selector
* Replace individual selectors in sample dialog component with selectSampleDialogPageViewModel selector

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

