### PR TITLE
Fix bug with Sign In button and handle views when dataset is not exist or user is not owner

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -13,10 +13,10 @@ exports[`stricter compilation`] = {
       [198, 8, 68, "Expected 0 arguments, but got 1.", "2820193145"],
       [262, 47, 29, "Expected 0 arguments, but got 1.", "2503700957"]
     ],
-    "src/app/datasets/dataset-detail/dataset-detail.component.ts:1688806200": [
-      [81, 31, 12, "Object is possibly \'undefined\'.", "1944648223"]
+    "src/app/datasets/dataset-detail/dataset-detail.component.ts:1629409600": [
+      [83, 31, 12, "Object is possibly \'undefined\'.", "1944648223"]
     ],
-    "src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts:1898272901": [
+    "src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts:1188047646": [
       [121, 31, 12, "Object is possibly \'undefined\'.", "1944648223"],
       [178, 35, 8, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'typeof TAB\'.\\n  No index signature with a parameter of type \'string\' was found on type \'typeof TAB\'.", "4213543011"]
     ],
@@ -1038,8 +1038,8 @@ exports[`stricter compilation`] = {
       [65, 8, 10, "Argument of type \'{ mode: null; sortField: string; skip: number; limit: number; }\' is not assignable to parameter of type \'Expected<JobFilters>\'.\\n  Type \'{ mode: null; sortField: string; skip: number; limit: number; }\' is not assignable to type \'{ mode: ExpectedRecursive<Record<string, string> | undefined>; sortField: ExpectedRecursive<string>; skip: ExpectedRecursive<number>; limit: ExpectedRecursive<...>; }\'.\\n    Types of property \'mode\' are incompatible.\\n      Type \'null\' is not assignable to type \'ExpectedRecursive<Record<string, string> | undefined>\'.", "2675413713"],
       [74, 16, 4, "Argument of type \'null\' is not assignable to parameter of type \'Expected<Record<string, string> | undefined>\'.", "2087897566"]
     ],
-    "src/app/users/login/login.component.spec.ts:2557971985": [
-      [156, 8, 71, "Expected 0 arguments, but got 1.", "3870196511"]
+    "src/app/users/login/login.component.spec.ts:1282385132": [
+      [155, 8, 71, "Expected 0 arguments, but got 1.", "3870196511"]
     ],
     "src/app/users/user-settings/user-settings.component.spec.ts:235762097": [
       [87, 47, 30, "Expected 0 arguments, but got 1.", "2329020575"]

--- a/src/app/app-routing/admin.guard.ts
+++ b/src/app/app-routing/admin.guard.ts
@@ -1,0 +1,46 @@
+import { Injectable } from "@angular/core";
+import {
+  Router,
+  CanActivate,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+} from "@angular/router";
+import { Store } from "@ngrx/store";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { selectIsAdmin } from "state-management/selectors/user.selectors";
+
+/**
+ * Ensure that the current user is admin
+ * and has access to the requested page
+ * @export
+ * @class AdminGuard
+ * @implements {CanActivate}
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class AdminGuard implements CanActivate {
+  constructor(private store: Store, private router: Router) {}
+
+  /**
+   * Needs to return either a boolean or an observable that maps to a boolean
+   */
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean>{
+    let isAdmin = false;
+    return this.store.select(selectIsAdmin).pipe<boolean>(map((isAdmin: boolean) => {
+      if(!isAdmin) {
+        this.router.navigate(["/401"], {
+          skipLocationChange: true,
+          queryParams: {
+            url: state.url,
+          },
+        });
+      }
+      return isAdmin;
+    }));
+  }
+}

--- a/src/app/app-routing/admin.guard.ts
+++ b/src/app/app-routing/admin.guard.ts
@@ -30,7 +30,6 @@ export class AdminGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean>{
-    let isAdmin = false;
     return this.store.select(selectIsAdmin).pipe<boolean>(map((isAdmin: boolean) => {
       if(!isAdmin) {
         this.router.navigate(["/401"], {

--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -83,6 +83,11 @@ export const routes: Routes = [
             data: {errorTitle: "404 Page not found", message: "Sorry, the page you are trying to view doesn't exist"}
           },
           {
+            path: "401",
+            component: ErrorPageComponent,
+            data: {errorTitle: "401 Unauthorized", message: "Sorry, you don't have permission to view this page"}
+          },
+          {
             path: "**",
             pathMatch: "full",
             component: ErrorPageComponent,

--- a/src/app/app-routing/lazy/dataset-details-dashboard-routing/dataset-details-dashboard.routing.module.ts
+++ b/src/app/app-routing/lazy/dataset-details-dashboard-routing/dataset-details-dashboard.routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
+import { AdminGuard } from "app-routing/admin.guard";
 import { AuthGuard } from "app-routing/auth.guard";
 import { LeavingPageGuard } from "app-routing/pending-changes.guard";
 import { ServiceGuard } from "app-routing/service.guard";
@@ -57,6 +58,7 @@ const routes: Routes = [
   {
     path: "admin",
     component: AdminTabComponent,
+    canActivate: [AuthGuard, AdminGuard]
   }
 ];
 @NgModule({

--- a/src/app/datasets/admin-tab/admin-tab.component.ts
+++ b/src/app/datasets/admin-tab/admin-tab.component.ts
@@ -9,7 +9,7 @@ import {
   selectCurrentDatablocks,
   selectCurrentDataset,
 } from "state-management/selectors/datasets.selectors";
-import { selectCurrentUser } from "state-management/selectors/user.selectors";
+import { selectCurrentUser, selectIsAdmin, selectIsLoading } from "state-management/selectors/user.selectors";
 
 @Component({
   selector: "app-admin-tab",
@@ -20,6 +20,8 @@ export class AdminTabComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription[] = [];
   dataset: Dataset | undefined;
   datablocks$ = this.store.select(selectCurrentDatablocks);
+  isAdmin$ = this.store.select(selectIsAdmin);
+  loading$  = this.store.select(selectIsLoading);
   constructor(private store: Store) {}
 
   ngOnInit(): void {

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -113,11 +113,3 @@
     (selectOne)="onSelectOne($event)"
   ></app-table>
 </ng-template>
-<ng-template [ngIf]="!(dataset$ | async)">
-  <error-page
-    *ngIf="(loading$ | async) === false"
-    [errorTitle]="'Dataset not found'"
-    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
-  >
-  </error-page>
-</ng-template>

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -1,113 +1,123 @@
-<ng-template [ngIf]="maxFileSize && tooLargeFile">
-  <span>
-    <mat-icon class="warning-icon"> warning </mat-icon>
-    One or more files are too large to be downloaded directly.
-    {{
-      sftpHost
-        ? "These files are available via sftp host " +
-          sftpHost +
-          " in directory " +
-          sourcefolder +
-          "."
-        : ""
-    }}
-  </span>
-</ng-template>
+<ng-template [ngIf]="(dataset$ |async)">
+  <ng-template [ngIf]="maxFileSize && tooLargeFile">
+    <span>
+      <mat-icon class="warning-icon"> warning </mat-icon>
+      One or more files are too large to be downloaded directly.
+      {{
+        sftpHost
+          ? "These files are available via sftp host " +
+            sftpHost +
+            " in directory " +
+            sourcefolder +
+            "."
+          : ""
+      }}
+    </span>
+  </ng-template>
 
-<ng-template [ngIf]="maxFileSize">
-  <div>
-    <mat-icon> info </mat-icon>
-    Maximum allowed download size: {{ maxFileSize | filesize }}
-  </div>
-</ng-template>
-
-<ng-template [ngIf]="tableData && maxFileSize">
-  <div class="selected" fxLayout="row" fxLayoutAlign="space-evenly end">
-    <div fxFlex="auto" style="margin-bottom: 0.5em;">
-      Selected: {{ selectedFileSize | filesize
-      }}{{ maxFileSize ? " / " + (maxFileSize | filesize) : "" }}
+  <ng-template [ngIf]="maxFileSize">
+    <div>
+      <mat-icon> info </mat-icon>
+      Maximum allowed download size: {{ maxFileSize | filesize }}
     </div>
-  </div>
-</ng-template>
+  </ng-template>
 
-<div class="datafiles-header">
-  <span [ngPlural]="count" class="nbr-of-files">
-    <ng-template ngPluralCase="=0">No datafiles.</ng-template>
-    <ng-template ngPluralCase="=1">1 datafile.</ng-template>
-    <ng-template ngPluralCase="other">{{ count }} datafiles.</ng-template>
-  </span>
-  <div
-    *ngIf="
-      (datablocks$ | async) && (datablocks$ | async)?.length === 0
-    "
-  >
-    <h3>No datafiles linked to this dataset</h3>
-  </div>
-  <form
-    ngNoForm
-    method="POST"
-    [action]="multipleDownloadAction"
-    target="_blank"
-    style="display: inline;"
-  >
-    <input type="hidden" name="jwt" [value]="jwt?.jwt" />
-    <input type="hidden" name="directory" [value]="sourcefolder" />
-    <input
-      *ngFor="let file of getAllFiles(); index as i"
-      type="hidden"
-      [name]="'files[' + i + ']'"
-      [value]="file"
-    />
-    <button
-      mat-raised-button
-      class="download-button"
-      type="submit"
-      color="accent"
-      [disabled]="!!maxFileSize && (totalFileSize > maxFileSize)"
-    >
-      Download All
-    </button>
-  </form>
+  <ng-template [ngIf]="tableData && maxFileSize">
+    <div class="selected" fxLayout="row" fxLayoutAlign="space-evenly end">
+      <div fxFlex="auto" style="margin-bottom: 0.5em;">
+        Selected: {{ selectedFileSize | filesize
+        }}{{ maxFileSize ? " / " + (maxFileSize | filesize) : "" }}
+      </div>
+    </div>
+  </ng-template>
 
-  <form
-    ngNoForm
-    method="POST"
-    [action]="multipleDownloadAction"
-    target="_blank"
-    style="display: inline;"
-  >
-    <input type="hidden" name="jwt" [value]="jwt?.jwt" />
-    <input type="hidden" name="directory" [value]="sourcefolder" />
-    <input
-      *ngFor="let file of getSelectedFiles(); index as i"
-      type="hidden"
-      [name]="'files[' + i + ']'"
-      [value]="file"
-    />
-    <button
-      mat-raised-button
-      class="download-button"
-      type="submit"
-      color="accent"
-      [disabled]="
-        isNoneSelected || (!!maxFileSize && !!(selectedFileSize > maxFileSize))
+  <div class="datafiles-header">
+    <span [ngPlural]="count" class="nbr-of-files">
+      <ng-template ngPluralCase="=0">No datafiles.</ng-template>
+      <ng-template ngPluralCase="=1">1 datafile.</ng-template>
+      <ng-template ngPluralCase="other">{{ count }} datafiles.</ng-template>
+    </span>
+    <div
+      *ngIf="
+        (datablocks$ | async) && (datablocks$ | async)?.length === 0
       "
     >
-      Download Selected
-    </button>
-  </form>
-  <div style="clear: both;"></div>
-</div>
+      <h3>No datafiles linked to this dataset</h3>
+    </div>
+    <form
+      ngNoForm
+      method="POST"
+      [action]="multipleDownloadAction"
+      target="_blank"
+      style="display: inline;"
+    >
+      <input type="hidden" name="jwt" [value]="jwt?.jwt" />
+      <input type="hidden" name="directory" [value]="sourcefolder" />
+      <input
+        *ngFor="let file of getAllFiles(); index as i"
+        type="hidden"
+        [name]="'files[' + i + ']'"
+        [value]="file"
+      />
+      <button
+        mat-raised-button
+        class="download-button"
+        type="submit"
+        color="accent"
+        [disabled]="!!maxFileSize && (totalFileSize > maxFileSize)"
+      >
+        Download All
+      </button>
+    </form>
 
-<app-table
-  [data]="tableData"
-  [columns]="tableColumns"
-  [paginate]="true"
-  [currentPage]="currentPage"
-  [dataCount]="count"
-  [dataPerPage]="pageSize"
-  (pageChange)="onPageChange($event)"
-  [select]="fileDownloadEnabled"
-  (selectAll)="onSelectAll($event)"
-  (selectOne)="onSelectOne($event)"
-></app-table>
+    <form
+      ngNoForm
+      method="POST"
+      [action]="multipleDownloadAction"
+      target="_blank"
+      style="display: inline;"
+    >
+      <input type="hidden" name="jwt" [value]="jwt?.jwt" />
+      <input type="hidden" name="directory" [value]="sourcefolder" />
+      <input
+        *ngFor="let file of getSelectedFiles(); index as i"
+        type="hidden"
+        [name]="'files[' + i + ']'"
+        [value]="file"
+      />
+      <button
+        mat-raised-button
+        class="download-button"
+        type="submit"
+        color="accent"
+        [disabled]="
+          isNoneSelected || (!!maxFileSize && !!(selectedFileSize > maxFileSize))
+        "
+      >
+        Download Selected
+      </button>
+    </form>
+    <div style="clear: both;"></div>
+  </div>
+
+  <app-table
+    [data]="tableData"
+    [columns]="tableColumns"
+    [paginate]="true"
+    [currentPage]="currentPage"
+    [dataCount]="count"
+    [dataPerPage]="pageSize"
+    (pageChange)="onPageChange($event)"
+    [select]="fileDownloadEnabled"
+    (selectAll)="onSelectAll($event)"
+    (selectOne)="onSelectOne($event)"
+  ></app-table>
+</ng-template>
+<ng-template [ngIf]="!(dataset$ | async)">
+  <error-page
+    *ngIf="(loading$ | async) === false"
+    [errorTitle]="'Dataset not found'"
+    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
+  >
+  </error-page>
+</ng-template>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -360,12 +360,3 @@
     </div>
   </div>
 </ng-template>
-
-<ng-template [ngIf]="!dataset">
-  <error-page
-    *ngIf="(loading$ | async) === false"
-    [errorTitle]="'Dataset not found'"
-    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
-  >
-  </error-page>
-</ng-template>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -1,360 +1,371 @@
-<div fxLayout="row">
-  <div fxFlex="auto">
-    <a
-      mat-raised-button
-      href="{{ appConfig.jupyterHubUrl }}"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="jupyter-button"
-      *ngIf="appConfig.jupyterHubUrl"
-    >
-      Jupyter Hub
-    </a>
+<ng-template [ngIf]="dataset">
+  <div fxLayout="row">
+    <div fxFlex="auto">
+      <a
+        mat-raised-button
+        href="{{ appConfig.jupyterHubUrl }}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="jupyter-button"
+        *ngIf="appConfig.jupyterHubUrl"
+      >
+        Jupyter Hub
+      </a>
+    </div>
+    <div fxFlex="auto" *ngIf="isPI()">
+      <mat-slide-toggle
+        class="public-toggle"
+        [checked]="dataset.isPublished"
+        (change)="onSlidePublic($event)"
+      >
+        Public
+      </mat-slide-toggle>
+    </div>
   </div>
-  <div fxFlex="auto" *ngIf="isPI()">
-    <mat-slide-toggle
-      class="public-toggle"
-      [checked]="dataset.isPublished"
-      (change)="onSlidePublic($event)"
-    >
-      Public
-    </mat-slide-toggle>
-  </div>
-</div>
-<div style="clear: both;"></div>
-<div fxLayout="row" fxLayout.xs="column" *ngIf="dataset">
-  <div fxFlex="80%">
-    <mat-card>
-      <mat-card-header class="general-header">
-        <div mat-card-avatar class="section-icon">
-          <mat-icon> description </mat-icon>
-        </div>
-        General Information
-      </mat-card-header>
+  <div style="clear: both;"></div>
+  <div fxLayout="row" fxLayout.xs="column" *ngIf="dataset">
+    <div fxFlex="80%">
+      <mat-card>
+        <mat-card-header class="general-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> description </mat-icon>
+          </div>
+          General Information
+        </mat-card-header>
 
-      <table>
-        <tr *ngIf="dataset.datasetName as value">
-          <th>Name</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.description as value">
-          <th>Description</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-        <tr>
-          <th>PID</th>
-          <td>{{ dataset.pid }}</td>
-        </tr>
-        <tr *ngIf="dataset.type as value">
-          <th>Type</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.creationTime as value">
-          <th>Creation Time</th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
-        </tr>
-        <tr class="keywords-row">
-          <th>Keywords</th>
-          <td *ngIf="!editEnabled">
-            <mat-chip-list #keywordChips>
-              <mat-chip
-                *ngFor="let keyword of dataset.keywords"
-                [removable]="editingAllowed"
-                (removed)="onRemoveKeyword(keyword)"
-                (click)="onClickKeyword(keyword)"
-              >
-                {{ keyword }}
-                <mat-icon *ngIf="editingAllowed" matChipRemove>cancel</mat-icon>
-              </mat-chip>
-              <mat-chip *ngIf="editingAllowed" class="add-keyword-chip" (click)="editEnabled = true">
-                Add Keyword <mat-icon>add</mat-icon>
-              </mat-chip>
-            </mat-chip-list>
-          </td>
-          <td *ngIf="editEnabled">
-            <mat-form-field>
+        <table>
+          <tr *ngIf="dataset.datasetName as value">
+            <th>Name</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset.description as value">
+            <th>Description</th>
+            <td><span [innerHTML]="value | linky"></span></td>
+          </tr>
+          <tr>
+            <th>PID</th>
+            <td>{{ dataset.pid }}</td>
+          </tr>
+          <tr *ngIf="dataset.type as value">
+            <th>Type</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset.creationTime as value">
+            <th>Creation Time</th>
+            <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+          </tr>
+          <tr class="keywords-row">
+            <th>Keywords</th>
+            <td *ngIf="!editEnabled">
               <mat-chip-list #keywordChips>
                 <mat-chip
                   *ngFor="let keyword of dataset.keywords"
-                  [removable]="true"
+                  [removable]="editingAllowed"
                   (removed)="onRemoveKeyword(keyword)"
                   (click)="onClickKeyword(keyword)"
                 >
                   {{ keyword }}
+                  <mat-icon *ngIf="editingAllowed" matChipRemove>cancel</mat-icon>
+                </mat-chip>
+                <mat-chip *ngIf="editingAllowed" class="add-keyword-chip" (click)="editEnabled = true">
+                  Add Keyword <mat-icon>add</mat-icon>
+                </mat-chip>
+              </mat-chip-list>
+            </td>
+            <td *ngIf="editEnabled">
+              <mat-form-field>
+                <mat-chip-list #keywordChips>
+                  <mat-chip
+                    *ngFor="let keyword of dataset.keywords"
+                    [removable]="true"
+                    (removed)="onRemoveKeyword(keyword)"
+                    (click)="onClickKeyword(keyword)"
+                  >
+                    {{ keyword }}
+                    <mat-icon matChipRemove>cancel</mat-icon>
+                  </mat-chip>
+                  <input
+                    id="keywordInput"
+                    [matChipInputFor]="keywordChips"
+                    [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+                    [matChipInputAddOnBlur]="true"
+                    (matChipInputTokenEnd)="onAddKeyword($event)"
+                  />
+                </mat-chip-list>
+              </mat-form-field>
+              <button
+                mat-raised-button
+                class="done-edit-button"
+                color="accent"
+                (click)="editEnabled = false"
+              >
+                Done
+              </button>
+            </td>
+          </tr>
+          <tr *ngIf="dataset.sharedWith && dataset.sharedWith.length > 0">
+            <th>Shared With</th>
+            <td>
+              <mat-chip-list>
+                <mat-chip
+                  *ngFor="let share of dataset.sharedWith"
+                  [removable]="true"
+                  (removed)="onRemoveShare(share)"
+                >
+                  {{ share }}
                   <mat-icon matChipRemove>cancel</mat-icon>
                 </mat-chip>
-                <input
-                  id="keywordInput"
-                  [matChipInputFor]="keywordChips"
-                  [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
-                  [matChipInputAddOnBlur]="true"
-                  (matChipInputTokenEnd)="onAddKeyword($event)"
-                />
               </mat-chip-list>
-            </mat-form-field>
-            <button
-              mat-raised-button
-              class="done-edit-button"
-              color="accent"
-              (click)="editEnabled = false"
-            >
-              Done
-            </button>
-          </td>
-        </tr>
-        <tr *ngIf="dataset.sharedWith && dataset.sharedWith.length > 0">
-          <th>Shared With</th>
-          <td>
-            <mat-chip-list>
-              <mat-chip
-                *ngFor="let share of dataset.sharedWith"
-                [removable]="true"
-                (removed)="onRemoveShare(share)"
-              >
-                {{ share }}
-                <mat-icon matChipRemove>cancel</mat-icon>
-              </mat-chip>
-            </mat-chip-list>
-          </td>
-        </tr>
-      </table>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header class="creator-header">
-        <div mat-card-avatar class="section-icon">
-          <mat-icon> person </mat-icon>
-        </div>
-        Creator Information
-      </mat-card-header>
-
-      <table>
-        <tr *ngIf="dataset.owner as value">
-          <th>Owner</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset['principalInvestigator'] as value">
-          <th>Principal Investigator</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-        <tr *ngIf="dataset['investigator'] as value">
-          <th>Investigator</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.orcidOfOwner as value">
-          <th>Orcid</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-        <tr *ngIf="dataset.contactEmail as value">
-          <th>Contact Email</th>
-          <td><span [innerHTML]="value | linky"></span></td>
-        </tr>
-        <tr *ngIf="dataset.ownerGroup as value">
-          <th>Owner Group</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.accessGroups as value">
-          <th>Access Groups</th>
-          <td>{{ value }}</td>
-        </tr>
-      </table>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header class="file-header">
-        <div mat-card-avatar class="section-icon">
-          <mat-icon> folder </mat-icon>
-        </div>
-        File Information
-      </mat-card-header>
-
-      <table>
-        <tr *ngIf="dataset.sourceFolder as value">
-          <th>Source Folder</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.size as value">
-          <th>Size</th>
-          <td>{{ value | filesize }}</td>
-        </tr>
-        <tr *ngIf="dataset['dataFormat'] as value">
-          <th>Data Format</th>
-          <td>{{ value }}</td>
-        </tr>
-      </table>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header class="related-header">
-        <div mat-card-avatar class="section-icon">
-          <mat-icon> library_books </mat-icon>
-        </div>
-        Related Documents
-      </mat-card-header>
-
-      <table>
-        <tr *ngIf="dataset['proposalId'] && proposal">
-          <th>Proposal</th>
-          <td [ngSwitch]="editingAllowed">
-            <a *ngSwitchCase="true" (click)="editingAllowed? onClickProposal(proposal.proposalId) : ''">{{ proposal.title }}</a>
-            <span *ngSwitchDefault>{{ proposal.title }}</span>
-          </td>
-        </tr>
-        <tr *ngIf="dataset['sampleId'] && sample">
-          <th>Sample</th>
-          <td [ngSwitch]="editingAllowed">
-            <a *ngSwitchCase="true" (click)="editingAllowed? onClickSample(sample.sampleId) : ''">
-              <span>{{ sample.description}}</span>
-            </a>
-            <span *ngSwitchDefault>{{ sample.description}}</span>
-            <span
-              class="sample-edit"
-              (click)="openSampleEditDialog()"
-              *ngIf="appConfig.editDatasetSampleEnabled && editingAllowed && isPI"
-            >
-              <mat-icon>edit</mat-icon>
-            </span>
-          </td>
-        </tr>
-        <tr *ngIf="dataset['creationLocation'] as value">
-          <th>Creation Location</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset.techniques && dataset.techniques.length > 0">
-          <th>Techniques</th>
-          <td>
-            <div *ngFor="let technique of dataset.techniques">
-              <span>
-                {{ technique.name }}
-              </span>
-              <span
-                *ngIf="
-                  dataset.techniques.indexOf(technique) <
-                  dataset.techniques.length - 1
-                "
-                >,
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr *ngIf="dataset['inputDatasets'] as value">
-          <th>Input Datasets</th>
-          <td>
-            <div *ngFor="let datasetPid of value">
-              <span>
-                <a [routerLink]="['/datasets/', datasetPid]">
-                  {{ datasetPid }}
-                </a>
-              </span>
-              <span *ngIf="value.indexOf(datasetPid) < value.length - 1"
-                >,
-              </span>
-            </div>
-          </td>
-        </tr>
-      </table>
-    </mat-card>
-
-    <mat-card *ngIf="dataset.type === 'derived'">
-      <mat-card-header class="derived-header">
-        <div mat-card-avatar class="section-icon">
-          <mat-icon> analytics </mat-icon>
-        </div>
-        Derived Data
-      </mat-card-header>
-
-      <table>
-        <tr *ngIf="dataset['usedSoftware'] as value">
-          <th>Software Used</th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="dataset['jobParameters'] as value">
-          <th>Job Parameters</th>
-          <td>{{ value | json }}</td>
-        </tr>
-        <tr *ngIf="dataset['jobLogData'] as value">
-          <th>Job Log Data</th>
-          <td>{{ value }}</td>
-        </tr>
-      </table>
-    </mat-card>
-
-    <mat-card>
-      <mat-card-header class="scientific-header">
-        <div mat-card-avatar class="section-icon">
-          <mat-icon> science </mat-icon>
-        </div>
-        Scientific Metadata
-      </mat-card-header>
-
-      <ng-template [ngIf]="appConfig.tableSciDataEnabled" [ngIfElse]="jsonView">
-        <ng-template #metadataView>
-          <div [ngSwitch]="appConfig.metadataStructure">
-            <tree-view *ngSwitchCase="'tree'"
-                       [metadata]="dataset['scientificMetadata']"></tree-view>
-            <metadata-view *ngSwitchDefault
-                           [metadata]="dataset['scientificMetadata']"></metadata-view>
-          </div>
-        </ng-template>
-        <mat-tab-group class="metadataGroup" *ngIf="editingAllowed;else metadataView">
-          <mat-tab>
-            <ng-template mat-tab-label>
-              <mat-icon> list </mat-icon> View
-            </ng-template>
-            <ng-container *ngTemplateOutlet="metadataView">
-            </ng-container>
-          </mat-tab>
-          <mat-tab class="editTab" *ngIf="editingAllowed" [hidden]="!appConfig.editMetadataEnabled">
-            <ng-template mat-tab-label>
-              <mat-icon> edit </mat-icon> Edit
-            </ng-template>
-            <div [ngSwitch]="appConfig.metadataStructure">
-              <tree-edit
-                *ngSwitchCase="'tree'"
-                [metadata]="dataset['scientificMetadata']"
-                (save)="onSaveMetadata($event)"
-                (hasUnsavedChanges)="onHasUnsavedChanges($event)"
-              ></tree-edit>
-              <metadata-edit
-                *ngSwitchDefault
-                [metadata]="dataset['scientificMetadata']"
-                (save)="onSaveMetadata($event)"
-              >
-              </metadata-edit>
-            </div>
-          </mat-tab>
-        </mat-tab-group>
-      </ng-template>
-
-      <ng-template #jsonView>
-        <ngx-json-viewer
-          [json]="dataset['scientificMetadata']"
-          [expanded]="false"
-        ></ngx-json-viewer>
-      </ng-template>
-    </mat-card>
-    <mat-card *ngIf="editingAllowed && appConfig.jsonMetadataEnabled">
-      <button mat-stroked-button (click)="show = !show">
-        {{ show ? "Hide MetaData" : "Show Metadata" }}
-      </button>
-
-      <br />
-
-      <div *ngIf="show">
-        <ngx-json-viewer
-          [json]="datasetWithout$ | async"
-          [expanded]="false"
-        ></ngx-json-viewer>
-      </div>
-    </mat-card>
-  </div>
-
-  <div fxFlex="30%" *ngIf="attachments$ | async as attachments">
-    <ng-container *ngFor="let da of attachments">
-      <mat-card>
-        <img mat-card-image src="{{ da.thumbnail }}" />
-        <p>{{ da.caption }}</p>
+            </td>
+          </tr>
+        </table>
       </mat-card>
-    </ng-container>
+
+      <mat-card>
+        <mat-card-header class="creator-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> person </mat-icon>
+          </div>
+          Creator Information
+        </mat-card-header>
+
+        <table>
+          <tr *ngIf="dataset.owner as value">
+            <th>Owner</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset['principalInvestigator'] as value">
+            <th>Principal Investigator</th>
+            <td><span [innerHTML]="value | linky"></span></td>
+          </tr>
+          <tr *ngIf="dataset['investigator'] as value">
+            <th>Investigator</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset.orcidOfOwner as value">
+            <th>Orcid</th>
+            <td><span [innerHTML]="value | linky"></span></td>
+          </tr>
+          <tr *ngIf="dataset.contactEmail as value">
+            <th>Contact Email</th>
+            <td><span [innerHTML]="value | linky"></span></td>
+          </tr>
+          <tr *ngIf="dataset.ownerGroup as value">
+            <th>Owner Group</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset.accessGroups as value">
+            <th>Access Groups</th>
+            <td>{{ value }}</td>
+          </tr>
+        </table>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-header class="file-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> folder </mat-icon>
+          </div>
+          File Information
+        </mat-card-header>
+
+        <table>
+          <tr *ngIf="dataset.sourceFolder as value">
+            <th>Source Folder</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset.size as value">
+            <th>Size</th>
+            <td>{{ value | filesize }}</td>
+          </tr>
+          <tr *ngIf="dataset['dataFormat'] as value">
+            <th>Data Format</th>
+            <td>{{ value }}</td>
+          </tr>
+        </table>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-header class="related-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> library_books </mat-icon>
+          </div>
+          Related Documents
+        </mat-card-header>
+
+        <table>
+          <tr *ngIf="dataset['proposalId'] && proposal">
+            <th>Proposal</th>
+            <td [ngSwitch]="editingAllowed">
+              <a *ngSwitchCase="true" (click)="editingAllowed? onClickProposal(proposal.proposalId) : ''">{{ proposal.title }}</a>
+              <span *ngSwitchDefault>{{ proposal.title }}</span>
+            </td>
+          </tr>
+          <tr *ngIf="dataset['sampleId'] && sample">
+            <th>Sample</th>
+            <td [ngSwitch]="editingAllowed">
+              <a *ngSwitchCase="true" (click)="editingAllowed? onClickSample(sample.sampleId) : ''">
+                <span>{{ sample.description}}</span>
+              </a>
+              <span *ngSwitchDefault>{{ sample.description}}</span>
+              <span
+                class="sample-edit"
+                (click)="openSampleEditDialog()"
+                *ngIf="appConfig.editDatasetSampleEnabled && editingAllowed && isPI"
+              >
+                <mat-icon>edit</mat-icon>
+              </span>
+            </td>
+          </tr>
+          <tr *ngIf="dataset['creationLocation'] as value">
+            <th>Creation Location</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset.techniques && dataset.techniques.length > 0">
+            <th>Techniques</th>
+            <td>
+              <div *ngFor="let technique of dataset.techniques">
+                <span>
+                  {{ technique.name }}
+                </span>
+                <span
+                  *ngIf="
+                    dataset.techniques.indexOf(technique) <
+                    dataset.techniques.length - 1
+                  "
+                  >,
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr *ngIf="dataset['inputDatasets'] as value">
+            <th>Input Datasets</th>
+            <td>
+              <div *ngFor="let datasetPid of value">
+                <span>
+                  <a [routerLink]="['/datasets/', datasetPid]">
+                    {{ datasetPid }}
+                  </a>
+                </span>
+                <span *ngIf="value.indexOf(datasetPid) < value.length - 1"
+                  >,
+                </span>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </mat-card>
+
+      <mat-card *ngIf="dataset.type === 'derived'">
+        <mat-card-header class="derived-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> analytics </mat-icon>
+          </div>
+          Derived Data
+        </mat-card-header>
+
+        <table>
+          <tr *ngIf="dataset['usedSoftware'] as value">
+            <th>Software Used</th>
+            <td>{{ value }}</td>
+          </tr>
+          <tr *ngIf="dataset['jobParameters'] as value">
+            <th>Job Parameters</th>
+            <td>{{ value | json }}</td>
+          </tr>
+          <tr *ngIf="dataset['jobLogData'] as value">
+            <th>Job Log Data</th>
+            <td>{{ value }}</td>
+          </tr>
+        </table>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-header class="scientific-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> science </mat-icon>
+          </div>
+          Scientific Metadata
+        </mat-card-header>
+
+        <ng-template [ngIf]="appConfig.tableSciDataEnabled" [ngIfElse]="jsonView">
+          <ng-template #metadataView>
+            <div [ngSwitch]="appConfig.metadataStructure">
+              <tree-view *ngSwitchCase="'tree'"
+                         [metadata]="dataset['scientificMetadata']"></tree-view>
+              <metadata-view *ngSwitchDefault
+                             [metadata]="dataset['scientificMetadata']"></metadata-view>
+            </div>
+          </ng-template>
+          <mat-tab-group class="metadataGroup" *ngIf="editingAllowed;else metadataView">
+            <mat-tab>
+              <ng-template mat-tab-label>
+                <mat-icon> list </mat-icon> View
+              </ng-template>
+              <ng-container *ngTemplateOutlet="metadataView">
+              </ng-container>
+            </mat-tab>
+            <mat-tab class="editTab" *ngIf="editingAllowed" [hidden]="!appConfig.editMetadataEnabled">
+              <ng-template mat-tab-label>
+                <mat-icon> edit </mat-icon> Edit
+              </ng-template>
+              <div [ngSwitch]="appConfig.metadataStructure">
+                <tree-edit
+                  *ngSwitchCase="'tree'"
+                  [metadata]="dataset['scientificMetadata']"
+                  (save)="onSaveMetadata($event)"
+                  (hasUnsavedChanges)="onHasUnsavedChanges($event)"
+                ></tree-edit>
+                <metadata-edit
+                  *ngSwitchDefault
+                  [metadata]="dataset['scientificMetadata']"
+                  (save)="onSaveMetadata($event)"
+                >
+                </metadata-edit>
+              </div>
+            </mat-tab>
+          </mat-tab-group>
+        </ng-template>
+
+        <ng-template #jsonView>
+          <ngx-json-viewer
+            [json]="dataset['scientificMetadata']"
+            [expanded]="false"
+          ></ngx-json-viewer>
+        </ng-template>
+      </mat-card>
+      <mat-card *ngIf="editingAllowed && appConfig.jsonMetadataEnabled">
+        <button mat-stroked-button (click)="show = !show">
+          {{ show ? "Hide MetaData" : "Show Metadata" }}
+        </button>
+
+        <br />
+
+        <div *ngIf="show">
+          <ngx-json-viewer
+            [json]="datasetWithout$ | async"
+            [expanded]="false"
+          ></ngx-json-viewer>
+        </div>
+      </mat-card>
+    </div>
+
+    <div fxFlex="30%" *ngIf="attachments$ | async as attachments">
+      <ng-container *ngFor="let da of attachments">
+        <mat-card>
+          <img mat-card-image src="{{ da.thumbnail }}" />
+          <p>{{ da.caption }}</p>
+        </mat-card>
+      </ng-container>
+    </div>
   </div>
-</div>
+</ng-template>
+
+<ng-template [ngIf]="!dataset">
+  <error-page
+    *ngIf="(loading$ | async) === false"
+    [errorTitle]="'Dataset not found'"
+    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
+  >
+  </error-page>
+</ng-template>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -15,6 +15,7 @@ import {
 import {
   selectCurrentUser,
   selectIsAdmin,
+  selectIsLoading,
   selectProfile,
 } from "state-management/selectors/user.selectors";
 import { map } from "rxjs/operators";
@@ -56,6 +57,7 @@ export class DatasetDetailComponent
   datasetWithout$ = this.store.select(selectCurrentDatasetWithoutFileInfo);
   attachments$ = this.store.select(selectCurrentAttachments);
   proposal$ = this.store.select(selectCurrentProposal);
+  loading$ = this.store.select(selectIsLoading);
   proposal: Proposal | undefined;
   sample: Sample | null = null;
   user: User | undefined;

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -19,4 +19,12 @@
 
   </nav>
 </ng-template>
+<ng-template [ngIf]="!dataset">
+  <error-page
+    *ngIf="(loading$ | async) === false"
+    [errorTitle]="'Dataset not found'"
+    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
+  >
+  </error-page>
+</ng-template>
 <router-outlet></router-outlet>

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -18,13 +18,5 @@
     </ng-container>
 
   </nav>
-  <router-outlet></router-outlet>
 </ng-template>
-<ng-template [ngIf]="!dataset">
-  <error-page
-    *ngIf="(loading$ | async) === false"
-    [errorTitle]="'Dataset not found'"
-    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
-  >
-  </error-page>
-</ng-template>
+<router-outlet></router-outlet>

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -111,7 +111,7 @@ export class DatasetDetailsDashboardComponent
         }
       })
       .unsubscribe();
-    this.dataset$
+    const datasetSub = this.dataset$
       .pipe(takeWhile((dataset) => !dataset, true))
       .subscribe((dataset) => {
         if (dataset) {
@@ -194,8 +194,9 @@ export class DatasetDetailsDashboardComponent
           }
         }
       });
+    this.subscriptions.push(datasetSub);
     this.jwt$ = this.userApi.jwt();
-  }
+  };
   onTabSelected(tab: string) {
     this.fetchDataForTab(tab);
   }

--- a/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.html
+++ b/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.html
@@ -1,4 +1,5 @@
 <app-file-uploader
+  *ngIf="dataset"
   [attachments]="attachments"
   (filePicked)="onFileUploaderFilePicked($event)"
   (submitCaption)="updateCaption($event)"

--- a/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.spec.ts
+++ b/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, inject, TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
 import { Store, StoreModule } from "@ngrx/store";
 import { MockStore } from "@ngrx/store/testing";
 import { SubmitCaptionEvent } from "shared/modules/file-uploader/file-uploader.component";
@@ -10,7 +11,9 @@ import {
 } from "state-management/actions/datasets.actions";
 
 import { DatasetFileUploaderComponent } from "./dataset-file-uploader.component";
-
+const router = {
+  navigateByUrl: jasmine.createSpy("navigateByUrl"),
+};
 describe("DatasetFileUploaderComponent", () => {
   let component: DatasetFileUploaderComponent;
   let fixture: ComponentFixture<DatasetFileUploaderComponent>;
@@ -22,6 +25,13 @@ describe("DatasetFileUploaderComponent", () => {
       declarations: [DatasetFileUploaderComponent],
       imports: [StoreModule.forRoot({})],
     }).compileComponents();
+    TestBed.overrideComponent(DatasetFileUploaderComponent, {
+      set: {
+        providers: [
+          { provide: Router, useValue: router },
+        ],
+      },
+    });
   });
 
   beforeEach(() => {

--- a/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.ts
+++ b/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
 import { Store } from "@ngrx/store";
 import { Subscription } from "rxjs";
 import {
@@ -6,6 +7,7 @@ import {
   SubmitCaptionEvent,
 } from "shared/modules/file-uploader/file-uploader.component";
 import { Attachment, Dataset, User } from "shared/sdk";
+import { OwnershipService } from "shared/services/ownership.service";
 import {
   addAttachmentAction,
   removeAttachmentAction,
@@ -28,13 +30,17 @@ export class DatasetFileUploaderComponent implements OnInit, OnDestroy {
   attachment: Partial<Attachment> = {};
   dataset: Dataset | undefined;
   user: User | undefined;
-  constructor(private store: Store) {}
+  constructor(
+    private store: Store,
+    private ownershipService: OwnershipService,
+    private router: Router) {}
 
   ngOnInit(): void {
     this.subscriptions.push(
       this.store.select(selectCurrentDataset).subscribe((dataset) => {
         if (dataset) {
           this.dataset = dataset;
+          this.ownershipService.checkPermission(dataset, this.store, this.router);
         }
       })
     );

--- a/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
+++ b/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
@@ -1,11 +1,3 @@
-<ng-template [ngIf]="!dataset">
-  <error-page
-    *ngIf="(loading$ | async) === false"
-    [errorTitle]="'Dataset not found'"
-    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
-  >
-  </error-page>
-</ng-template>
 <div fxLayout="row">
   <div fxFlex="80">
     <ng-container *ngIf="dataset">

--- a/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
+++ b/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.html
@@ -1,3 +1,11 @@
+<ng-template [ngIf]="!dataset">
+  <error-page
+    *ngIf="(loading$ | async) === false"
+    [errorTitle]="'Dataset not found'"
+    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
+  >
+  </error-page>
+</ng-template>
 <div fxLayout="row">
   <div fxFlex="80">
     <ng-container *ngIf="dataset">

--- a/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.ts
+++ b/src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.ts
@@ -12,6 +12,7 @@ import { PageEvent } from "@angular/material/paginator";
 import { selectCurrentDataset } from "state-management/selectors/datasets.selectors";
 import { Store } from "@ngrx/store";
 import { AppConfigService } from "app-config.service";
+import { selectIsLoading } from "state-management/selectors/user.selectors";
 
 export interface HistoryItem {
   property: string;
@@ -50,7 +51,7 @@ export class DatasetLifecycleComponent implements OnInit, OnChanges {
   dataSource: HistoryItem[] = [];
   displayedColumns = ["property", "updatedBy", "updatedAt"];
   expandedItem: any | null;
-
+  loading$ = this.store.select(selectIsLoading);
   constructor(
     public appConfigService: AppConfigService,
     private datePipe: DatePipe,

--- a/src/app/datasets/reduce/reduce.component.html
+++ b/src/app/datasets/reduce/reduce.component.html
@@ -1,256 +1,267 @@
-<div fxLayout="row" fxLayout.xs="column">
-  <div fxFlex="70">
-    <mat-card>
-      <mat-card-header class="action-header">
-        New Action
-      </mat-card-header>
+<ng-template [ngIf]="!dataset">
+  <error-page
+    *ngIf="(loading$ | async) === false"
+    [errorTitle]="'Dataset not found'"
+    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
+  >
+  </error-page>
+</ng-template>
+<ng-template [ngIf]="dataset">
+  <div fxLayout="row" fxLayout.xs="column">
+    <div fxFlex="70">
+      <mat-card>
+        <mat-card-header class="action-header">
+          New Action
+        </mat-card-header>
 
-      <ng-template [ngIf]="(result$ | async) || derivedDatasets.length > 0">
-        <div class="details">
-          <table>
-            <tr>
-              <th><mat-icon>info</mat-icon> Status</th>
-              <td *ngIf="result$ | async as result; else noResult">
-                <ng-container *ngIf="result['message'] as message">
-                  {{ message }}
-                </ng-container>
+        <ng-template [ngIf]="(result$ | async) || derivedDatasets.length > 0">
+          <div class="details">
+            <table>
+              <tr>
+                <th><mat-icon>info</mat-icon> Status</th>
+                <td *ngIf="result$ | async as result; else noResult">
+                  <ng-container *ngIf="result['message'] as message">
+                    {{ message }}
+                  </ng-container>
 
-                <ng-container *ngIf="result['errno'] && result['code']">
-                  Error reducing dataset: {{ result["code"] }}
-                </ng-container>
-              </td>
-              <ng-template #noResult>
-                <td *ngIf="derivedDatasets.length > 0">
-                  Previously derived dataset available.
+                  <ng-container *ngIf="result['errno'] && result['code']">
+                    Error reducing dataset: {{ result["code"] }}
+                  </ng-container>
                 </td>
-              </ng-template>
-            </tr>
-          </table>
-        </div>
-      </ng-template>
+                <ng-template #noResult>
+                  <td *ngIf="derivedDatasets.length > 0">
+                    Previously derived dataset available.
+                  </td>
+                </ng-template>
+              </tr>
+            </table>
+          </div>
+        </ng-template>
 
-      <div class="action-workflow">
-        <form [formGroup]="actionsForm">
-          <mat-horizontal-stepper linear formArrayName="formArray" #stepper>
-            <mat-step formGroupName="0" [stepControl]="formArray.get([0])">
-              <ng-template matStepLabel>Select action</ng-template>
-              <div class="action-selector">
-                <mat-radio-group
-                  aria-label="Select an action"
-                  formControlName="actionForm"
-                >
-                  <mat-radio-button
-                    *ngFor="let action of actions"
-                    [value]="action"
-                    >{{ action }}</mat-radio-button
+        <div class="action-workflow">
+          <form [formGroup]="actionsForm">
+            <mat-horizontal-stepper linear formArrayName="formArray" #stepper>
+              <mat-step formGroupName="0" [stepControl]="formArray.get([0])">
+                <ng-template matStepLabel>Select action</ng-template>
+                <div class="action-selector">
+                  <mat-radio-group
+                    aria-label="Select an action"
+                    formControlName="actionForm"
                   >
-                </mat-radio-group>
-              </div>
-              <div>
-                <button mat-stroked-button matStepperNext type="button">
-                  Next
-                </button>
-              </div>
-            </mat-step>
+                    <mat-radio-button
+                      *ngFor="let action of actions"
+                      [value]="action"
+                      >{{ action }}</mat-radio-button
+                    >
+                  </mat-radio-group>
+                </div>
+                <div>
+                  <button mat-stroked-button matStepperNext type="button">
+                    Next
+                  </button>
+                </div>
+              </mat-step>
 
-            <mat-step formGroupName="1" [stepControl]="formArray.get([1])">
-              <ng-template matStepLabel>Select script</ng-template>
-              <div class="script-selector" fxLayout="row">
-                <div fxFlex="50">
-                  <mat-form-field
-                    *ngIf="
-                      selectedAction?.value === 'Reduce';
-                      else analyzeSelector
-                    "
-                  >
-                    <mat-label>Reduce script</mat-label>
-                    <mat-select formControlName="scriptForm" required>
-                      <mat-option
-                        *ngFor="let script of reduceScripts"
-                        [value]="script.value"
-                        >{{ script.value }}</mat-option
-                      >
-                    </mat-select>
-                    <mat-error>Please choose a script</mat-error>
-                  </mat-form-field>
-
-                  <ng-template #analyzeSelector>
-                    <mat-form-field>
-                      <mat-label>Analyze script</mat-label>
+              <mat-step formGroupName="1" [stepControl]="formArray.get([1])">
+                <ng-template matStepLabel>Select script</ng-template>
+                <div class="script-selector" fxLayout="row">
+                  <div fxFlex="50">
+                    <mat-form-field
+                      *ngIf="
+                        selectedAction?.value === 'Reduce';
+                        else analyzeSelector
+                      "
+                    >
+                      <mat-label>Reduce script</mat-label>
                       <mat-select formControlName="scriptForm" required>
                         <mat-option
-                          *ngFor="let script of analyzeScripts"
+                          *ngFor="let script of reduceScripts"
                           [value]="script.value"
                           >{{ script.value }}</mat-option
                         >
                       </mat-select>
                       <mat-error>Please choose a script</mat-error>
                     </mat-form-field>
-                  </ng-template>
+
+                    <ng-template #analyzeSelector>
+                      <mat-form-field>
+                        <mat-label>Analyze script</mat-label>
+                        <mat-select formControlName="scriptForm" required>
+                          <mat-option
+                            *ngFor="let script of analyzeScripts"
+                            [value]="script.value"
+                            >{{ script.value }}</mat-option
+                          >
+                        </mat-select>
+                        <mat-error>Please choose a script</mat-error>
+                      </mat-form-field>
+                    </ng-template>
+                  </div>
+
+                  <div class="script-details" fxFlex="50">
+                    <h4>Description</h4>
+                    <ng-container
+                      *ngIf="
+                        selectedAction?.value === 'Reduce';
+                        else analyzeDescription
+                      "
+                    >
+                      <div *ngFor="let script of reduceScripts">
+                        <p *ngIf="script.value === selectedScript?.value">
+                          {{ script.description }}
+                        </p>
+                      </div>
+                    </ng-container>
+
+                    <ng-template #analyzeDescription>
+                      <div *ngFor="let script of analyzeScripts">
+                        <p *ngIf="script.value === selectedScript?.value">
+                          {{ script.description }}
+                        </p>
+                      </div>
+                    </ng-template>
+
+                    <ng-container *ngIf="!selectedScript?.value">
+                      Select a script to view description.
+                    </ng-container>
+                  </div>
                 </div>
 
-                <div class="script-details" fxFlex="50">
-                  <h4>Description</h4>
-                  <ng-container
-                    *ngIf="
-                      selectedAction?.value === 'Reduce';
-                      else analyzeDescription
-                    "
+                <div>
+                  <button
+                    mat-stroked-button
+                    matStepperPrevious
+                    type="button"
+                    (click)="stepper.reset()"
                   >
-                    <div *ngFor="let script of reduceScripts">
-                      <p *ngIf="script.value === selectedScript?.value">
-                        {{ script.description }}
-                      </p>
-                    </div>
-                  </ng-container>
-
-                  <ng-template #analyzeDescription>
-                    <div *ngFor="let script of analyzeScripts">
-                      <p *ngIf="script.value === selectedScript?.value">
-                        {{ script.description }}
-                      </p>
-                    </div>
-                  </ng-template>
-
-                  <ng-container *ngIf="!selectedScript?.value">
-                    Select a script to view description.
-                  </ng-container>
+                    Back
+                  </button>
+                  <button
+                    mat-stroked-button
+                    matStepperNext
+                    type="button"
+                    id="ScriptNext"
+                  >
+                    Next
+                  </button>
                 </div>
+              </mat-step>
+
+              <mat-step>
+                <ng-template matStepLabel>Confirm</ng-template>
+                <div class="confirmation-table">
+                  <table>
+                    <tr>
+                      <th>Action</th>
+                      <td>{{ selectedAction?.value }}</td>
+                    </tr>
+                    <tr>
+                      <th>Script</th>
+                      <td>{{ selectedScript?.value }}</td>
+                    </tr>
+                  </table>
+                </div>
+                <div>
+                  <button mat-stroked-button matStepperPrevious type="button">
+                    Back
+                  </button>
+                  <button mat-stroked-button (click)="stepper.reset()">
+                    Reset
+                  </button>
+                  <button
+                    mat-flat-button
+                    color="primary"
+                    (click)="reduceDataset(dataset)"
+                    id="runAction"
+                  >
+                    Run Action
+                  </button>
+                </div>
+              </mat-step>
+            </mat-horizontal-stepper>
+          </form>
+        </div>
+      </mat-card>
+
+      <mat-card *ngIf="derivedDatasets">
+        <mat-card-header class="derived-header">
+          Derived Datasets
+        </mat-card-header>
+
+        <mat-table [dataSource]="derivedDatasets" class="history-table">
+          <!-- Column Definitions -->
+
+          <!-- Timestamp Column -->
+          <ng-container matColumnDef="timestamp">
+            <mat-header-cell *matHeaderCellDef>
+              <div fxLayout="column" style="align-items: center;">
+                <div>
+                  <mat-icon>calendar_today</mat-icon>
+                </div>
+                <div>Creation Time</div>
               </div>
+            </mat-header-cell>
+            <mat-cell *matCellDef="let dataset">
+              {{ dataset.createdAt | date: "yyyy-MM-dd, EEE HH:mm" }}
+            </mat-cell>
+          </ng-container>
 
-              <div>
-                <button
-                  mat-stroked-button
-                  matStepperPrevious
-                  type="button"
-                  (click)="stepper.reset()"
-                >
-                  Back
-                </button>
-                <button
-                  mat-stroked-button
-                  matStepperNext
-                  type="button"
-                  id="ScriptNext"
-                >
-                  Next
-                </button>
+          <!-- Name Column -->
+          <ng-container matColumnDef="name">
+            <mat-header-cell *matHeaderCellDef>
+              <div fxLayout="column" style="align-items: center;">
+                <div>
+                  <mat-icon>fingerprint</mat-icon>
+                </div>
+                <div>Name</div>
               </div>
-            </mat-step>
+            </mat-header-cell>
+            <mat-cell *matCellDef="let dataset">
+              {{ dataset.datasetName }}
+            </mat-cell>
+          </ng-container>
 
-            <mat-step>
-              <ng-template matStepLabel>Confirm</ng-template>
-              <div class="confirmation-table">
-                <table>
-                  <tr>
-                    <th>Action</th>
-                    <td>{{ selectedAction?.value }}</td>
-                  </tr>
-                  <tr>
-                    <th>Script</th>
-                    <td>{{ selectedScript?.value }}</td>
-                  </tr>
-                </table>
+          <!-- Pid Column -->
+          <ng-container matColumnDef="pid">
+            <mat-header-cell *matHeaderCellDef>
+              <div fxLayout="column" style="align-items: center;">
+                <div>
+                  <mat-icon> perm_contact_calendar </mat-icon>
+                </div>
+                <div>PID</div>
               </div>
-              <div>
-                <button mat-stroked-button matStepperPrevious type="button">
-                  Back
-                </button>
-                <button mat-stroked-button (click)="stepper.reset()">
-                  Reset
-                </button>
-                <button
-                  mat-flat-button
-                  color="primary"
-                  (click)="reduceDataset(dataset)"
-                  id="runAction"
-                >
-                  Run Action
-                </button>
+            </mat-header-cell>
+            <mat-cell *matCellDef="let dataset">
+              {{ dataset.pid }}
+            </mat-cell>
+          </ng-container>
+
+          <!-- Software Column -->
+          <ng-container matColumnDef="software">
+            <mat-header-cell *matHeaderCellDef>
+              <div fxLayout="column" style="align-items: center;">
+                <div>
+                  <mat-icon> screen_share</mat-icon>
+                </div>
+                <div>Software Used</div>
               </div>
-            </mat-step>
-          </mat-horizontal-stepper>
-        </form>
-      </div>
-    </mat-card>
+            </mat-header-cell>
+            <mat-cell *matCellDef="let dataset">
+              {{ dataset.usedSoftware }}
+            </mat-cell>
+          </ng-container>
 
-    <mat-card *ngIf="derivedDatasets">
-      <mat-card-header class="derived-header">
-        Derived Datasets
-      </mat-card-header>
+          <!-- End of Column Definitions -->
 
-      <mat-table [dataSource]="derivedDatasets" class="history-table">
-        <!-- Column Definitions -->
-
-        <!-- Timestamp Column -->
-        <ng-container matColumnDef="timestamp">
-          <mat-header-cell *matHeaderCellDef>
-            <div fxLayout="column" style="align-items: center;">
-              <div>
-                <mat-icon>calendar_today</mat-icon>
-              </div>
-              <div>Creation Time</div>
-            </div>
-          </mat-header-cell>
-          <mat-cell *matCellDef="let dataset">
-            {{ dataset.createdAt | date: "yyyy-MM-dd, EEE HH:mm" }}
-          </mat-cell>
-        </ng-container>
-
-        <!-- Name Column -->
-        <ng-container matColumnDef="name">
-          <mat-header-cell *matHeaderCellDef>
-            <div fxLayout="column" style="align-items: center;">
-              <div>
-                <mat-icon>fingerprint</mat-icon>
-              </div>
-              <div>Name</div>
-            </div>
-          </mat-header-cell>
-          <mat-cell *matCellDef="let dataset">
-            {{ dataset.datasetName }}
-          </mat-cell>
-        </ng-container>
-
-        <!-- Pid Column -->
-        <ng-container matColumnDef="pid">
-          <mat-header-cell *matHeaderCellDef>
-            <div fxLayout="column" style="align-items: center;">
-              <div>
-                <mat-icon> perm_contact_calendar </mat-icon>
-              </div>
-              <div>PID</div>
-            </div>
-          </mat-header-cell>
-          <mat-cell *matCellDef="let dataset">
-            {{ dataset.pid }}
-          </mat-cell>
-        </ng-container>
-
-        <!-- Software Column -->
-        <ng-container matColumnDef="software">
-          <mat-header-cell *matHeaderCellDef>
-            <div fxLayout="column" style="align-items: center;">
-              <div>
-                <mat-icon> screen_share</mat-icon>
-              </div>
-              <div>Software Used</div>
-            </div>
-          </mat-header-cell>
-          <mat-cell *matCellDef="let dataset">
-            {{ dataset.usedSoftware }}
-          </mat-cell>
-        </ng-container>
-
-        <!-- End of Column Definitions -->
-
-        <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
-        <mat-row
-          *matRowDef="let dataset; columns: columnsToDisplay"
-          (click)="onRowClick(dataset)"
-        >
-        </mat-row>
-      </mat-table>
-    </mat-card>
+          <mat-header-row *matHeaderRowDef="columnsToDisplay"></mat-header-row>
+          <mat-row
+            *matRowDef="let dataset; columns: columnsToDisplay"
+            (click)="onRowClick(dataset)"
+          >
+          </mat-row>
+        </mat-table>
+      </mat-card>
+    </div>
   </div>
-</div>
+
+</ng-template>

--- a/src/app/datasets/reduce/reduce.component.html
+++ b/src/app/datasets/reduce/reduce.component.html
@@ -1,11 +1,3 @@
-<ng-template [ngIf]="!dataset">
-  <error-page
-    *ngIf="(loading$ | async) === false"
-    [errorTitle]="'Dataset not found'"
-    [message]="'The dataset you are trying to view either doesn\'t exist or you don\'t have permission to view it.'"
-  >
-  </error-page>
-</ng-template>
 <ng-template [ngIf]="dataset">
   <div fxLayout="row" fxLayout.xs="column">
     <div fxFlex="70">

--- a/src/app/datasets/reduce/reduce.component.ts
+++ b/src/app/datasets/reduce/reduce.component.ts
@@ -145,6 +145,6 @@ export class ReduceComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy() {
     this.subscriptions.forEach((subscription) => {
       subscription.unsubscribe();
-    })
+    });
   }
 }

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.html
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="logbook">
+<div *ngIf="logbook && dataset">
   <div fxLayout="row" fxLayout.lt-lg="column">
     <div fxFlex="14">
       <mat-card class="big-filter">

--- a/src/app/shared/services/ownership.service.ts
+++ b/src/app/shared/services/ownership.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from "@angular/core";
+import { Router } from "@angular/router";
+import { Store } from "@ngrx/store";
+import { RowTransformCallback } from "exceljs";
+import { combineLatest, Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { Dataset } from "shared/sdk";
+import { selectIsAdmin, selectProfile } from "state-management/selectors/user.selectors";
+
+@Injectable({
+  providedIn: "root"
+})
+export class OwnershipService {
+  checkPermission(dataset: Dataset | undefined, store: Store, router: Router) {
+    if (dataset) {
+      const userProfile$:Observable<any> = store.select(selectProfile);
+      const isAdmin$ = store.select(selectIsAdmin);
+      const accessGroups$: Observable<string[]> = userProfile$.pipe(
+        map((profile) => (profile ? profile.accessGroups : []))
+      );
+      combineLatest([accessGroups$, isAdmin$]).subscribe(([groups, isAdmin]) =>{
+        const isInOwnerGroup =
+            groups.indexOf(dataset.ownerGroup) !== -1 || isAdmin;
+          if(!isInOwnerGroup) {
+            router.navigate(["/401"], {
+              skipLocationChange: true,
+              queryParams: {
+                url: router.routerState.snapshot.url,
+              },
+          });
+        }
+      }).unsubscribe();
+      }
+  }
+}


### PR DESCRIPTION
## Description
See #780. While trying to fix this bug I also improved the error handling of the user interface related to dataset. One thing I think is really confusing is to know what user should see base on access group. Should access group see reduce, attachments and logbook? Maybe we should have a schema or something where we specify what each different group could see.
## For Reviewer
Check that the user interface shows up correctly on the following cases:
- Not logged in + view public dataset => Should only see tabs for details, datafiles and data lifecycle
- Not logged in + view private dataset => Should see 404 page on paths: "", /datafile, /lifecycle
- Not logged in + view private dataset/view public dataset => Should be redirected to log in page on paths: /reduce, attachments, logbook
- Logged in + view public dataset + is owner => Should see all tabs
- Logged in + view public dataset + is not owner => Should see only 3 tabs (details, datafiles, lifecyfle)
- Logged in + view public dataset + is not owner + try to view urls: /reduce, /attachments, /logbooks => redirected to 401 page
- Logged in + view private dataset + is owner => Should see all tabs
- Logged in + view private dataset + is not owner => Should see 404 page.
Not sure if I have covered all the cases.

## Fixes:
- Fix bug with the Sign In button
- Redirect logged in user to 401 if user requests to view /reduce, /attachments, /logbook of  public dataset that the user is not owner to
- Show 404 page if dataset doesnt exist or the current logged in user tries to view private dataset that he/she is not owner to.
## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

