### PR TITLE
fix: remove printing oAuth endoints

### DIFF
--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -13,7 +13,6 @@
         <div fxFlex="auto"></div>
       </div>
       <mat-card-content>
-        {{ oAuth2Endpoints }}
         <div *ngFor="let endpoint of oAuth2Endpoints">
           <button
             class="oauth-login-button"


### PR DESCRIPTION
## Description

This PR removes debug message which prints out all oAuth endpoints

## Motivation

There should be no debugged info printed out


## Changes:

Login screen


