### PR TITLE
Additinal CONTAINS_STRING option for characteristic filter

### DIFF
--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -185,6 +185,9 @@
           <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
             &nbsp;=&nbsp;
           </ng-container>
+          <ng-container *ngSwitchCase="'CONTAINS_STRING'">
+            &nbsp;contains&nbsp;
+          </ng-container>
           <ng-container *ngSwitchCase="'LESS_THAN'">
             &nbsp;&lt;&nbsp;
           </ng-container>
@@ -193,7 +196,7 @@
           </ng-container>
         </ng-container>
         {{
-          condition.relation === "EQUAL_TO_STRING"
+          ["EQUAL_TO_STRING", "CONTAINS_STRING"].includes(condition.relation)
             ? '"' + condition.rhs + '"'
             : condition.rhs
         }}

--- a/src/app/samples/sample-dashboard/sample-dashboard.component.html
+++ b/src/app/samples/sample-dashboard/sample-dashboard.component.html
@@ -45,6 +45,9 @@
                   <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
                     &nbsp;=&nbsp;
                   </ng-container>
+                  <ng-container *ngSwitchCase="'CONTAINS_STRING'">
+                    &nbsp;=&nbsp;
+                  </ng-container>
                   <ng-container *ngSwitchCase="'LESS_THAN'">
                     &nbsp;&lt;&nbsp;
                   </ng-container>
@@ -53,7 +56,7 @@
                   </ng-container>
                 </ng-container>
                 {{
-                  characteristic.relation === "EQUAL_TO_STRING"
+                  [ "EQUAL_TO_STRING", "CONTAINS_STRING" ].includes(characteristic.relation)
                     ? '"' + characteristic.rhs + '"'
                     : characteristic.rhs
                 }}

--- a/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.html
+++ b/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.html
@@ -33,6 +33,7 @@
         <mat-option value="LESS_THAN">is less than</mat-option>
         <mat-option value="EQUAL_TO_NUMERIC">is equal to (numeric)</mat-option>
         <mat-option value="EQUAL_TO_STRING">is equal to (string)</mat-option>
+        <mat-option value="CONTAINS_STRING">contains string</mat-option>
       </mat-select>
     </mat-form-field>
 

--- a/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.spec.ts
+++ b/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.spec.ts
@@ -107,7 +107,7 @@ describe("SearchParametersDialogComponent", () => {
   });
 
   describe("#toggleUnitField()", () => {
-    it("should enable unitField if lhs is valid and relation is not EQUAL_TO_STRING", () => {
+    it("should enable unitField if lhs is valid and relation is not CONTAINS_STRING or EQUAL_TO_STRING" , () => {
       const formValues = {
         lhs: "mass",
         relation: "LESS_THAN",

--- a/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
+++ b/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
@@ -55,7 +55,7 @@ export class SearchParametersDialogComponent {
     const { lhs, relation, unit } = this.parametersForm.value;
     const rawRhs = this.parametersForm.get("rhs")?.value;
     const rhs =
-      relation === "EQUAL_TO_STRING" ? String(rawRhs) : Number(rawRhs);
+      [ "CONTAINS_STRING", "EQUAL_TO_STRING" ].includes(relation) ? String(rawRhs) : Number(rawRhs);
     this.parametersForm.patchValue({ rhs });
     this.dialogRef.close({ data: { lhs, relation, rhs, unit } });
   };
@@ -70,7 +70,7 @@ export class SearchParametersDialogComponent {
   toggleUnitField = (): void => {
     const lhsInvalid = this.parametersForm.get("lhs")?.invalid;
     const { relation } = this.parametersForm.value;
-    const isStringRelation = relation === "EQUAL_TO_STRING" ? true : false;
+    const isStringRelation = [ "CONTAINS_STRING", "EQUAL_TO_STRING" ].includes(relation) ? true : false;
     const unitField = this.parametersForm.get("unit");
     unitField?.enable();
     if (lhsInvalid || isStringRelation) {
@@ -85,7 +85,7 @@ export class SearchParametersDialogComponent {
     if (invalid) {
       return invalid;
     }
-    if (relation !== "EQUAL_TO_STRING" && isNaN(Number(rhs))) {
+    if (![ "CONTAINS_STRING", "EQUAL_TO_STRING" ].includes(relation) && isNaN(Number(rhs))) {
       return true;
     }
     return lhs.length * rhs.length === 0;

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -81,6 +81,7 @@ export enum JobViewMode {
 type ScientificConditionRelation =
   | "EQUAL_TO_NUMERIC"
   | "EQUAL_TO_STRING"
+  | "CONTAINS_STRING"
   | "GREATER_THAN"
   | "LESS_THAN";
 


### PR DESCRIPTION
## Description

In https://github.com/SciCatProject/backend/pull/680 we propose a filter option for partially matching strings and here we added the corresponding frontend modifications.

## Motivation

imagine you'd have the following metadata for a dataset

```json
"scientificMetadata": {
        "localContact": "John Doe",
        "experimentalists": [
                "John Doe",
                "Max Mustermann"
         ]
```

now we would like to filter all datasts where `John` participated in the measurement (or was local contact respectivly). So far this type of query was not possible using the options offered when clicking `add condition`  in the search box as there was only an option to exactly match complete strings and no option for partial string matching or matching strings in lists.

## Changes:

![new_contains_string_option](https://user-images.githubusercontent.com/3169764/172996550-a5f9a6d6-6877-4925-9d2a-cffaa62ab0c9.png)

![condition_label](https://user-images.githubusercontent.com/3169764/172996533-5f0672c2-7a9e-4cab-b8f7-b5baae816af0.png)


## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [x] Requires update of SciCat backend API?

