### PR TITLE
Fix/dataset sample link

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -231,6 +231,18 @@
             </span>
           </td>
         </tr>
+        <tr *ngIf="dataset['instrumentId'] && instrument">
+          <th>Instrument</th>
+          <td [ngSwitch]="editingAllowed">
+            <a
+              *ngSwitchCase="true"
+              (click)="editingAllowed && onClickInstrument(instrument.pid)"
+            >
+              {{ instrument.name }}
+            </a>
+            <span *ngSwitchDefault>{{ instrument.name }}</span>
+          </td>
+        </tr>
         <tr *ngIf="dataset['creationLocation'] as value">
           <th>Creation Location</th>
           <td>{{ value }}</td>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -21,7 +21,7 @@
     </mat-slide-toggle>
   </div>
 </div>
-<div style="clear: both;"></div>
+<div style="clear: both"></div>
 <div fxLayout="row" fxLayout.xs="column" *ngIf="dataset">
   <div fxFlex="80%">
     <mat-card>
@@ -66,7 +66,11 @@
                 {{ keyword }}
                 <mat-icon *ngIf="editingAllowed" matChipRemove>cancel</mat-icon>
               </mat-chip>
-              <mat-chip *ngIf="editingAllowed" class="add-keyword-chip" (click)="editEnabled = true">
+              <mat-chip
+                *ngIf="editingAllowed"
+                class="add-keyword-chip"
+                (click)="editEnabled = true"
+              >
                 Add Keyword <mat-icon>add</mat-icon>
               </mat-chip>
             </mat-chip-list>
@@ -196,21 +200,32 @@
         <tr *ngIf="dataset['proposalId'] && proposal">
           <th>Proposal</th>
           <td [ngSwitch]="editingAllowed">
-            <a *ngSwitchCase="true" (click)="editingAllowed? onClickProposal(proposal.proposalId) : ''">{{ proposal.title }}</a>
+            <a
+              *ngSwitchCase="true"
+              (click)="
+                editingAllowed ? onClickProposal(proposal.proposalId) : ''
+              "
+              >{{ proposal.title }}</a
+            >
             <span *ngSwitchDefault>{{ proposal.title }}</span>
           </td>
         </tr>
         <tr *ngIf="dataset['sampleId'] && sample">
           <th>Sample</th>
           <td [ngSwitch]="editingAllowed">
-            <a *ngSwitchCase="true" (click)="editingAllowed? onClickSample(sample.sampleId) : ''">
-              <span>{{ sample.description}}</span>
+            <a
+              *ngSwitchCase="true"
+              (click)="editingAllowed ? onClickSample(sample.sampleId) : ''"
+            >
+              <span>{{ sample.description }}</span>
             </a>
-            <span *ngSwitchDefault>{{ sample.description}}</span>
+            <span *ngSwitchDefault>{{ sample.description }}</span>
             <span
               class="sample-edit"
               (click)="openSampleEditDialog()"
-              *ngIf="appConfig.editDatasetSampleEnabled && editingAllowed && isPI"
+              *ngIf="
+                appConfig.editDatasetSampleEnabled && editingAllowed && isPI
+              "
             >
               <mat-icon>edit</mat-icon>
             </span>
@@ -290,21 +305,31 @@
       <ng-template [ngIf]="appConfig.tableSciDataEnabled" [ngIfElse]="jsonView">
         <ng-template #metadataView>
           <div [ngSwitch]="appConfig.metadataStructure">
-            <tree-view *ngSwitchCase="'tree'"
-                       [metadata]="dataset['scientificMetadata']"></tree-view>
-            <metadata-view *ngSwitchDefault
-                           [metadata]="dataset['scientificMetadata']"></metadata-view>
+            <tree-view
+              *ngSwitchCase="'tree'"
+              [metadata]="dataset['scientificMetadata']"
+            ></tree-view>
+            <metadata-view
+              *ngSwitchDefault
+              [metadata]="dataset['scientificMetadata']"
+            ></metadata-view>
           </div>
         </ng-template>
