### PR TITLE
Solved the problem with undefined value in scientific metadata

### DIFF
--- a/src/app/shared/modules/scientific-metadata-tree/base-classes/tree-base.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/base-classes/tree-base.ts
@@ -53,7 +53,7 @@ export class TreeBaseComponent {
       // suport both {value: any, unit: string} and {v: any , u: string}
       if (value?.unit || value?.unit === "" || value?.u || value?.u === "") {
         node.unit = value.unit || value.u || undefined;
-        node.value = value.value || value.v;
+        node.value = value.value ?? value.v;
       } else {
         node.value = value;
       }


### PR DESCRIPTION
closes #989 

## Description

solves the issue with displaying `undefined` in `scientificMetadata` (tree view) for `0` values.

## Fixes:

using the following scientific metadata of an dataset as demo

```json
{
...
  "scientificMetadata": {
    "Experimentalist": "Linus",
    "Material": {
      "value": "Pentacene",
      "unit": ""
    },
    "Motor": {
      "Position_a": {
        "value": 0,
        "unit": "mm",
        "unitSI": "mm"
      },
      "Position_b": {
        "value": 1.3,
        "unit": "mm",
        "valueSI": 0.0013000000000000002,
        "unitSI": "m"
      }
    },
    "Scan": 4,
    "test": 0
  }
}
```
Display before change:

![grafik](https://user-images.githubusercontent.com/3169764/203049880-8bf594c7-50ea-4c61-9994-5582729fd094.png)

after change:

![grafik](https://user-images.githubusercontent.com/3169764/203049958-041ee8c0-7649-42e6-9464-8fb02800c32a.png)

## Changes:

* use of `nullish coalescing operator` instead of  `||` 
