### PR TITLE
Add optional tooltip to retrieve destinations

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -12,6 +12,7 @@ export interface OAuth2Endpoint {
 export class RetrieveDestinations {
   location?: string | null;
   option = "";
+  tooltip?: string | null;
 }
 
 export class HelpMessages {

--- a/src/app/shared/modules/dialog/dialog.component.html
+++ b/src/app/shared/modules/dialog/dialog.component.html
@@ -11,7 +11,7 @@
     <mat-label>{{data.choice.title}}</mat-label>
     <mat-select [(ngModel)]="data.option">
       <mat-option *ngFor="let choice of data.choice.options"
-        [value]="choice.option">{{choice.option}}</mat-option>
+        [value]="choice.option" [matTooltip]="choice.tooltip">{{choice.option}}</mat-option>
     </mat-select>
   </mat-form-field>
 

--- a/src/app/shared/modules/dialog/dialog.component.scss
+++ b/src/app/shared/modules/dialog/dialog.component.scss
@@ -1,4 +1,10 @@
-.mat-input-element {    
+.mat-input-element {
     margin: -6px 0px -3px 0px;
     vertical-align: middle;
+}
+
+::ng-deep .mat-tooltip {
+    min-width: 100% !important;
+    max-width: 100% !important;
+    margin: 0px;
 }

--- a/src/app/shared/modules/dialog/dialog.module.ts
+++ b/src/app/shared/modules/dialog/dialog.module.ts
@@ -8,6 +8,7 @@ import { MatDialogModule } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
+import { MatTooltipModule } from "@angular/material/tooltip";
 
 @NgModule({
   imports: [
@@ -17,6 +18,7 @@ import { MatSelectModule } from "@angular/material/select";
     MatSelectModule,
     MatButtonModule,
     MatFormFieldModule,
+    MatTooltipModule,
     FormsModule,
   ],
   declarations: [DialogComponent],


### PR DESCRIPTION
## Description

Add an optional tooltip to retrieve destinations

## Motivation

The tooltip allows explaining what different retrieve options do

## Changes:

* dialog component displays tooltip with styling

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

