### PR TITLE
Hotfix/proposal date filters

### DIFF
--- a/src/app/shared/modules/shared-table/shared-table.component.ts
+++ b/src/app/shared/modules/shared-table/shared-table.component.ts
@@ -131,7 +131,9 @@ export class SharedTableComponent
       for (let [columnId, value] of Object.entries(values)){
         // handle date filters
         if ((columnId.endsWith(".start") || columnId.endsWith(".end")) && value){
-          const date = DateTime.fromISO(value).toISODate();
+          // make sure that date is an ISO string
+          const valueISO = new Date(value).toISOString();
+          const date = DateTime.fromISO(valueISO).toISODate();
           this.filterExpressions[columnId] = date;
           queryParams[columnId] = date;
         } else if (value) {

--- a/src/app/shared/modules/shared-table/shared-table.component.ts
+++ b/src/app/shared/modules/shared-table/shared-table.component.ts
@@ -105,11 +105,11 @@ export class SharedTableComponent
 
   }
   ngOnInit(){
-    this.filterForm = this.initilizeFormControl();
+    this.filterForm = this.initializeFormControl();
     this.subscriptions.push(this.activateColumnFilters());
   }
 
-  initilizeFormControl() {
+  initializeFormControl() {
     const formControls = this.columnsdef.reduce((acc: {[key: string]: string[]}, column: Column) => {
       if(column.matchMode === "between"){
         acc[column.id + ".start"] = [""];


### PR DESCRIPTION
## Description

For some reason the date returned from the date range picker isn't always in the correct format, which causes the filtering to break (currently in the proposals dashboard). This fix is a bit hacky, but it works.

## Motivation

Bug fix.

## Fixes:

* Fix date range filter by casting value to ISO string
* Fix typo

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

