### PR TITLE
Allow help messages configuration from config.json

### DIFF
--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from "@angular/common/http";
 import { TestBed } from "@angular/core/testing";
-import { AppConfig, AppConfigService } from "app-config.service";
+import { AppConfig, AppConfigService, HelpMessages } from "app-config.service";
 import { of } from "rxjs";
 import { MockHttp } from "shared/MockStubs";
 
@@ -120,7 +120,8 @@ const appConfig: AppConfig = {
   tableSciDataEnabled: true,
   fileserverBaseURL: "",
   fileserverButtonLabel: "",
-  datasetDetailsShowMissingProposalId: true
+  datasetDetailsShowMissingProposalId: true,
+  helpMessages: new HelpMessages(),
 };
 
 describe("AppConfigService", () => {
@@ -160,4 +161,5 @@ describe("AppConfigService", () => {
       expect(config).toEqual(appConfig);
     });
   });
+
 });

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -14,6 +14,20 @@ export class RetrieveDestinations {
   option = "";
 }
 
+export class HelpMessages {
+  ingestManual: string;
+  gettingStarted: string;
+
+  constructor(
+    gettingStarted = "gives a brief description on how to get started using the data catalog.",
+    ingestManual = `provides detailed information on how to make your data available to the
+    catalog as well as archiving and retrieval of datasets.`
+  ) {
+    this.gettingStarted = gettingStarted;
+    this.ingestManual = ingestManual;
+  }
+}
+
 export interface AppConfig {
   accessTokenPrefix: string;
   addDatasetEnabled: boolean;
@@ -58,6 +72,7 @@ export interface AppConfig {
   fileserverBaseURL: string;
   fileserverButtonLabel: string | undefined;
   datasetDetailsShowMissingProposalId: boolean;
+  helpMessages?: HelpMessages;
 }
 
 @Injectable()

--- a/src/app/help/help/help.component.html
+++ b/src/app/help/help/help.component.html
@@ -17,7 +17,7 @@
     </mat-card-header>
     The
     <a href="{{ gettingStarted }}" target="blank">Getting Started Guide</a>
-    gives a brief description on how to get started using the data catalog.
+    {{ helpMessages.gettingStarted }}
   </mat-card>
 </p>
 
@@ -65,8 +65,7 @@
     </mat-card-header>
     The
     <a href="{{ ingestManual }}" target="blank">Ingest Manual</a>
-    provides detailed information on how to make your data available to the
-    catalog as well as archiving and retrieval of datasets.
+    {{ helpMessages.ingestManual }}
   </mat-card>
 </p>
 

--- a/src/app/help/help/help.component.spec.ts
+++ b/src/app/help/help/help.component.spec.ts
@@ -1,11 +1,15 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { HelpComponent } from "./help.component";
 import { MatCardModule } from "@angular/material/card";
-import { AppConfigService } from "app-config.service";
+import { AppConfigService, HelpMessages } from "app-config.service";
 
 const getConfig = () => ({
   facility: "ESS",
+  gettingStarted: true,
+  ingestManual: true
 });
+
+const helpMessages = new HelpMessages();
 
 describe("HelpComponent", () => {
   let component: HelpComponent;
@@ -42,4 +46,45 @@ describe("HelpComponent", () => {
   it("should create", () => {
     expect(component).toBeTruthy();
   });
+
+  it("should have default messages", () => {
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.innerHTML).toContain(helpMessages.gettingStarted);
+    expect(compiled.innerHTML).toContain(helpMessages.ingestManual);
+  });
+
+  describe("should have custom messages", () => {
+    let customHelpMessages: HelpMessages;
+    beforeEach(() => {
+      fixture = TestBed.createComponent(HelpComponent);
+      component = fixture.componentInstance;
+      customHelpMessages = { gettingStarted: "someGettingStart", ingestManual: "someOtherIngest" };
+      component.appConfig.helpMessages = customHelpMessages;
+      fixture.detectChanges();
+    });
+
+    it("should have custom messages", () => {
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.innerHTML).toContain(customHelpMessages.gettingStarted);
+      expect(compiled.innerHTML).toContain(customHelpMessages.ingestManual);
+    });
+  });
+
+  describe("should set only one custom message", () => {
+    let customHelpMessages: HelpMessages;
+    beforeEach(() => {
+      fixture = TestBed.createComponent(HelpComponent);
+      component = fixture.componentInstance;
+      customHelpMessages = new HelpMessages("someGettingStart");
+      component.appConfig.helpMessages = customHelpMessages;
+      fixture.detectChanges();
+    });
+
+    it("should set only one custom message", () => {
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.innerHTML).toContain(customHelpMessages.gettingStarted);
+      expect(compiled.innerHTML).toContain(helpMessages.ingestManual);
+    });
+  });
+
 });

--- a/src/app/help/help/help.component.ts
+++ b/src/app/help/help/help.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from "@angular/core";
-import { AppConfigService } from "app-config.service";
+import { AppConfigService, HelpMessages } from "app-config.service";
 
 @Component({
   selector: "help",
@@ -12,11 +12,16 @@ export class HelpComponent implements OnInit {
   ingestManual: string | null = null;
   gettingStarted: string | null = null;
   shoppingCartEnabled = false;
+  helpMessages: HelpMessages;
   constructor(public appConfigService: AppConfigService) {}
 
   ngOnInit() {
     this.facility = this.appConfig.facility;
     this.ingestManual = this.appConfig.ingestManual;
+    this.helpMessages = new HelpMessages(
+      this.appConfig.helpMessages?.gettingStarted, 
+      this.appConfig.helpMessages?.ingestManual
+      );
     this.gettingStarted = this.appConfig.gettingStarted;
     this.shoppingCartEnabled = this.appConfig.shoppingCartEnabled;
   }


### PR DESCRIPTION
## Description

It allows to set the some custom messages in the helper

## Motivation

At PSI we need to put a note stating that some links only work internally

## Changes:

* add help message class to config
* retrieve messages from config in help component
* add tests

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

