### PR TITLE
feat: Allow for owner groups and admins to edit dataset name and description

### DIFF
--- a/cypress/integration/datasets-keyword.spec.js
+++ b/cypress/integration/datasets-keyword.spec.js
@@ -2,8 +2,6 @@
 
 describe("Datasets", () => {
   beforeEach(() => {
-    cy.wait(5000);
-
     cy.login(Cypress.config("username"), Cypress.config("password"));
 
     cy.intercept("PUT", "/api/v3/Datasets/**/*").as("keyword");
@@ -18,63 +16,79 @@ describe("Datasets", () => {
     cy.removeDatasets();
   });
 
-  describe("Add keyword", () => {
+  describe("Edit datasets", () => {
+    it("should be able to edit dataset details", () => {
+      const newName = "Test changing dataset name";
+      const newDescription = "Test changing dataset description";
+      cy.createDataset("raw");
+
+      cy.visit("/datasets");
+
+      cy.get(".mat-row").contains("Cypress Dataset").click();
+
+      cy.wait("@fetch");
+
+      cy.get('[data-cy="edit-general-information"]').click();
+
+      cy.get("input[formcontrolname='datasetName']").clear().type(newName);
+      cy.get("textarea[formcontrolname='description']")
+        .clear()
+        .type(newDescription);
+
+      cy.get('[data-cy="save-general-information"]').click();
+
+      cy.wait("@keyword").then(({ request, response }) => {
+        expect(request.method).to.eq("PUT");
+        expect(response.statusCode).to.eq(200);
+      });
+
+      cy.get("[data-cy='general-info']")
+        .children()
+        .should("contain.text", newName);
+      cy.get("[data-cy='general-info']")
+        .children()
+        .should("contain.text", newDescription);
+    });
     it("should go to dataset details and add a keyword", () => {
       cy.createDataset("raw");
 
       cy.visit("/datasets");
 
-      cy.wait(5000);
-
-      cy.get(".mat-row")
-        .contains("Cypress Dataset")
-        .click();
+      cy.get(".mat-row").contains("Cypress Dataset").click();
 
       cy.wait("@fetch");
 
-      cy.get(".add-keyword-chip").click();
+      cy.get('[data-cy="edit-general-information"]').click();
 
-      cy.get("#keywordInput").type("cypresskey{enter}");
+      cy.get("input.mat-chip-input").type("cypresskey{enter}");
+
+      cy.get('[data-cy="save-general-information"]').click();
 
       cy.wait("@keyword").then(({ request, response }) => {
         expect(request.method).to.eq("PUT");
         expect(response.statusCode).to.eq(200);
       });
 
-      cy.wait(5000);
-
-      cy.get(".done-edit-button").click({ force: true });
-
-      cy.get(".mat-chip-list")
-        .children()
-        .should("contain.text", "cypresskey");
+      cy.get(".mat-chip-list").children().should("contain.text", "cypresskey");
     });
-  });
 
-  describe("Remove keyword", () => {
     it("should go to dataset details and remove the added keyword", () => {
       cy.visit("/datasets");
 
-      cy.wait(5000);
+      cy.get(".mat-row").contains("Cypress Dataset").click();
 
-      cy.get(".mat-row")
-        .contains("Cypress Dataset")
-        .click();
+      cy.get('[data-cy="edit-general-information"]').click();
 
-      cy.wait(5000);
+      cy.contains("cypresskey").children(".mat-chip-remove").click();
 
-      cy.contains("cypresskey")
-        .children(".mat-chip-remove")
-        .click();
+      cy.get('[data-cy="save-general-information"]').click();
 
       cy.wait("@keyword").then(({ request, response }) => {
         expect(request.method).to.eq("PUT");
         expect(response.statusCode).to.eq(200);
       });
 
-      cy.get(".mat-chip-list")
-        .children()
-        .should("not.contain", "cypresskey");
+      cy.get(".mat-chip-list").children().should("not.contain", "cypresskey");
     });
   });
 });

--- a/cypress/integration/datasets-metadata.spec.js
+++ b/cypress/integration/datasets-metadata.spec.js
@@ -37,7 +37,7 @@ describe("Datasets", () => {
 
       cy.scrollTo("bottom");
 
-      cy.contains("Edit").click();
+      cy.get('[role="tab"]').contains("Edit").click();
 
       cy.get('[data-cy="add-new-row"]').click();
 
@@ -84,7 +84,7 @@ describe("Datasets", () => {
       cy.get(".mat-row").contains("Cypress Dataset").click();
 
       cy.finishedLoading();
-      cy.contains("Edit").click();
+      cy.get('[role="tab"]').contains("Edit").click();
 
       cy.get("button.deleteButton").first().click();
 

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -131,7 +131,6 @@
         <mat-card-actions align="end" *ngIf="editingAllowed">
           <button
             mat-raised-button
-            class="done-edit-button"
             color="primary"
             (click)="onEditModeEnable()"
             *ngIf="!editEnabled"
@@ -142,7 +141,6 @@
             *ngIf="editEnabled"
             mat-raised-button
             color="warn"
-            class="done-edit-button"
             (click)="editEnabled = false"
           >
             Close
@@ -150,7 +148,6 @@
           <button
             *ngIf="editEnabled"
             mat-raised-button
-            class="done-edit-button"
             color="primary"
             (click)="onSaveGeneralInformationChanges()"
           >

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -25,7 +25,7 @@
   <div style="clear: both"></div>
   <div fxLayout="row" fxLayout.xs="column" *ngIf="dataset">
     <div fxFlex="80%">
-      <mat-card [formGroup]="form">
+      <mat-card [formGroup]="form" data-cy="general-info">
         <mat-card-header class="general-header">
           <div mat-card-avatar class="section-icon">
             <mat-icon> description </mat-icon>
@@ -134,6 +134,7 @@
             color="primary"
             (click)="onEditModeEnable()"
             *ngIf="!editEnabled"
+            data-cy="edit-general-information"
           >
             <mat-icon> edit </mat-icon> Edit
           </button>
@@ -150,6 +151,7 @@
             mat-raised-button
             color="primary"
             (click)="onSaveGeneralInformationChanges()"
+            data-cy="save-general-information"
           >
             <mat-icon> save </mat-icon> Save changes
           </button>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -34,9 +34,9 @@
         </mat-card-header>
         <mat-card-content>
           <table>
-            <tr *ngIf="dataset.datasetName as value">
+            <tr>
               <th>Name</th>
-              <td *ngIf="!editEnabled">{{ value }}</td>
+              <td *ngIf="!editEnabled">{{ dataset.datasetName || "-" }}</td>
               <td *ngIf="editEnabled && editingAllowed">
                 <mat-form-field class="full-width">
                   <input
@@ -48,10 +48,10 @@
                 </mat-form-field>
               </td>
             </tr>
-            <tr *ngIf="dataset.description as value">
+            <tr>
               <th>Description</th>
               <td *ngIf="!editEnabled">
-                <span [innerHTML]="value | linky"></span>
+                <span [innerHTML]="(dataset.description || '-') | linky"></span>
               </td>
               <td *ngIf="editEnabled && editingAllowed">
                 <mat-form-field class="full-width">

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -12,10 +12,7 @@
         Jupyter Hub
       </a>
     </div>
-    <div
-      fxFlex="auto"
-      *ngIf="isPI()"
-    >
+    <div fxFlex="auto" *ngIf="isPI()">
       <mat-slide-toggle
         class="public-toggle"
         [checked]="dataset.isPublished"
@@ -25,126 +22,146 @@
       </mat-slide-toggle>
     </div>
   </div>
-  <div style="clear: both;"></div>
-  <div
-    fxLayout="row"
-    fxLayout.xs="column"
-    *ngIf="dataset"
-  >
+  <div style="clear: both"></div>
+  <div fxLayout="row" fxLayout.xs="column" *ngIf="dataset">
     <div fxFlex="80%">
-      <mat-card>
+      <mat-card [formGroup]="form">
         <mat-card-header class="general-header">
-          <div
-            mat-card-avatar
-            class="section-icon"
-          >
+          <div mat-card-avatar class="section-icon">
             <mat-icon> description </mat-icon>
           </div>
           General Information
         </mat-card-header>
-
-        <table>
-          <tr *ngIf="dataset.datasetName as value">
-            <th>Name</th>
-            <td>{{ value }}</td>
-          </tr>
-          <tr *ngIf="dataset.description as value">
-            <th>Description</th>
-            <td><span [innerHTML]="value | linky"></span></td>
-          </tr>
-          <tr>
-            <th>PID</th>
-            <td>{{ dataset.pid }}</td>
-          </tr>
-          <tr *ngIf="dataset.type as value">
-            <th>Type</th>
-            <td>{{ value }}</td>
-          </tr>
-          <tr *ngIf="dataset.creationTime as value">
-            <th>Creation Time</th>
-            <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
-          </tr>
-          <tr class="keywords-row">
-            <th>Keywords</th>
-            <td *ngIf="!editEnabled">
-              <mat-chip-list #keywordChips>
-                <mat-chip
-                  *ngFor="let keyword of dataset.keywords"
-                  [removable]="editingAllowed"
-                  (removed)="onRemoveKeyword(keyword)"
-                  (click)="onClickKeyword(keyword)"
-                >
-                  {{ keyword }}
-                  <mat-icon
-                    *ngIf="editingAllowed"
-                    matChipRemove
-                  >cancel
-                  </mat-icon>
-                </mat-chip>
-                <mat-chip
-                  *ngIf="editingAllowed"
-                  class="add-keyword-chip"
-                  (click)="editEnabled = true"
-                >
-                  Add Keyword <mat-icon>add</mat-icon>
-                </mat-chip>
-              </mat-chip-list>
-            </td>
-            <td *ngIf="editEnabled">
-              <mat-form-field>
+        <mat-card-content>
+          <table>
+            <tr *ngIf="dataset.datasetName as value">
+              <th>Name</th>
+              <td *ngIf="!editEnabled">{{ value }}</td>
+              <td *ngIf="editEnabled && editingAllowed">
+                <mat-form-field class="full-width">
+                  <input
+                    matInput
+                    type="text"
+                    placeholder="Name"
+                    formControlName="datasetName"
+                  />
+                </mat-form-field>
+              </td>
+            </tr>
+            <tr *ngIf="dataset.description as value">
+              <th>Description</th>
+              <td *ngIf="!editEnabled">
+                <span [innerHTML]="value | linky"></span>
+              </td>
+              <td *ngIf="editEnabled && editingAllowed">
+                <mat-form-field class="full-width">
+                  <textarea
+                    matInput
+                    placeholder="Description"
+                    rows="5"
+                    formControlName="description"
+                  ></textarea>
+                </mat-form-field>
+              </td>
+            </tr>
+            <tr>
+              <th>PID</th>
+              <td>{{ dataset.pid }}</td>
+            </tr>
+            <tr *ngIf="dataset.type as value">
+              <th>Type</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="dataset.creationTime as value">
+              <th>Creation Time</th>
+              <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+            </tr>
+            <tr class="keywords-row">
+              <th>Keywords</th>
+              <td *ngIf="!editEnabled">
                 <mat-chip-list #keywordChips>
                   <mat-chip
                     *ngFor="let keyword of dataset.keywords"
-                    [removable]="true"
                     (removed)="onRemoveKeyword(keyword)"
                     (click)="onClickKeyword(keyword)"
                   >
                     {{ keyword }}
+                  </mat-chip>
+                </mat-chip-list>
+              </td>
+              <td *ngIf="editEnabled && editingAllowed">
+                <mat-form-field class="full-width">
+                  <mat-chip-list #keywordChips formArrayName="keywords">
+                    <mat-chip
+                      *ngFor="let keyword of keywords.value"
+                      [removable]="true"
+                      (removed)="onRemoveKeyword(keyword)"
+                      (click)="onClickKeyword(keyword)"
+                    >
+                      {{ keyword }}
+                      <mat-icon matChipRemove>cancel</mat-icon>
+                    </mat-chip>
+                    <input
+                      [matChipInputFor]="keywordChips"
+                      [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+                      [matChipInputAddOnBlur]="true"
+                      (matChipInputTokenEnd)="onAddKeyword($event)"
+                    />
+                  </mat-chip-list>
+                </mat-form-field>
+              </td>
+            </tr>
+            <tr *ngIf="dataset.sharedWith && dataset.sharedWith.length > 0">
+              <th>Shared With</th>
+              <td>
+                <mat-chip-list>
+                  <mat-chip
+                    *ngFor="let share of dataset.sharedWith"
+                    [removable]="true"
+                    (removed)="onRemoveShare(share)"
+                  >
+                    {{ share }}
                     <mat-icon matChipRemove>cancel</mat-icon>
                   </mat-chip>
-                  <input
-                    id="keywordInput"
-                    [matChipInputFor]="keywordChips"
-                    [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
-                    [matChipInputAddOnBlur]="true"
-                    (matChipInputTokenEnd)="onAddKeyword($event)"
-                  />
                 </mat-chip-list>
-              </mat-form-field>
-              <button
-                mat-raised-button
-                class="done-edit-button"
-                color="accent"
-                (click)="editEnabled = false"
-              >
-                Done
-              </button>
-            </td>
-          </tr>
-          <tr *ngIf="dataset.sharedWith && dataset.sharedWith.length > 0">
-            <th>Shared With</th>
-            <td>
-              <mat-chip-list>
-                <mat-chip
-                  *ngFor="let share of dataset.sharedWith"
-                  [removable]="true"
-                  (removed)="onRemoveShare(share)"
-                >
-                  {{ share }}
-                  <mat-icon matChipRemove>cancel</mat-icon>
-                </mat-chip>
-              </mat-chip-list>
-            </td>
-          </tr>
-        </table>
+              </td>
+            </tr>
+          </table>
+        </mat-card-content>
+        <mat-card-actions align="end" *ngIf="editingAllowed">
+          <button
+            mat-raised-button
+            class="done-edit-button"
+            color="primary"
+            (click)="onEditModeEnable()"
+            *ngIf="!editEnabled"
+          >
+            <mat-icon> edit </mat-icon> Edit
+          </button>
+          <button
+            *ngIf="editEnabled"
+            mat-raised-button
+            color="warn"
+            class="done-edit-button"
+            (click)="editEnabled = false"
+          >
+            Close
+          </button>
+          <button
+            *ngIf="editEnabled"
+            mat-raised-button
+            class="done-edit-button"
+            color="primary"
+            (click)="onSaveGeneralInformationChanges()"
+          >
+            <mat-icon> save </mat-icon> Save changes
+          </button>
+        </mat-card-actions>
       </mat-card>
 
       <mat-card>
         <mat-card-header class="creator-header">
-          <div
-            mat-card-avatar
-            class="section-icon"
-          >
+          <div mat-card-avatar class="section-icon">
             <mat-icon> person </mat-icon>
           </div>
           Creator Information
@@ -184,10 +201,7 @@
 
       <mat-card>
         <mat-card-header class="file-header">
-          <div
-            mat-card-avatar
-            class="section-icon"
-          >
+          <div mat-card-avatar class="section-icon">
             <mat-icon> folder </mat-icon>
           </div>
           File Information
@@ -211,10 +225,7 @@
 
       <mat-card>
         <mat-card-header class="related-header">
-          <div
-            mat-card-avatar
-            class="section-icon"
-          >
+          <div mat-card-avatar class="section-icon">
             <mat-icon> library_books </mat-icon>
           </div>
           Related Documents
@@ -227,9 +238,10 @@
               <a
                 *ngSwitchCase="true"
                 (click)="
-                editingAllowed ? onClickProposal(proposal.proposalId) : ''
-              "
-              >{{ proposal.title }}</a>
+                  editingAllowed ? onClickProposal(proposal.proposalId) : ''
+                "
+                >{{ proposal.title }}</a
+              >
               <span *ngSwitchDefault>{{ proposal.title }}</span>
             </td>
           </tr>
@@ -247,8 +259,8 @@
                 class="sample-edit"
                 (click)="openSampleEditDialog()"
                 *ngIf="
-                appConfig.editDatasetSampleEnabled && editingAllowed && isPI
-              "
+                  appConfig.editDatasetSampleEnabled && editingAllowed && isPI
+                "
               >
                 <mat-icon>edit</mat-icon>
               </span>
@@ -277,10 +289,12 @@
                 <span>
                   {{ technique.name }}
                 </span>
-                <span *ngIf="
-                  dataset.techniques.indexOf(technique) <
-                  dataset.techniques.length - 1
-                ">,
+                <span
+                  *ngIf="
+                    dataset.techniques.indexOf(technique) <
+                    dataset.techniques.length - 1
+                  "
+                  >,
                 </span>
               </div>
             </td>
@@ -294,7 +308,8 @@
                     {{ datasetPid }}
                   </a>
                 </span>
-                <span *ngIf="value.indexOf(datasetPid) < value.length - 1">,
+                <span *ngIf="value.indexOf(datasetPid) < value.length - 1"
+                  >,
                 </span>
               </div>
             </td>
@@ -304,10 +319,7 @@
 
       <mat-card *ngIf="dataset.type === 'derived'">
         <mat-card-header class="derived-header">
-          <div
-            mat-card-avatar
-            class="section-icon"
-          >
+          <div mat-card-avatar class="section-icon">
             <mat-icon> analytics </mat-icon>
           </div>
           Derived Data
@@ -331,10 +343,7 @@
 
       <mat-card>
         <mat-card-header class="scientific-header">
-          <div
-            mat-card-avatar
-            class="section-icon"
-          >
+          <div mat-card-avatar class="section-icon">
             <mat-icon> science </mat-icon>
           </div>
           Scientific Metadata
@@ -401,35 +410,23 @@
         </ng-template>
       </mat-card>
       <mat-card *ngIf="editingAllowed && appConfig.jsonMetadataEnabled">
-        <button
-          mat-stroked-button
-          (click)="show = !show"
-        >
+        <button mat-stroked-button (click)="show = !show">
           {{ show ? "Hide MetaData" : "Show Metadata" }}
         </button>
 
         <br />
 
         <div *ngIf="show">
-          <ngx-json-viewer
-            [json]="datasetWithout$ | async"
-            [expanded]="false"
-          >
+          <ngx-json-viewer [json]="datasetWithout$ | async" [expanded]="false">
           </ngx-json-viewer>
         </div>
       </mat-card>
     </div>
 
-    <div
-      fxFlex="30%"
-      *ngIf="attachments$ | async as attachments"
-    >
+    <div fxFlex="30%" *ngIf="attachments$ | async as attachments">
       <ng-container *ngFor="let da of attachments">
         <mat-card>
-          <img
-            mat-card-image
-            src="{{ da.thumbnail }}"
-          />
+          <img mat-card-image src="{{ da.thumbnail }}" />
           <p>{{ da.caption }}</p>
         </mat-card>
       </ng-container>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -47,10 +47,6 @@ mat-card {
       .add-keyword-chip:hover {
         cursor: pointer;
       }
-
-      .done-edit-button {
-        margin-left: 1rem;
-      }
     }
   }
 }

--- a/src/app/datasets/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.scss
@@ -24,7 +24,7 @@ mat-card {
 
     td {
       width: 100%;
-      padding: 0.5rem;
+      padding: 0.5rem 0;
 
       .sample-edit {
         padding-left: 0.5rem;
@@ -39,13 +39,13 @@ mat-card {
       }
     }
 
+    .full-width {
+      width: 100%;
+    }
+
     .keywords-row {
       .add-keyword-chip:hover {
         cursor: pointer;
-      }
-
-      mat-form-field {
-        width: 92%;
       }
 
       .done-edit-button {

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -38,7 +38,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { MockActivatedRoute } from "shared/MockStubs";
 import { DialogComponent } from "shared/modules/dialog/dialog.component";
 import { AppConfigService } from "app-config.service";
-import { FormBuilder } from "@angular/forms";
 
 describe("DatasetDetailComponent", () => {
   let component: DatasetDetailComponent;

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -2,7 +2,12 @@ import { DatafilesComponent } from "../../datasets/datafiles/datafiles.component
 import { DatasetDetailComponent } from "./dataset-detail.component";
 import { LinkyPipe } from "ngx-linky";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
-import { ComponentFixture, inject, TestBed, waitForAsync } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  inject,
+  TestBed,
+  waitForAsync,
+} from "@angular/core/testing";
 import { SharedScicatFrontendModule } from "shared/shared.module";
 import { MatTableModule } from "@angular/material/table";
 import { MatChipInputEvent, MatChipsModule } from "@angular/material/chips";
@@ -33,6 +38,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { MockActivatedRoute } from "shared/MockStubs";
 import { DialogComponent } from "shared/modules/dialog/dialog.component";
 import { AppConfigService } from "app-config.service";
+import { FormBuilder } from "@angular/forms";
 
 describe("DatasetDetailComponent", () => {
   let component: DatasetDetailComponent;
@@ -48,43 +54,41 @@ describe("DatasetDetailComponent", () => {
 
   let store: MockStore;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        schemas: [NO_ERRORS_SCHEMA],
-        imports: [
-          BrowserAnimationsModule,
-          MatButtonModule,
-          MatCardModule,
-          MatChipsModule,
-          MatFormFieldModule,
-          MatIconModule,
-          MatInputModule,
-          MatTableModule,
-          MatTabsModule,
-          NgxJsonViewerModule,
-          SharedScicatFrontendModule,
-          StoreModule.forRoot({}),
-        ],
-        declarations: [DatasetDetailComponent, DatafilesComponent, LinkyPipe],
-      });
-      TestBed.overrideComponent(DatasetDetailComponent, {
-        set: {
-          providers: [
-            { provide: Router, useValue: router },
-            {
-              provide: AppConfigService,
-              useValue: {
-                getConfig,
-              },
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [
+        BrowserAnimationsModule,
+        MatButtonModule,
+        MatCardModule,
+        MatChipsModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatTableModule,
+        MatTabsModule,
+        NgxJsonViewerModule,
+        SharedScicatFrontendModule,
+        StoreModule.forRoot({}),
+      ],
+      declarations: [DatasetDetailComponent, DatafilesComponent, LinkyPipe],
+    });
+    TestBed.overrideComponent(DatasetDetailComponent, {
+      set: {
+        providers: [
+          { provide: Router, useValue: router },
+          {
+            provide: AppConfigService,
+            useValue: {
+              getConfig,
             },
-            { provide: ActivatedRoute, useClass: MockActivatedRoute },
-          ],
-        },
-      });
-      TestBed.compileComponents();
-    })
-  );
+          },
+          { provide: ActivatedRoute, useClass: MockActivatedRoute },
+        ],
+      },
+    });
+    TestBed.compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DatasetDetailComponent);
@@ -124,46 +128,65 @@ describe("DatasetDetailComponent", () => {
 
   describe("#onAddKeyword()", () => {
     it("should add property keywords if it does not exist already", () => {
-      const dispatchSpy = spyOn(store, "dispatch");
       const event = {
+        chipInput: {
+          inputElement: {
+            value: "test",
+          },
+        },
         value: "test",
       };
       const pid = "testPid";
       component.dataset = new Dataset();
       component.dataset.pid = pid;
+      component.onEditModeEnable();
       component.onAddKeyword(event as MatChipInputEvent);
 
-      expect(component.dataset.keywords).toBeTruthy();
+      expect(component.keywords).toBeTruthy();
+      expect(component.keywords.length).toBe(1);
+      expect(component.form.value.keywords.length).toBe(1);
     });
 
     it("should do nothing if keyword already exists", () => {
-      const dispatchSpy = spyOn(store, "dispatch");
       const event = {
+        chipInput: {
+          inputElement: {
+            value: "test",
+          },
+        },
         value: "test",
       };
       component.dataset = new Dataset();
       component.dataset.keywords = ["test"];
+      component.onEditModeEnable();
+      expect(component.keywords.value.length).toBe(1);
+      expect(component.form.value.keywords.length).toBe(1);
       component.onAddKeyword(event as MatChipInputEvent);
 
-      expect(dispatchSpy).toHaveBeenCalledTimes(0);
+      expect(component.keywords.value.length).toBe(1);
+      expect(component.form.value.keywords.length).toBe(1);
     });
 
-    it("should dispatch an updatePropertyAction if the keyword does not exist", () => {
-      const dispatchSpy = spyOn(store, "dispatch");
+    it("should add a keyword if the keyword does not exist", () => {
       const event = {
+        chipInput: {
+          inputElement: {
+            value: "test",
+          },
+        },
         value: "test",
       };
       const pid = "testPid";
       component.dataset = new Dataset();
       component.dataset.pid = pid;
       component.dataset.keywords = [];
-      const property = { keywords: ["test"] };
+      component.onEditModeEnable();
+      expect(component.keywords.value.length).toBe(0);
+      expect(component.form.value.keywords.length).toBe(0);
       component.onAddKeyword(event as MatChipInputEvent);
 
-      expect(dispatchSpy).toHaveBeenCalledTimes(1);
-      expect(dispatchSpy).toHaveBeenCalledWith(
-        updatePropertyAction({ pid, property })
-      );
+      expect(component.keywords.value.length).toBe(1);
+      expect(component.form.value.keywords.length).toBe(1);
     });
   });
 
@@ -180,6 +203,23 @@ describe("DatasetDetailComponent", () => {
     });
 
     it("should dispatch an updatePropertyAction if the keyword does exist", () => {
+      const keyword = "test";
+      const pid = "testPid";
+      component.dataset = new Dataset();
+      component.dataset.pid = pid;
+      component.dataset.keywords = [keyword];
+      component.onEditModeEnable();
+      expect(component.keywords.value.length).toBe(1);
+      expect(component.form.value.keywords.length).toBe(1);
+      component.onRemoveKeyword(keyword);
+
+      expect(component.keywords.value.length).toBe(0);
+      expect(component.form.value.keywords.length).toBe(0);
+    });
+  });
+
+  describe("#onSaveGeneralInformationChanges()", () => {
+    it("should dispatch an updatePropertyAction", () => {
       const dispatchSpy = spyOn(store, "dispatch");
 
       const keyword = "test";
@@ -187,8 +227,18 @@ describe("DatasetDetailComponent", () => {
       component.dataset = new Dataset();
       component.dataset.pid = pid;
       component.dataset.keywords = [keyword];
-      const property = { keywords: [] };
-      component.onRemoveKeyword(keyword);
+      component.dataset.datasetName = "Test dataset name";
+      component.dataset.description = "Test dataset description";
+      component.onEditModeEnable();
+      expect(component.keywords.value.length).toBe(1);
+      expect(component.form.value.keywords.length).toBe(1);
+      component.onSaveGeneralInformationChanges();
+
+      const property = {
+        keywords: component.dataset.keywords,
+        datasetName: component.dataset.datasetName,
+        description: component.dataset.description,
+      };
 
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledWith(

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -144,9 +144,9 @@ export class DatasetDetailComponent
 
   onEditModeEnable() {
     this.form = this.fb.group({
-      datasetName: this.dataset.datasetName,
-      description: this.dataset.description,
-      keywords: this.fb.array(this.dataset.keywords),
+      datasetName: this.dataset.datasetName || "",
+      description: this.dataset.description || "",
+      keywords: this.fb.array(this.dataset.keywords || []),
     });
     this.editEnabled = true;
   }
@@ -217,13 +217,15 @@ export class DatasetDetailComponent
   onSaveGeneralInformationChanges() {
     const pid = this.dataset.pid;
 
-    const property = {
-      datasetName: this.form.value.datasetName,
-      description: this.form.value.description,
-      keywords: this.keywords.value,
-    };
+    if (pid) {
+      const property = {
+        datasetName: this.form.value.datasetName,
+        description: this.form.value.description,
+        keywords: this.keywords.value,
+      };
 
-    this.store.dispatch(updatePropertyAction({ pid, property }));
+      this.store.dispatch(updatePropertyAction({ pid, property }));
+    }
 
     this.editEnabled = false;
   }

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -51,8 +51,7 @@ import {
   styleUrls: ["./dataset-detail.component.scss"],
 })
 export class DatasetDetailComponent
-  implements OnInit, OnDestroy, EditableComponent
-{
+  implements OnInit, OnDestroy, EditableComponent {
   private subscriptions: Subscription[] = [];
   private _hasUnsavedChanges = false;
   form: FormGroup;

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -32,6 +32,13 @@ import { EditableComponent } from "app-routing/pending-changes.guard";
 import { AppConfigService } from "app-config.service";
 import { selectCurrentSample } from "state-management/selectors/samples.selectors";
 import { selectCurrentInstrument } from "state-management/selectors/instruments.selectors";
+import {
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  Validators,
+} from "@angular/forms";
 /**
  * Component to show details for a data set, using the
  * form component
@@ -44,9 +51,11 @@ import { selectCurrentInstrument } from "state-management/selectors/instruments.
   styleUrls: ["./dataset-detail.component.scss"],
 })
 export class DatasetDetailComponent
-  implements OnInit, OnDestroy, EditableComponent {
+  implements OnInit, OnDestroy, EditableComponent
+{
   private subscriptions: Subscription[] = [];
   private _hasUnsavedChanges = false;
+  form: FormGroup;
   userProfile$ = this.store.select(selectProfile);
   isAdmin$ = this.store.select(selectIsAdmin);
   accessGroups$: Observable<string[]> = this.userProfile$.pipe(
@@ -73,10 +82,17 @@ export class DatasetDetailComponent
     public appConfigService: AppConfigService,
     public dialog: MatDialog,
     private store: Store,
-    private router: Router
+    private router: Router,
+    private fb: FormBuilder
   ) {}
 
   ngOnInit() {
+    this.form = this.fb.group({
+      datasetName: new FormControl("", [Validators.required]),
+      description: new FormControl("", [Validators.required]),
+      keywords: this.fb.array([]),
+    });
+
     this.subscriptions.push(
       this.store.select(selectCurrentDataset).subscribe((dataset) => {
         this.dataset = dataset;
@@ -127,6 +143,15 @@ export class DatasetDetailComponent
     );
   }
 
+  onEditModeEnable() {
+    this.form = this.fb.group({
+      datasetName: this.dataset.datasetName,
+      description: this.dataset.description,
+      keywords: this.fb.array(this.dataset.keywords),
+    });
+    this.editEnabled = true;
+  }
+
   hasUnsavedChanges() {
     return this._hasUnsavedChanges;
   }
@@ -162,40 +187,46 @@ export class DatasetDetailComponent
     this.router.navigateByUrl("/datasets");
   }
 
+  get keywords(): FormArray {
+    return this.form.controls.keywords as FormArray;
+  }
+
   onAddKeyword(event: MatChipInputEvent): void {
-    const input = event.input;
+    const input = event.chipInput.inputElement;
     const value = event.value;
 
     if ((value || "").trim() && this.dataset) {
       const keyword = value.trim().toLowerCase();
-      if (!this.dataset.keywords) {
-        const keywords: Array<string> = [];
-        this.dataset.keywords = keywords;
-      }
-      if (this.dataset.keywords.indexOf(keyword) === -1) {
-        const pid = this.dataset.pid;
-        const keywords = [...this.dataset.keywords, keyword];
-        const property = { keywords };
-        this.store.dispatch(updatePropertyAction({ pid, property }));
-      }
-    }
+      if (this.keywords.value.indexOf(keyword) === -1) {
+        this.keywords.push(this.fb.control(keyword));
 
-    if (input) {
-      input.value = "";
+        // Reset the input value
+        if (input) {
+          input.value = "";
+        }
+      }
     }
   }
 
   onRemoveKeyword(keyword: string): void {
-    if (this.dataset) {
-      const index = this.dataset.keywords.indexOf(keyword);
-      if (index >= 0) {
-        const pid = this.dataset.pid;
-        const keywords = [...this.dataset.keywords];
-        keywords.splice(index, 1);
-        const property = { keywords };
-        this.store.dispatch(updatePropertyAction({ pid, property }));
-      }
+    const index = this.keywords.value.indexOf(keyword);
+    if (index >= 0) {
+      this.keywords.removeAt(index);
     }
+  }
+
+  onSaveGeneralInformationChanges() {
+    const pid = this.dataset.pid;
+
+    const property = {
+      datasetName: this.form.value.datasetName,
+      description: this.form.value.description,
+      keywords: this.keywords.value,
+    };
+
+    this.store.dispatch(updatePropertyAction({ pid, property }));
+
+    this.editEnabled = false;
   }
 
   onRemoveShare(share: string): void {


### PR DESCRIPTION
## Description

Users with right access or admins are now allowed to edit the name and description of a given dataset.

## Motivation

There was no way of editing datasets name or description.

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-2890

## Changes:

https://user-images.githubusercontent.com/6333063/201943443-f6e54c9d-195d-4467-b548-4668dc9bb136.mp4

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

