### PR TITLE
Remove creationTime from fullfacet included params

### DIFF
--- a/src/app/state-management/selectors/datasets.selectors.spec.ts
+++ b/src/app/state-management/selectors/datasets.selectors.spec.ts
@@ -280,11 +280,11 @@ describe("test dataset selectors", () => {
 
   describe("selectFullfacetParams", () => {
     it("should return the fullfacet params", () => {
-      const fullfacetKeys = Object.keys(
-        fromDatasetSelectors.selectFullfacetParams.projector(
-          initialDatasetState.filters
-        )
+      const fullfacet = fromDatasetSelectors.selectFullfacetParams.projector(
+        initialDatasetState.filters
       );
+      const fullfacetKeys = Object.keys(fullfacet);
+      expect(fullfacet.facets).toEqual(["type", "creationLocation", "ownerGroup", "keywords"]);
       expect(fullfacetKeys).toContain("facets");
     });
   });

--- a/src/app/state-management/selectors/datasets.selectors.ts
+++ b/src/app/state-management/selectors/datasets.selectors.ts
@@ -171,7 +171,6 @@ export const selectFullfacetParams = createSelector(selectFilters, (filter) => {
   const fields = restrictFilter(theRest);
   const facets = [
     "type",
-    "creationTime",
     "creationLocation",
     "ownerGroup",
     "keywords",


### PR DESCRIPTION
## Description

Remove the creationTime from the fullfacet sent fields

## Motivation

As the facet doesn't show the number of items on a particular date, that has been removed from the fields sent to the endpoint

## Changes:

* remove from list

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

