### PR TITLE
Logbook access and proposal display

### DIFF
--- a/src/app/_layout/app-header/app-header.component.html
+++ b/src/app/_layout/app-header/app-header.component.html
@@ -22,13 +22,14 @@
       </button>
     </ng-container>
 
-    <ng-container *ngIf="config.logbookEnabled">
+<!--    <ng-container *ngIf="config.logbookEnabled">
       <button mat-menu-item routerLink="/logbooks/">
         <mat-icon> book</mat-icon>
         <span>Logbooks</span>
       </button>
     </ng-container>
-
+  -->
+  
     <ng-container *ngIf="config.policiesEnabled">
       <button mat-menu-item routerLink="/policies/">
         <mat-icon> cloud_download</mat-icon>

--- a/src/app/_layout/app-header/app-header.component.html
+++ b/src/app/_layout/app-header/app-header.component.html
@@ -22,14 +22,6 @@
       </button>
     </ng-container>
 
-<!--    <ng-container *ngIf="config.logbookEnabled">
-      <button mat-menu-item routerLink="/logbooks/">
-        <mat-icon> book</mat-icon>
-        <span>Logbooks</span>
-      </button>
-    </ng-container>
-  -->
-  
     <ng-container *ngIf="config.policiesEnabled">
       <button mat-menu-item routerLink="/policies/">
         <mat-icon> cloud_download</mat-icon>

