### PR TITLE
feat: Adding oauth redirect component

### DIFF
--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -18,7 +18,11 @@ export const routes: Routes = [
       },
       {
         path: "login",
-        loadChildren: () => import("./lazy/login-routing/login.feature.module").then(m => m.LoginFeatureModule)
+        loadChildren: () => import("./lazy/login-routing/login.feature.module").then( (m) => m.LoginFeatureModule),
+      },
+      {
+        path: "auth-callback",
+        loadChildren: () => import("./lazy/auth-callback-routing/auth-callback.feature.module").then((m) => m.AuthCallbackFeatureModule),
       },
       {
         path: "",

--- a/src/app/app-routing/lazy/auth-callback-routing/auth-callback.feature.module.ts
+++ b/src/app/app-routing/lazy/auth-callback-routing/auth-callback.feature.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from "@angular/core";
+import { UsersModule } from "users/users.module";
+import { AuthCallbackRoutingModule } from "./auth-callback.routing.module";
+
+@NgModule({
+  imports: [UsersModule, AuthCallbackRoutingModule,],
+})
+export class AuthCallbackFeatureModule {}

--- a/src/app/app-routing/lazy/auth-callback-routing/auth-callback.routing.module.ts
+++ b/src/app/app-routing/lazy/auth-callback-routing/auth-callback.routing.module.ts
@@ -1,0 +1,15 @@
+import { AuthCallbackComponent } from "../../../users/auth-callback/auth-callback.component";
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: AuthCallbackComponent,
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AuthCallbackRoutingModule {}

--- a/src/app/shared/modules/shared-table/shared-table.module.ts
+++ b/src/app/shared/modules/shared-table/shared-table.module.ts
@@ -57,7 +57,6 @@ export interface Column {
     MatCheckboxModule,
     MatIconModule,
     MatPaginatorModule,
-    MatProgressSpinnerModule,
     MatSortModule,
     MatProgressSpinnerModule,
     MatTableModule,

--- a/src/app/users/auth-callback/auth-callback.component.html
+++ b/src/app/users/auth-callback/auth-callback.component.html
@@ -1,0 +1,3 @@
+<div class="loading">
+  Loading...
+</div>

--- a/src/app/users/auth-callback/auth-callback.component.scss
+++ b/src/app/users/auth-callback/auth-callback.component.scss
@@ -1,0 +1,3 @@
+.loading {
+  margin: 10px;
+}

--- a/src/app/users/auth-callback/auth-callback.component.spec.ts
+++ b/src/app/users/auth-callback/auth-callback.component.spec.ts
@@ -1,24 +1,65 @@
-import { ComponentFixture, TestBed } from "@angular/core/testing";
-
+import {
+  ComponentFixture,
+  inject,
+  TestBed,
+  waitForAsync,
+} from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
+import { Store, StoreModule } from "@ngrx/store";
+import { provideMockStore } from "@ngrx/store/testing";
+import { MockActivatedRoute, MockRouter, MockStore } from "shared/MockStubs";
+import { selectLoginPageViewModel } from "state-management/selectors/user.selectors";
 import { AuthCallbackComponent } from "./auth-callback.component";
 
 describe("AuthCallbackComponent", () => {
   let component: AuthCallbackComponent;
   let fixture: ComponentFixture<AuthCallbackComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  let store: MockStore;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
       declarations: [AuthCallbackComponent],
-    }).compileComponents();
+      imports: [StoreModule.forRoot({})],
+      providers: [
+        provideMockStore({
+          selectors: [
+            {
+              selector: selectLoginPageViewModel,
+              value: { isLoggedIn: true, isLoggingIn: false },
+            },
+          ],
+        }),
+      ],
+    });
+    TestBed.overrideComponent(AuthCallbackComponent, {
+      set: {
+        providers: [
+          { provide: ActivatedRoute, useClass: MockActivatedRoute },
+          { provide: Router, useClass: MockRouter },
+        ],
+      },
+    });
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(inject([Store], (mockStore: MockStore) => {
+    store = mockStore;
+  }));
+
+  afterEach(() => {
+    fixture.destroy();
   });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AuthCallbackComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe("component construction", () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(AuthCallbackComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      TestBed.compileComponents();
+    });
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
   });
 });

--- a/src/app/users/auth-callback/auth-callback.component.spec.ts
+++ b/src/app/users/auth-callback/auth-callback.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { AuthCallbackComponent } from "./auth-callback.component";
+
+describe("AuthCallbackComponent", () => {
+  let component: AuthCallbackComponent;
+  let fixture: ComponentFixture<AuthCallbackComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AuthCallbackComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthCallbackComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/users/auth-callback/auth-callback.component.ts
+++ b/src/app/users/auth-callback/auth-callback.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import {
+  fetchUserAction,
+  loginOIDCAction,
+} from "state-management/actions/user.actions";
+import { Store } from "@ngrx/store";
+
+@Component({
+  selector: "app-auth-callback",
+  templateUrl: "./auth-callback.component.html",
+  styleUrls: ["./auth-callback.component.scss"],
+})
+export class AuthCallbackComponent implements OnInit {
+  constructor(
+    private route: ActivatedRoute,
+    private store: Store,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.route.queryParams.subscribe((params) => {
+      // External authentication will redirect to this component with a access-token and user-id query parameter
+      const accessToken = params["access-token"];
+      const userId = params["user-id"];
+
+      if (accessToken && userId) {
+        // If the user is authenticated, we will store the access token and user id in the store
+        this.store.dispatch(
+          loginOIDCAction({ oidcLoginResponse: { accessToken, userId } })
+        );
+
+        // We will also fetch the user from the backend
+        this.store.dispatch(
+          fetchUserAction({
+            adLoginResponse: { access_token: accessToken, userId: userId },
+          })
+        );
+
+        // After the user is authenticated, we will redirect to the home page
+        const returnUrl = params["returnUrl"];
+        this.router.navigateByUrl(returnUrl || "/");
+      }
+    });
+  }
+}

--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -13,6 +13,7 @@
         <div fxFlex="auto"></div>
       </div>
       <mat-card-content>
+        {{ oAuth2Endpoints }}
         <div *ngFor="let endpoint of oAuth2Endpoints">
           <button
             class="oauth-login-button"

--- a/src/app/users/users.module.ts
+++ b/src/app/users/users.module.ts
@@ -20,6 +20,7 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
 import { PrivacyDialogComponent } from "./privacy-dialog/privacy-dialog.component";
 import { MatTooltipModule } from "@angular/material/tooltip";
+import { AuthCallbackComponent } from "./auth-callback/auth-callback.component";
 
 @NgModule({
   imports: [
@@ -40,7 +41,12 @@ import { MatTooltipModule } from "@angular/material/tooltip";
     SharedScicatFrontendModule,
     StoreModule.forFeature("users", userReducer),
   ],
-  declarations: [LoginComponent, UserSettingsComponent, PrivacyDialogComponent],
+  declarations: [
+    LoginComponent,
+    UserSettingsComponent,
+    PrivacyDialogComponent,
+    AuthCallbackComponent,
+  ],
   providers: [ADAuthService],
 })
 export class UsersModule {}


### PR DESCRIPTION
## Description

This PR aims to add a new component `auth-callback` whose sole purpose is to read query params and update the frontend application state. 

## Motivation

I think it is better to keep it in a different component than the login-component, because of two reasons
- This functionality can be split into another component, which keeps code more readable
- If logic is in the login component then for a split second after redirect you see the input form

## Fixes:

SWAP-2835

## Changes:

Added auth-callback component

## Tests included/Docs Updated?

- [x] Passing? (Merge will not be approved unless this is checked) 


