### PR TITLE
Change metadata table css in order to show more content

### DIFF
--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
@@ -1,12 +1,11 @@
 .metadataTable {
-  max-width: 50em;
 
   .mat-column-name {
     flex: 1 0 7em;
   }
 
   .mat-column-value {
-    flex: 1 0 7em;
+    flex: 2 0 7em;
   }
 
   .mat-column-unit {


### PR DESCRIPTION
## Description

As a user, when I view the dataset's details, it would be nice to expand the "Scientific Metadata" table to use most of the available width in the container.

In the image below, one can see that the table occupy only half of the width of the "Scientific Metadata" Section.
The idea is to minimize the wrapping in the value column and change the ratio to 1:2:1

![image](https://user-images.githubusercontent.com/6403388/156769118-7d1839d0-5372-4de9-a3ac-ee9ca6de636c.png)