--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -119,7 +119,8 @@ const appConfig: AppConfig = {
   shoppingCartOnHeader: true,
   tableSciDataEnabled: true,
   fileserverBaseURL: "",
-  fileserverButtonLabel: ""
+  fileserverButtonLabel: "",
+  datasetDetailsShowMissingProposalId: true
 };
 
 describe("AppConfigService", () => {

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -57,6 +57,7 @@ export interface AppConfig {
   tableSciDataEnabled: boolean;
   fileserverBaseURL: string;
   fileserverButtonLabel: string | undefined;
+  datasetDetailsShowMissingProposalId: boolean;
 }
 
 @Injectable()

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -233,6 +233,10 @@
               <span *ngSwitchDefault>{{ proposal.title }}</span>
             </td>
           </tr>
+          <tr *ngIf="dataset['proposalId'] && !proposal && appConfig.datasetDetailsShowMissingProposalId">
+            <th>Proposal Id</th>
+            <td>{{ dataset['proposalId'] }}</td>
+          </tr>
           <tr *ngIf="dataset['sampleId'] && sample">
             <th>Sample</th>
             <td [ngSwitch]="editingAllowed">

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -27,7 +27,7 @@ import {
 } from "state-management/actions/datasets.actions";
 import {
   clearLogbookAction,
-  fetchLogbookAction,
+  //fetchLogbookAction,
   fetchDatasetLogbookAction,
 } from "state-management/actions/logbooks.actions";
 import {

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -27,7 +27,6 @@ import {
 } from "state-management/actions/datasets.actions";
 import {
   clearLogbookAction,
-  //fetchLogbookAction,
   fetchDatasetLogbookAction,
 } from "state-management/actions/logbooks.actions";
 import {
@@ -167,7 +166,6 @@ export class DatasetDetailsDashboardComponent
                     this.appConfig.logbookEnabled &&
                     isLoggedIn &&
                     hasAccessToLogbook,
-                    //isInOwnerGroup,
                 },
                 {
                   location: "./attachments",
@@ -215,17 +213,6 @@ export class DatasetDetailsDashboardComponent
   fetchDataForTab(tab: string) {
     if (tab in this.fetchDataActions) {
       let args: { [key: string]: any };
-      /*
-      if (tab === TAB.logbook) {
-        if (this.dataset && "proposalId" in this.dataset) {
-          args = { name: this.dataset["proposalId"] };
-        } else {
-          return;
-        }
-      } else {
-        args = { pid: this.dataset?.pid };
-      }
-      */
       args = { pid: this.dataset?.pid };
       // load related data for selected tab
       switch (tab) {

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.ts
@@ -28,6 +28,7 @@ import {
 import {
   clearLogbookAction,
   fetchLogbookAction,
+  fetchDatasetLogbookAction,
 } from "state-management/actions/logbooks.actions";
 import {
   clearCurrentProposalStateAction,
@@ -88,7 +89,7 @@ export class DatasetDetailsDashboardComponent
       loaded: false,
     },
     [TAB.datafiles]: { action: fetchOrigDatablocksAction, loaded: false },
-    [TAB.logbook]: { action: fetchLogbookAction, loaded: false },
+    [TAB.logbook]: { action: fetchDatasetLogbookAction, loaded: false },
     [TAB.attachments]: { action: fetchAttachmentsAction, loaded: false },
     [TAB.admin]: { action: fetchDatablocksAction, loaded: false },
   };
@@ -128,6 +129,8 @@ export class DatasetDetailsDashboardComponent
             .subscribe(([groups, isAdmin, isLoggedIn]) => {
               const isInOwnerGroup =
                 groups.indexOf(this.dataset.ownerGroup) !== -1 || isAdmin;
+              const hasAccessToLogbook = 
+                isInOwnerGroup || this.dataset.accessGroups.some(g => groups.includes(g));
               this.navLinks = [
                 {
                   location: "./",
@@ -163,7 +166,8 @@ export class DatasetDetailsDashboardComponent
                   enabled:
                     this.appConfig.logbookEnabled &&
                     isLoggedIn &&
-                    isInOwnerGroup,
+                    hasAccessToLogbook,
+                    //isInOwnerGroup,
                 },
                 {
                   location: "./attachments",
@@ -211,6 +215,7 @@ export class DatasetDetailsDashboardComponent
   fetchDataForTab(tab: string) {
     if (tab in this.fetchDataActions) {
       let args: { [key: string]: any };
+      /*
       if (tab === TAB.logbook) {
         if (this.dataset && "proposalId" in this.dataset) {
           args = { name: this.dataset["proposalId"] };
@@ -220,6 +225,8 @@ export class DatasetDetailsDashboardComponent
       } else {
         args = { pid: this.dataset?.pid };
       }
+      */
+      args = { pid: this.dataset?.pid };
       // load related data for selected tab
       switch (tab) {
         case TAB.details:

--- a/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.ts
+++ b/src/app/datasets/dataset-file-uploader/dataset-file-uploader.component.ts
@@ -40,7 +40,7 @@ export class DatasetFileUploaderComponent implements OnInit, OnDestroy {
       this.store.select(selectCurrentDataset).subscribe((dataset) => {
         if (dataset) {
           this.dataset = dataset;
-          this.ownershipService.checkPermission(dataset, this.store, this.router);
+          this.ownershipService.checkDatasetAccess(dataset, this.store, this.router);
         }
       })
     );

--- a/src/app/datasets/reduce/reduce.component.ts
+++ b/src/app/datasets/reduce/reduce.component.ts
@@ -108,7 +108,7 @@ export class ReduceComponent implements OnInit, OnChanges, OnDestroy {
       this.store.select(selectCurrentDataset).subscribe((dataset) => {
         this.dataset = dataset;
         if (dataset) {
-          this.ownershipService.checkPermission(dataset, this.store, this.router);
+          this.ownershipService.checkDatasetAccess(dataset, this.store, this.router);
         }
       })
     );

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.html
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.html
@@ -5,18 +5,18 @@
         <mat-card class="big-filter">
           <div class="title">Filter</div>
           <app-search-bar [prefilledValue]="vm.filters.textSearch"
-            (search)="onTextSearchChange(vm.logbook.name, $event)"
-            (searchBarFocus)="onTextSearchChange(vm.logbook.name, $event)">
+            (search)="onTextSearchChange(dataset.pid, $event)"
+            (searchBarFocus)="onTextSearchChange(dataset.pid, $event)">
           </app-search-bar>
           <logbook-filter [filters]="vm.filters"
-            (filterSelect)="onFilterSelect(vm.logbook.name, $event)">
+            (filterSelect)="onFilterSelect(dataset.pid, $event)">
           </logbook-filter>
         </mat-card>
 
         <div class="small-filter">
           <app-search-bar [prefilledValue]="vm.filters.textSearch"
-            (search)="onTextSearchChange(vm.logbook.name, $event)"
-            (searchBarFocus)="onTextSearchChange(vm.logbook.name, $event)">
+            (search)="onTextSearchChange(dataset.pid, $event)"
+            (searchBarFocus)="onTextSearchChange(dataset.pid, $event)">
           </app-search-bar>
 
           <mat-expansion-panel>
@@ -26,7 +26,7 @@
               </mat-panel-title>
             </mat-expansion-panel-header>
             <logbook-filter [filters]="vm.filters"
-              (filterSelect)="onFilterSelect(vm.logbook.name, $event)">
+              (filterSelect)="onFilterSelect(dataset.pid, $event)">
             </logbook-filter>
           </mat-expansion-panel>
         </div>
@@ -52,8 +52,8 @@
         <app-logbooks-detail [logbook]="vm.logbook"
           [entriesCount]="vm.entriesCount" [entriesPerPage]="vm.entriesPerPage"
           [currentPage]="vm.currentPage"
-          (pageChange)="onPageChange(vm.logbook.name, $event)"
-          (sortChange)="onSortChange(vm.logbook.name, $event)">
+          (pageChange)="onPageChange(dataset.pid, $event)"
+          (sortChange)="onSortChange(dataset.pid, $event)">
         </app-logbooks-detail>
       </div>
     </div>

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.spec.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.spec.ts
@@ -12,12 +12,12 @@ import { MockStore, MockActivatedRoute } from "shared/MockStubs";
 import { ActivatedRoute, Router } from "@angular/router";
 import {
   setTextFilterAction,
-  fetchLogbookAction,
+  fetchDatasetLogbookAction,
   setDisplayFiltersAction,
   changePageAction,
   sortByColumnAction,
 } from "state-management/actions/logbooks.actions";
-import { Logbook, LogbookInterface } from "shared/sdk";
+import { RawDataset, RawDatasetInterface, Logbook, LogbookInterface } from "shared/sdk";
 import { LogbookFilters } from "state-management/models";
 import { RouterTestingModule } from "@angular/router/testing";
 
@@ -44,11 +44,25 @@ describe("DashboardComponent", () => {
   let dispatchSpy;
 
   const logbookData: LogbookInterface = {
-    name: "tesName",
+    name: "testLogbook",
     roomId: "testId",
     messages: [{ message: "test1" }, { message: "test2" }],
   };
   const logbook = new Logbook(logbookData);
+
+  const rawDatasetData: RawDatasetInterface = {
+    pid: "67ac46e4-5e87-11ed-9634-fba3f42127ef",
+    ownerGroup: "testLogbook",
+    proposalId: "testLogbook",
+    principalInvestigator: "somebody",
+    creationLocation: "somewhere",
+    owner: "somebody else",
+    contactEmail: "somebody@somewhere.here",
+    sourceFolder: "some/folders/on/some/server",
+    creationTime: undefined,
+    type: "raw"
+  };
+  const dataset = new RawDataset(rawDatasetData);
 
   beforeEach(
     waitForAsync(() => {
@@ -108,10 +122,10 @@ describe("DashboardComponent", () => {
         skip: 0,
         limit: 25,
       };
-      component.applyRouterState(logbook.name, filters);
+      component.applyRouterState(dataset.pid, filters);
 
       expect(navigateSpy).toHaveBeenCalledTimes(1);
-      expect(navigateSpy).toHaveBeenCalledWith(["/logbooks", logbook.name], {
+      expect(navigateSpy).toHaveBeenCalledWith(["/datasets", dataset.pid, "logbook"], {
         queryParams: { args: JSON.stringify(filters) },
       });
     });
@@ -122,15 +136,15 @@ describe("DashboardComponent", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
       const textSearch = "test";
-      component.onTextSearchChange(logbook.name, textSearch);
+      component.onTextSearchChange(dataset.pid, textSearch);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2);
       expect(dispatchSpy).toHaveBeenCalledWith(
         setTextFilterAction({ textSearch })
       );
       expect(dispatchSpy).toHaveBeenCalledWith(
-        fetchLogbookAction({
-          name: logbook.name,
+        fetchDatasetLogbookAction({
+          pid: dataset.pid,
         })
       );
     });
@@ -152,7 +166,7 @@ describe("DashboardComponent", () => {
       };
       const { showBotMessages, showImages, showUserMessages } = filters;
 
-      component.onFilterSelect(logbook.name, filters);
+      component.onFilterSelect(dataset.pid, filters);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2);
       expect(dispatchSpy).toHaveBeenCalledWith(
@@ -163,8 +177,8 @@ describe("DashboardComponent", () => {
         })
       );
       expect(dispatchSpy).toHaveBeenCalledWith(
-        fetchLogbookAction({
-          name: logbook.name,
+        fetchDatasetLogbookAction({
+          pid: dataset.pid,
         })
       );
       expect(methodSpy).toHaveBeenCalled();
@@ -181,14 +195,14 @@ describe("DashboardComponent", () => {
         length: 100,
       };
 
-      component.onPageChange(logbook.name, event);
+      component.onPageChange(dataset.pid, event);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2);
       expect(dispatchSpy).toHaveBeenCalledWith(
         changePageAction({ page: event.pageIndex, limit: event.pageSize })
       );
       expect(dispatchSpy).toHaveBeenCalledWith(
-        fetchLogbookAction({ name: logbook.name })
+        fetchDatasetLogbookAction({ pid: dataset.pid })
       );
     });
   });
@@ -202,14 +216,14 @@ describe("DashboardComponent", () => {
         direction: "asc",
       };
 
-      component.onSortChange(logbook.name, event);
+      component.onSortChange(dataset.pid, event);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2);
       expect(dispatchSpy).toHaveBeenCalledWith(
         sortByColumnAction({ column: event.active, direction: event.direction })
       );
       expect(dispatchSpy).toHaveBeenCalledWith(
-        fetchLogbookAction({ name: logbook.name })
+        fetchDatasetLogbookAction({ pid: dataset.pid })
       );
     });
   });

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
@@ -53,13 +53,11 @@ export class LogbooksDashboardComponent
     private ownershipService: OwnershipService
   ) { }
 
-  applyRouterState(name: string, filters: LogbookFilters) {
-    if (this.route.snapshot.url[0].path === "logbooks") {
-      console.log("Rerouting to Logbooks")
-      this.router.navigate(["/logbooks", name], {
-        queryParams: { args: JSON.stringify(filters) },
-      });
-    }
+  applyRouterState(pid: string, filters: LogbookFilters) {
+    console.log("Rerouting to Dataset Logbook");
+    this.router.navigate(["/datasets", pid, "logbook"], {
+      queryParams: { args: JSON.stringify(filters) },
+    });
   }
 
   onTextSearchChange(pid: string, query: string) {

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
@@ -10,7 +10,7 @@ import { Dataset } from "shared/sdk";
 import { combineLatest, Subscription } from "rxjs";
 import { selectLogbooksDashboardPageViewModel } from "state-management/selectors/logbooks.selectors";
 import {
-  fetchLogbookAction,
+  fetchDatasetLogbookAction,
   prefillFiltersAction,
   setTextFilterAction,
   setDisplayFiltersAction,
@@ -55,50 +55,52 @@ export class LogbooksDashboardComponent
 
   applyRouterState(name: string, filters: LogbookFilters) {
     if (this.route.snapshot.url[0].path === "logbooks") {
+      console.log("Rerouting to Logbooks")
       this.router.navigate(["/logbooks", name], {
         queryParams: { args: JSON.stringify(filters) },
       });
     }
   }
 
-  onTextSearchChange(name: string, query: string) {
+  onTextSearchChange(pid: string, query: string) {
     this.store.dispatch(setTextFilterAction({ textSearch: query }));
-    this.store.dispatch(fetchLogbookAction({ name }));
+    this.store.dispatch(fetchDatasetLogbookAction({ pid }));
   }
 
-  onFilterSelect(name: string, filters: LogbookFilters) {
+  onFilterSelect(pid: string, filters: LogbookFilters) {
     const { showBotMessages, showImages, showUserMessages } = filters;
     this.store.dispatch(
       setDisplayFiltersAction({ showBotMessages, showImages, showUserMessages })
     );
-    this.store.dispatch(fetchLogbookAction({ name }));
-    this.applyRouterState(name, filters);
+    this.store.dispatch(fetchDatasetLogbookAction({ pid }));
+    this.applyRouterState(pid, filters);
   }
 
-  onPageChange(name: string, event: PageChangeEvent) {
+  onPageChange(pid: string, event: PageChangeEvent) {
     this.store.dispatch(
       changePageAction({ page: event.pageIndex, limit: event.pageSize })
     );
-    this.store.dispatch(fetchLogbookAction({ name }));
+    this.store.dispatch(fetchDatasetLogbookAction({ pid }));
   }
 
-  onSortChange(name: string, event: SortChangeEvent) {
+  onSortChange(pid: string, event: SortChangeEvent) {
     const { active: column, direction } = event;
     this.store.dispatch(sortByColumnAction({ column, direction }));
-    this.store.dispatch(fetchLogbookAction({ name }));
+    this.store.dispatch(fetchDatasetLogbookAction({ pid }));
   }
 
   ngOnInit() {
+  
     this.subscriptions.push(
       combineLatest([this.route.params, this.vm$])
         .pipe(
           map(([params, vm]) => [params, vm.filters]),
           distinctUntilChanged(deepEqual)
         )
-        .subscribe(([{ name }, filters]) => {
-          if (name) {
-            this.store.dispatch(fetchLogbookAction({ name }));
-            this.applyRouterState(name, filters as LogbookFilters);
+        .subscribe(([{ pid }, filters]) => {
+          if (pid) {
+            this.store.dispatch(fetchDatasetLogbookAction({ pid }));
+            this.applyRouterState(pid, filters as LogbookFilters);
           }
         })
     );
@@ -106,7 +108,7 @@ export class LogbooksDashboardComponent
       this.store.select(selectCurrentDataset).subscribe((dataset) => {
         if (dataset) {
           this.dataset = dataset;
-          this.ownershipService.checkPermission(dataset, this.store, this.router);
+          this.ownershipService.checkDatasetAccess(dataset, this.store, this.router);
         }
       })
     );

--- a/src/app/shared/sdk/services/custom/Logbook.ts
+++ b/src/app/shared/sdk/services/custom/Logbook.ts
@@ -56,6 +56,33 @@ export class LogbookApi extends BaseLoopBackApi {
     return result.pipe(map((instance: Logbook) => new Logbook(instance)));
   }
 
+    /**
+   * Find Logbook model instance associated to the dataset passed
+   *
+   * @param {string} pid Dataset pid
+   *
+   * @param {string} filters Filter json object, keys: textSearch, showBotMessages, showUserMessages, showImages, skip, limit, sortField
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * Logbook model instance
+   */
+  public findDatasetLogbook(pid: any, filters: any = {}, customHeaders?: Function): Observable<Logbook> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/Datasets/:pid/Logbook";
+    let _routeParams: any = {
+      pid: pid
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof filters !== 'undefined' && filters !== null) _urlParams.filters = filters;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result.pipe(map((instance: Logbook) => new Logbook(instance)));
+  }
+
   /**
    * Send message to a Logbook
    *

--- a/src/app/shared/services/ownership.service.ts
+++ b/src/app/shared/services/ownership.service.ts
@@ -10,27 +10,6 @@ import { selectIsAdmin, selectProfile } from "state-management/selectors/user.se
   providedIn: "root"
 })
 export class OwnershipService {
-  TO_BE_DELETED_checkPermission(dataset: Dataset | undefined, store: Store, router: Router) {
-    if (dataset) {
-      const userProfile$: Observable<any> = store.select(selectProfile);
-      const isAdmin$ = store.select(selectIsAdmin);
-      const accessGroups$: Observable<string[]> = userProfile$.pipe(
-        map((profile) => (profile ? profile.accessGroups : []))
-      );
-      combineLatest([accessGroups$, isAdmin$]).subscribe(([groups, isAdmin]) => {
-        const isInOwnerGroup =
-          groups.indexOf(dataset.ownerGroup) !== -1 || isAdmin;
-        if (!isInOwnerGroup) {
-          router.navigate(["/401"], {
-            skipLocationChange: true,
-            queryParams: {
-              url: router.routerState.snapshot.url,
-            },
-          });
-        }
-      }).unsubscribe();
-    }
-  }
 
   checkDatasetAccess(dataset: Dataset | undefined, store: Store, router: Router) {
     if (dataset) {

--- a/src/app/state-management/actions/logbooks.actions.ts
+++ b/src/app/state-management/actions/logbooks.actions.ts
@@ -23,6 +23,18 @@ export const fetchLogbookFailedAction = createAction(
   "[Logbook] Fetch Logbook Failed"
 );
 
+export const fetchDatasetLogbookAction = createAction(
+  "[Logbook] Fetch Dataset Logbook",
+  props<{ pid: string }>()
+);
+export const fetchDatasetLogbookCompleteAction = createAction(
+  "[Logbook] Fetch Dataset Logbook Complete",
+  props<{ logbook: Logbook }>()
+);
+export const fetchDatasetLogbookFailedAction = createAction(
+  "[Logbook] Fetch Dataset Logbook Failed"
+);
+
 export const clearLogbookAction = createAction("[Logbook] Clear Logbook");
 
 export const fetchCountAction = createAction(

--- a/src/app/state-management/effects/logbooks.effects.ts
+++ b/src/app/state-management/effects/logbooks.effects.ts
@@ -49,6 +49,24 @@ export class LogbookEffects {
     );
   });
 
+  fetchDatasetLogbook$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(fromActions.fetchDatasetLogbookAction),
+      concatLatestFrom(() => this.filters$),
+      mergeMap(([{ pid }, filters]) =>
+        this.logbookApi
+          .findDatasetLogbook(encodeURIComponent(pid), JSON.stringify(filters))
+          .pipe(
+            timeout(3000),
+            mergeMap((logbook) => [
+              fromActions.fetchLogbookCompleteAction({ logbook })
+            ]),
+            catchError(() => of(fromActions.fetchDatasetLogbookFailedAction()))
+          )
+      )
+    );
+  });
+
   fetchCount$ = createEffect(() => {
     return this.actions$.pipe(
       ofType(fromActions.fetchCountAction),

--- a/src/app/state-management/reducers/logbooks.reducer.ts
+++ b/src/app/state-management/reducers/logbooks.reducer.ts
@@ -103,7 +103,7 @@ export const logbooksReducer = (
   action: Action
 ) => {
   if (action.type.indexOf("[Logbook]") !== -1) {
-    console.log("Action came in! " + action.type);
+    console.log("Logbook reducer Action came in! " + action.type);
   }
   return reducer(state, action);
 };

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -111,5 +111,6 @@
   "shareEnabled": true,
   "shoppingCartEnabled": true,
   "shoppingCartOnHeader": true,
-  "tableSciDataEnabled": true
+  "tableSciDataEnabled": true,
+  "datasetDetailsShowMissingProposalId": false
 }


### PR DESCRIPTION
## Description

This PR add the following new features:
- show the proposal name even if it is not present. This feature is controlled by option datasetDetailsShowMissingProposalId in config file
- provide logbook access to users that part of dataset access group.
 
## Motivation
When data is ingest automatically, we do not know if the proposal associated has already been created. The system allows to create a dataset with a proposal id that does not exists in scicat. If that happens we need to be able to display it and follow up with the proper actions.
Logbooks where not accessible to users belonging to access groups. We are going to use the access groups for beam lines scientists and other facility experts and we would like to grant access to every details of the dataset using access groups.

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [x] Docs updated?
- [ ] New packages used/requires npm install? 
- [x] Toggle added for new features?
- [x] Requires update of SciCat backend API?

