### PR TITLE
Ignore search events that are not strings

### DIFF
--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -156,6 +156,7 @@ export class DatasetsFilterComponent implements OnInit, OnDestroy {
   }
 
   textSearchChanged(terms: string) {
+    if ('string' != typeof terms) return;
     this.clearSearchBar = false;
     this.store.dispatch(setSearchTermsAction({ terms }));
   }

--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -156,7 +156,7 @@ export class DatasetsFilterComponent implements OnInit, OnDestroy {
   }
 
   textSearchChanged(terms: string) {
-    if ('string' != typeof terms) return;
+    if ("string" != typeof terms) return;
     this.clearSearchBar = false;
     this.store.dispatch(setSearchTermsAction({ terms }));
   }


### PR DESCRIPTION
## Description
Fixes #877

## Fixes:

On Chrome (windows and Mac) and Chromium (Linux), `textSearchChanged` in `datasets-filter.component.ts` is expecting a string. On Firefox, this seems to be the case. However, on Chrome, the method is getting many more events, and some come in as Event objects. This turns has the effect updating `input` with the string representation of the event: [object Event].

This fix checks the type of the input and rejects the update if not a string.

The fix seems to work, though I don't fully understand the event model here, so maybe this could have been done more gracefully.

