### PR TITLE
Chore/policies view model selectors

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -13,12 +13,12 @@ exports[`stricter compilation`] = {
       [198, 8, 68, "Expected 0 arguments, but got 1.", "2820193145"],
       [262, 47, 29, "Expected 0 arguments, but got 1.", "2503700957"]
     ],
-    "src/app/datasets/dataset-detail/dataset-detail.component.ts:1688806200": [
-      [81, 31, 12, "Object is possibly \'undefined\'.", "1944648223"]
+    "src/app/datasets/dataset-detail/dataset-detail.component.ts:3260648166": [
+      [83, 31, 12, "Object is possibly \'undefined\'.", "1944648223"]
     ],
-    "src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts:1898272901": [
-      [121, 31, 12, "Object is possibly \'undefined\'.", "1944648223"],
-      [178, 35, 8, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'typeof TAB\'.\\n  No index signature with a parameter of type \'string\' was found on type \'typeof TAB\'.", "4213543011"]
+    "src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts:3875342984": [
+      [122, 31, 12, "Object is possibly \'undefined\'.", "1944648223"],
+      [179, 35, 8, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'typeof TAB\'.\\n  No index signature with a parameter of type \'string\' was found on type \'typeof TAB\'.", "4213543011"]
     ],
     "src/app/datasets/dataset-lifecycle/dataset-lifecycle.component.spec.ts:2957427070": [
       [173, 20, 3, "Parameter \'key\' implicitly has an \'any\' type.", "193424690"],
@@ -128,17 +128,17 @@ exports[`stricter compilation`] = {
       [216, 8, 72, "Expected 0 arguments, but got 1.", "2723127549"],
       [219, 8, 42, "Expected 0 arguments, but got 1.", "3485696116"]
     ],
-    "src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts:4210154999": [
-      [189, 8, 66, "Expected 0 arguments, but got 1.", "829953720"],
-      [207, 8, 103, "Expected 0 arguments, but got 1.", "1292591848"],
-      [227, 8, 72, "Expected 0 arguments, but got 1.", "2723127549"],
-      [244, 8, 109, "Expected 0 arguments, but got 1.", "1426938445"],
-      [261, 47, 25, "Expected 0 arguments, but got 1.", "45720501"],
-      [272, 47, 22, "Expected 0 arguments, but got 1.", "3206069091"],
-      [289, 8, 49, "Expected 0 arguments, but got 1.", "1596683029"],
-      [305, 8, 51, "Expected 0 arguments, but got 1.", "1809416436"],
-      [332, 8, 104, "Expected 0 arguments, but got 1.", "2940355500"],
-      [337, 47, 22, "Expected 0 arguments, but got 1.", "3206069091"]
+    "src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts:132889990": [
+      [200, 8, 66, "Expected 0 arguments, but got 1.", "829953720"],
+      [218, 8, 103, "Expected 0 arguments, but got 1.", "1292591848"],
+      [238, 8, 72, "Expected 0 arguments, but got 1.", "2723127549"],
+      [255, 8, 109, "Expected 0 arguments, but got 1.", "1426938445"],
+      [272, 47, 25, "Expected 0 arguments, but got 1.", "45720501"],
+      [283, 47, 22, "Expected 0 arguments, but got 1.", "3206069091"],
+      [300, 8, 49, "Expected 0 arguments, but got 1.", "1596683029"],
+      [316, 8, 51, "Expected 0 arguments, but got 1.", "1809416436"],
+      [343, 8, 104, "Expected 0 arguments, but got 1.", "2940355500"],
+      [348, 47, 22, "Expected 0 arguments, but got 1.", "3206069091"]
     ],
     "src/app/proposals/view-proposal-page/view-proposal-page.component.spec.ts:773841882": [
       [84, 45, 4, "Argument of type \'null\' is not assignable to parameter of type \'Dataset[]\'.", "2087897566"],

--- a/src/app/policies/policies-dashboard/policies-dashboard.component.html
+++ b/src/app/policies/policies-dashboard/policies-dashboard.component.html
@@ -1,67 +1,69 @@
-<mat-tab-group (selectedTabChange)="onTabChange($event)">
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <ng-container>
-        Readable
-      </ng-container>
-    </ng-template>
-
-    <div fxLayout="row">
-      <div fxFlex="1"></div>
-      <div fxFlex="98">
-        <app-table
-          class="readable"
-          [data]="policies$ | async"
-          [columns]="tableColumns"
-          [paginate]="paginate"
-          [currentPage]="currentPage$ | async"
-          [dataCount]="policyCount$ | async"
-          [dataPerPage]="policiesPerPage$ | async"
-          (pageChange)="onPoliciesPageChange($event)"
-          (sortChange)="onPoliciesSortChange($event)"
-        ></app-table>
-      </div>
-      <div fxFlex="1"></div>
-    </div>
-  </mat-tab>
-  <mat-tab>
-    <ng-template mat-tab-label>
-      Editable
-    </ng-template>
-
-    <div fxLayout="column" fxLayoutGap="row" fxLayoutAlign="end end">
-      <ng-template [ngIf]="editEnabled">
-        <button
-          mat-button
-          [disabled]="selectedPolicies.length === 0"
-          (click)="openDialog()"
-          color="primary"
-          data-cy="editSelection"
-        >
-          <mat-icon>edit</mat-icon> Edit Selection
-        </button>
+<ng-container *ngIf="vm$ | async as vm">
+  <mat-tab-group (selectedTabChange)="onTabChange($event)">
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <ng-container> Readable </ng-container>
       </ng-template>
-    </div>
 
-    <div fxLayout="row">
-      <div fxFlex="1"></div>
-      <div fxFlex="98">
-        <app-table
-          class="editable"
-          [data]="editablePolicies$ | async"
-          [columns]="tableColumns"
-          [select]="editEnabled"
-          [paginate]="paginate"
-          [currentPage]="currentEditablePage$ | async"
-          [dataCount]="editableCount$ | async"
-          [dataPerPage]="editablePoliciesPerPage$ | async"
-          (pageChange)="onEditablePoliciesPageChange($event)"
-          (sortChange)="onEditablePoliciesSortChange($event)"
-          (selectAll)="onSelectAll($event)"
-          (selectOne)="onSelectOne($event)"
-        ></app-table>
+      <ng-container *ngIf="vm.policies">
+        <div fxLayout="row">
+          <div fxFlex="1"></div>
+          <div fxFlex="98">
+            <app-table
+              class="readable"
+              [data]="vm.policies"
+              [columns]="tableColumns"
+              [paginate]="paginate"
+              [currentPage]="vm.currentPage"
+              [dataCount]="vm.policyCount"
+              [dataPerPage]="vm.policiesPerPage"
+              (pageChange)="onPoliciesPageChange($event)"
+              (sortChange)="onPoliciesSortChange($event)"
+            ></app-table>
+          </div>
+          <div fxFlex="1"></div>
+        </div>
+      </ng-container>
+    </mat-tab>
+    <mat-tab>
+      <ng-template mat-tab-label> Editable </ng-template>
+
+      <div fxLayout="column" fxLayoutGap="row" fxLayoutAlign="end end">
+        <ng-template [ngIf]="editEnabled">
+          <button
+            mat-button
+            [disabled]="vm.selectedPolicies.length === 0"
+            (click)="openDialog(vm.selectedPolicies)"
+            color="primary"
+            data-cy="editSelection"
+          >
+            <mat-icon>edit</mat-icon> Edit Selection
+          </button>
+        </ng-template>
       </div>
-      <div fxFlex="1"></div>
-    </div>
-  </mat-tab>
-</mat-tab-group>
+
+      <ng-container *ngIf="vm.editablePolicies">
+        <div fxLayout="row">
+          <div fxFlex="1"></div>
+          <div fxFlex="98">
+            <app-table
+              class="editable"
+              [data]="vm.editablePolicies"
+              [columns]="tableColumns"
+              [select]="editEnabled"
+              [paginate]="paginate"
+              [currentPage]="vm.currentEditablePage"
+              [dataCount]="vm.editableCount"
+              [dataPerPage]="vm.editablePoliciesPerPage"
+              (pageChange)="onEditablePoliciesPageChange($event)"
+              (sortChange)="onEditablePoliciesSortChange($event)"
+              (selectAll)="onSelectAll($event)"
+              (selectOne)="onSelectOne($event)"
+            ></app-table>
+          </div>
+          <div fxFlex="1"></div>
+        </div>
+      </ng-container>
+    </mat-tab>
+  </mat-tab-group>
+</ng-container>

--- a/src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts
+++ b/src/app/policies/policies-dashboard/policies-dashboard.component.spec.ts
@@ -33,10 +33,7 @@ import { GenericFilters } from "state-management/models";
 
 import { RouterTestingModule } from "@angular/router/testing";
 import { provideMockStore } from "@ngrx/store/testing";
-import {
-  selectFilters,
-  selectEditableFilters,
-} from "state-management/selectors/policies.selectors";
+import { selectPoliciesDashboardPageViewModel } from "state-management/selectors/policies.selectors";
 import {
   MatTabChangeEvent,
   MatTab,
@@ -76,8 +73,22 @@ describe("PoliciesDashboardComponent", () => {
         providers: [
           provideMockStore({
             selectors: [
-              { selector: selectFilters, value: {} },
-              { selector: selectEditableFilters, value: {} },
+              {
+                selector: selectPoliciesDashboardPageViewModel,
+                value: {
+                  policies: [],
+                  policiesPerPage: 25,
+                  currentPage: 0,
+                  policyCount: 0,
+                  filters: {},
+                  editablePolicies: [],
+                  editablePoliciesPerPage: 25,
+                  currentEditablePage: 0,
+                  editableCount: 0,
+                  editableFilters: {},
+                  selectedPolicies: [],
+                },
+              },
             ],
           }),
         ],

--- a/src/app/state-management/selectors/policies.selectors.spec.ts
+++ b/src/app/state-management/selectors/policies.selectors.spec.ts
@@ -128,6 +128,44 @@ describe("Policies Selectors", () => {
     });
   });
 
+  describe("selectPoliciesPagination", () => {
+    it("should select policies pagination state", () => {
+      expect(
+        fromSelectors.selectPoliciesPagination.projector(
+          fromSelectors.selectPoliciesPerPage.projector(
+            initialPolicyState.policiesFilters
+          ),
+          fromSelectors.selectPage.projector(
+            initialPolicyState.policiesFilters
+          ),
+          fromSelectors.selectPoliciesCount.projector(initialPolicyState)
+        )
+      ).toEqual({ policiesPerPage: 25, currentPage: 0, policyCount: 0 });
+    });
+  });
+
+  describe("selectEditablePoliciesPagination", () => {
+    it("should select editable policies pagination state", () => {
+      expect(
+        fromSelectors.selectEditablePoliciesPagination.projector(
+          fromSelectors.selectEditablePoliciesPerPage.projector(
+            initialPolicyState.editableFilters
+          ),
+          fromSelectors.selectEditablePage.projector(
+            initialPolicyState.editableFilters
+          ),
+          fromSelectors.selectEditablePoliciesCount.projector(
+            initialPolicyState
+          )
+        )
+      ).toEqual({
+        editablePoliciesPerPage: 25,
+        currentEditablePage: 0,
+        editableCount: 0,
+      });
+    });
+  });
+
   describe("selectQueryParams", () => {
     it("should select query params from policiesFilters", () => {
       const { skip, limit, sortField } = policiesFilters;
@@ -149,6 +187,52 @@ describe("Policies Selectors", () => {
           initialPolicyState.editableFilters
         )
       ).toEqual(params);
+    });
+  });
+
+  describe("selectPoliciesDashboardPageViewModel", () => {
+    it("should select policies dashboard page view model state", () => {
+      expect(
+        fromSelectors.selectPoliciesDashboardPageViewModel.projector(
+          fromSelectors.selectPolicies.projector(initialPolicyState),
+          fromSelectors.selectPoliciesPagination.projector(
+            fromSelectors.selectPoliciesPerPage.projector(
+              initialPolicyState.policiesFilters
+            ),
+            fromSelectors.selectPage.projector(
+              initialPolicyState.policiesFilters
+            ),
+            fromSelectors.selectPoliciesCount.projector(initialPolicyState)
+          ),
+          fromSelectors.selectFilters.projector(initialPolicyState),
+          initialPolicyState.editablePolicies,
+          fromSelectors.selectEditablePoliciesPagination.projector(
+            fromSelectors.selectEditablePoliciesPerPage.projector(
+              initialPolicyState.editableFilters
+            ),
+            fromSelectors.selectEditablePage.projector(
+              initialPolicyState.editableFilters
+            ),
+            fromSelectors.selectEditablePoliciesCount.projector(
+              initialPolicyState
+            )
+          ),
+          fromSelectors.selectEditableFilters.projector(initialPolicyState),
+          fromSelectors.selectSelectedPolicies.projector(initialPolicyState)
+        )
+      ).toEqual({
+        policies: [],
+        policiesPerPage: 25,
+        currentPage: 0,
+        policyCount: 0,
+        filters: policiesFilters,
+        editablePolicies: [],
+        editablePoliciesPerPage: 25,
+        currentEditablePage: 0,
+        editableCount: 0,
+        editableFilters,
+        selectedPolicies: [],
+      });
     });
   });
 });

--- a/src/app/state-management/selectors/policies.selectors.ts
+++ b/src/app/state-management/selectors/policies.selectors.ts
@@ -61,6 +61,28 @@ export const selectEditablePoliciesPerPage = createSelector(
   (filters) => filters.limit
 );
 
+export const selectPoliciesPagination = createSelector(
+  selectPoliciesPerPage,
+  selectPage,
+  selectPoliciesCount,
+  (policiesPerPage, currentPage, policyCount) => ({
+    policiesPerPage,
+    currentPage,
+    policyCount,
+  })
+);
+
+export const selectEditablePoliciesPagination = createSelector(
+  selectEditablePoliciesPerPage,
+  selectEditablePage,
+  selectEditablePoliciesCount,
+  (editablePoliciesPerPage, currentEditablePage, editableCount) => ({
+    editablePoliciesPerPage,
+    currentEditablePage,
+    editableCount,
+  })
+);
+
 export const selectQueryParams = createSelector(selectFilters, (filters) => {
   const { skip, limit, sortField } = filters;
   return { order: sortField, skip, limit };
@@ -72,4 +94,35 @@ export const selectEditableQueryParams = createSelector(
     const { skip, limit, sortField } = filters;
     return { order: sortField, skip, limit };
   }
+);
+
+export const selectPoliciesDashboardPageViewModel = createSelector(
+  selectPolicies,
+  selectPoliciesPagination,
+  selectFilters,
+  selectEditablePolicies,
+  selectEditablePoliciesPagination,
+  selectEditableFilters,
+  selectSelectedPolicies,
+  (
+    policies,
+    policiesPagination,
+    filters,
+    editablePolicies,
+    editablePoliciesPagination,
+    editableFilters,
+    selectedPolicies
+  ) => ({
+    policies,
+    policiesPerPage: policiesPagination.policiesPerPage,
+    currentPage: policiesPagination.currentPage,
+    policyCount: policiesPagination.policyCount,
+    filters,
+    editablePolicies,
+    editablePoliciesPerPage: editablePoliciesPagination.editablePoliciesPerPage,
+    currentEditablePage: editablePoliciesPagination.currentEditablePage,
+    editableCount: editablePoliciesPagination.editableCount,
+    editableFilters,
+    selectedPolicies,
+  })
 );


### PR DESCRIPTION
## Description

Replaces individual selectors for policies views with page view selector.

## Motivation

Background on use case, changes needed

## Changes:

* Create new selector `selectPoliciesDashboardPageViewModel`
* Replace individual selectors in policies dashboard with new selector

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

