### PR TITLE
Add links from published data to datasets

### DIFF
--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
@@ -153,14 +153,25 @@
           <th>Related Publications</th>
           <td>{{ publishedData.relatedPublications }}</td>
         </tr>
-        <tr *ngIf="publishedData.pidArray as value">
+        <tr *ngIf="publishedData.pidArray as pidArray">
           <th>Dataset IDs</th>
-          <td>{{ value }}</td>
+          <td>
+            <ng-container *ngFor="let pid of pidArray">
+              <a [routerLink]="['/datasets/', pid]">
+                {{ pid }}
+              </a>
+              <span *ngIf="pidArray.indexOf(pid) < pidArray.length - 1"
+                >,
+              </span>
+            </ng-container>
+          </td>
         </tr>
       </table>
     </mat-card>
 
-    <mat-card>
+    <mat-card
+      *ngIf="appConfig.editPublishedData && appConfig.jsonMetadataEnabled"
+    >
       <button
         mat-raised-button
         id="editBtn"

--- a/src/app/publisheddata/publisheddata.module.ts
+++ b/src/app/publisheddata/publisheddata.module.ts
@@ -22,6 +22,7 @@ import { MatOptionModule } from "@angular/material/core";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
 import { MatTooltipModule } from "@angular/material/tooltip";
+import { RouterModule } from "@angular/router";
 
 @NgModule({
   declarations: [
@@ -42,6 +43,7 @@ import { MatTooltipModule } from "@angular/material/tooltip";
     MatTooltipModule,
     NgxJsonViewerModule,
     ReactiveFormsModule,
+    RouterModule,
     SharedCatanieModule,
     StoreModule.forFeature("publishedData", publishedDataReducer),
     FormsModule,


### PR DESCRIPTION
## Description

Add link from Published Data to the Datasets that are part of it.

## Motivation

As a user, when I'm visiting a published data page, I would like to be able to have a link to the dataset page.

## Changes:

* Add router link from Published Data Details page to Dataset Details page
* Add RouterModule to Published Data Module imports

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of catamel API?

