### PR TITLE
Display "Service" on loginForm if msad enabled

### DIFF
--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -37,13 +37,13 @@
           (ngSubmit)="onLogin()"
           *ngIf="loginFormEnabled"
         >
-          <mat-form-field hintLabel="{{ facility }} account username">
+          <mat-form-field hintLabel="{{ loginFormPrefix }} account username">
             <mat-label> <b> Username</b> </mat-label>
             <span matPrefix> <mat-icon>person</mat-icon> &nbsp; </span>
             <input matInput id="usernameInput" formControlName="username" />
           </mat-form-field>
 
-          <mat-form-field hintLabel="{{ facility }} account password">
+          <mat-form-field hintLabel="{{ loginFormPrefix }} account password">
             <mat-label> <b> Password</b> </mat-label>
             <span matPrefix> <mat-icon>vpn_key</mat-icon> &nbsp; </span>
             <input

--- a/src/app/users/login/login.component.spec.ts
+++ b/src/app/users/login/login.component.spec.ts
@@ -220,4 +220,35 @@ describe("LoginComponent", () => {
       // expect(component.document.location.href).toEqual(`${appConfig.lbBaseURL}/auth/foo`);
     });
   });
+
+  describe("should contain service account hint", () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(LoginComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+    it("should contain service account hint", () => {
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.innerHTML).toContain("Service account username");
+      expect(compiled.innerHTML).toContain("Service account password");
+    });
+  });
+
+
+  describe("should contain facility hint", () => {
+    let externalAuthEndpoint: string;
+    beforeEach(() => {
+      fixture = TestBed.createComponent(LoginComponent);
+      component = fixture.componentInstance;
+      externalAuthEndpoint = "some/ext";
+      component.appConfig.externalAuthEndpoint = externalAuthEndpoint;
+      fixture.detectChanges();
+    });
+    it("should contain facility hint", () => {
+      const compiled = fixture.debugElement.nativeElement;
+      expect(compiled.innerHTML).toContain("not-ESS account username");
+      expect(compiled.innerHTML).toContain("not-ESS account password");
+    });
+  });
+
 });

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -42,6 +42,7 @@ export class LoginComponent implements OnInit, OnDestroy {
   facility: string | null = null;
   loginFormEnabled = false;
   oAuth2Endpoints: OAuth2Endpoint[] = [];
+  loginFormPrefix: string;
 
   returnUrl: string;
   hide = true;
@@ -85,6 +86,7 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.facility = this.appConfig.facility;
+    this.loginFormPrefix = this.appConfig.externalAuthEndpoint ? this.facility: "Service";
     this.loginFormEnabled = this.appConfig.loginFormEnabled;
     this.oAuth2Endpoints = this.appConfig.oAuth2Endpoints;
 


### PR DESCRIPTION
## Description

When the externalAuth option in the config file is disabled, the hint in the login form defaults to service account

## Motivation

When the externalAuth option in the config file is disabled, the hint in the login form should default to service account

## Changes:

* default hint logic depending on externalAuth in config
* tests

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