-        <mat-tab-group class="metadataGroup" *ngIf="editingAllowed;else metadataView">
+        <mat-tab-group
+          class="metadataGroup"
+          *ngIf="editingAllowed; else metadataView"
+        >
           <mat-tab>
             <ng-template mat-tab-label>
               <mat-icon> list </mat-icon> View
             </ng-template>
-            <ng-container *ngTemplateOutlet="metadataView">
-            </ng-container>
+            <ng-container *ngTemplateOutlet="metadataView"> </ng-container>
           </mat-tab>
-          <mat-tab class="editTab" *ngIf="editingAllowed" [hidden]="!appConfig.editMetadataEnabled">
+          <mat-tab
+            class="editTab"
+            *ngIf="editingAllowed"
+            [hidden]="!appConfig.editMetadataEnabled"
+          >
             <ng-template mat-tab-label>
               <mat-icon> edit </mat-icon> Edit
             </ng-template>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -265,6 +265,18 @@ describe("DatasetDetailComponent", () => {
     });
   });
 
+  describe("#onClickInstrument()", () => {
+    it("should navigate to an instrument", () => {
+      const instrumentId = "testId";
+
+      component.onClickInstrument(instrumentId);
+
+      expect(router.navigateByUrl).toHaveBeenCalledWith(
+        "/instruments/" + instrumentId
+      );
+    });
+  });
+
   describe("#onClickProposal()", () => {
     it("should navigate to a proposal", () => {
       const proposalId = "ABC123";

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -96,7 +96,6 @@ export class DatasetDetailComponent
     this.subscriptions.push(
       this.store.select(selectCurrentSample).subscribe((sample) => {
         this.sample = sample;
-        console.log({ sample });
       })
     );
 

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -29,6 +29,7 @@ import { DerivedDataset, RawDataset, User } from "shared/sdk";
 import { MatSlideToggleChange } from "@angular/material/slide-toggle";
 import { EditableComponent } from "app-routing/pending-changes.guard";
 import { AppConfigService } from "app-config.service";
+import { selectCurrentSample } from "state-management/selectors/samples.selectors";
 /**
  * Component to show details for a data set, using the
  * form component
@@ -57,7 +58,7 @@ export class DatasetDetailComponent
   attachments$ = this.store.select(selectCurrentAttachments);
   proposal$ = this.store.select(selectCurrentProposal);
   proposal: Proposal | undefined;
-  sample: Sample | null = null;
+  sample: Sample | undefined;
   user: User | undefined;
   editingAllowed = false;
   editEnabled = false;
@@ -85,11 +86,20 @@ export class DatasetDetailComponent
         }
       })
     );
+
     this.subscriptions.push(
       this.store.select(selectCurrentProposal).subscribe((proposal) => {
         this.proposal = proposal;
       })
     );
+
+    this.subscriptions.push(
+      this.store.select(selectCurrentSample).subscribe((sample) => {
+        this.sample = sample;
+        console.log({ sample });
+      })
+    );
+
     // Prevent user from reloading page if there are unsave changes
     this.subscriptions.push(
       fromEvent(window, "beforeunload").subscribe((event) => {
@@ -98,6 +108,7 @@ export class DatasetDetailComponent
         }
       })
     );
+
     this.subscriptions.push(
       this.store.select(selectCurrentUser).subscribe((user) => {
         if (user) {

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -56,7 +56,6 @@ export class DatasetDetailComponent
   dataset: Dataset | undefined;
   datasetWithout$ = this.store.select(selectCurrentDatasetWithoutFileInfo);
   attachments$ = this.store.select(selectCurrentAttachments);
-  proposal$ = this.store.select(selectCurrentProposal);
   proposal: Proposal | undefined;
   sample: Sample | undefined;
   user: User | undefined;

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -25,11 +25,12 @@ import {
 } from "state-management/actions/datasets.actions";
 import { Router } from "@angular/router";
 import { selectCurrentProposal } from "state-management/selectors/proposals.selectors";
-import { DerivedDataset, RawDataset, User } from "shared/sdk";
+import { DerivedDataset, Instrument, RawDataset, User } from "shared/sdk";
 import { MatSlideToggleChange } from "@angular/material/slide-toggle";
 import { EditableComponent } from "app-routing/pending-changes.guard";
 import { AppConfigService } from "app-config.service";
 import { selectCurrentSample } from "state-management/selectors/samples.selectors";
+import { selectCurrentInstrument } from "state-management/selectors/instruments.selectors";
 /**
  * Component to show details for a data set, using the
  * form component
@@ -56,6 +57,7 @@ export class DatasetDetailComponent
   dataset: Dataset | undefined;
   datasetWithout$ = this.store.select(selectCurrentDatasetWithoutFileInfo);
   attachments$ = this.store.select(selectCurrentAttachments);
+  instrument: Instrument | undefined;
   proposal: Proposal | undefined;
   sample: Sample | undefined;
   user: User | undefined;
@@ -83,6 +85,12 @@ export class DatasetDetailComponent
             }
           );
         }
+      })
+    );
+
+    this.subscriptions.push(
+      this.store.select(selectCurrentInstrument).subscribe((instrument) => {
+        this.instrument = instrument;
       })
     );
 
@@ -207,6 +215,11 @@ export class DatasetDetailComponent
         }
       }
     });
+  }
+
+  onClickInstrument(instrumentId: string): void {
+    const pid = encodeURIComponent(instrumentId);
+    this.router.navigateByUrl("/instruments/" + pid);
   }
 
   onClickProposal(proposalId: string): void {

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -38,6 +38,7 @@ import {
 } from "state-management/actions/samples.actions";
 import { MatDialog } from "@angular/material/dialog";
 import { AppConfigService } from "app-config.service";
+import { fetchInstrumentAction } from "state-management/actions/instruments.actions";
 
 export interface JWT {
   jwt: string;
@@ -190,6 +191,11 @@ export class DatasetDetailsDashboardComponent
           if ("sampleId" in dataset) {
             this.store.dispatch(
               fetchSampleAction({ sampleId: dataset["sampleId"] })
+            );
+          }
+          if ("instrumentId" in dataset) {
+            this.store.dispatch(
+              fetchInstrumentAction({ pid: dataset["instrumentId"] })
             );
           }
         }

--- a/src/app/datasets/datasets.module.ts
+++ b/src/app/datasets/datasets.module.ts
@@ -76,6 +76,8 @@ import { LogbookEffects } from "state-management/effects/logbooks.effects";
 import { logbooksReducer } from "state-management/reducers/logbooks.reducer";
 import { DatasetFileUploaderComponent } from "./dataset-file-uploader/dataset-file-uploader.component";
 import { AdminTabComponent } from "./admin-tab/admin-tab.component";
+import { instrumentsReducer } from "state-management/reducers/instruments.reducer";
+import { InstrumentEffects } from "state-management/effects/instruments.effects";
 
 @NgModule({
   imports: [
@@ -116,6 +118,7 @@ import { AdminTabComponent } from "./admin-tab/admin-tab.component";
     BatchCardModule,
     EffectsModule.forFeature([
       UserEffects,
+      InstrumentEffects,
       JobEffects,
       ProposalEffects,
       SampleEffects,
@@ -123,6 +126,7 @@ import { AdminTabComponent } from "./admin-tab/admin-tab.component";
       LogbookEffects,
     ]),
     StoreModule.forFeature("datasets", datasetsReducer),
+    StoreModule.forFeature("instruments", instrumentsReducer),
     StoreModule.forFeature("jobs", jobsReducer),
     StoreModule.forFeature("proposals", proposalsReducer),
     StoreModule.forFeature("samples", samplesReducer),


### PR DESCRIPTION
## Description

Fixes bug where a Datasets connected sample is not displayed in the Dataset Details view. Also adds a Datasets connected Instrument to the view.

## Motivation

Fixes bug addressed in #931.

## Fixes:

* Fixes #931

## Changes:

* Set up initialization of sample prop in dataset details view
* Add and initialize instrument prop in dataset details view
* Add link from dataset to instrument

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

