### PR TITLE
remove Bearer from the token in settings and fix oidc login issue with querying userIdentity

### DIFF
--- a/src/app/state-management/effects/datasets.effects.spec.ts
+++ b/src/app/state-management/effects/datasets.effects.spec.ts
@@ -89,6 +89,7 @@ describe("DatasetEffects", () => {
             "metadataKeys",
             "find",
             "findOne",
+            "findById",
             "patchAttributes",
             "createAttachments",
             "updateByIdAttachments",
@@ -295,7 +296,7 @@ describe("DatasetEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-a|", { a: dataset });
-      datasetApi.findOne.and.returnValue(response);
+      datasetApi.findById.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchDataset$).toBeObservable(expected);
@@ -307,7 +308,7 @@ describe("DatasetEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-#", {});
-      datasetApi.findOne.and.returnValue(response);
+      datasetApi.findById.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchDataset$).toBeObservable(expected);

--- a/src/app/state-management/effects/user.effects.spec.ts
+++ b/src/app/state-management/effects/user.effects.spec.ts
@@ -193,19 +193,27 @@ describe("UserEffects", () => {
       userId: "testId",
     });
 
-    it("should result in a fetchUserCompleteAction and a loginCompleteAction", () => {
+    it("should result in a fetchUserCompleteAction, loginCompleteAction, fetchUserIdentityAction and a fetchUserSettingsAction", () => {
       const user = new User();
+      user.id = "testId";
       const accountType = "external";
       const action = fromActions.fetchUserAction({ adLoginResponse });
       const outcome1 = fromActions.fetchUserCompleteAction();
       const outcome2 = fromActions.loginCompleteAction({ user, accountType });
+      const outcome3 = fromActions.fetchUserIdentityAction({ id: user.id });
+      const outcome4 = fromActions.fetchUserSettingsAction({ id: user.id });
 
       actions = hot("-a", { a: action });
       const response = cold("-a|", { a: user });
       loopBackAuth.setToken(token);
       userApi.findById.and.returnValue(response);
 
-      const expected = cold("--(bc)", { b: outcome1, c: outcome2 });
+      const expected = cold("--(bcde)", {
+        b: outcome1,
+        c: outcome2,
+        d: outcome3,
+        e: outcome4,
+      });
       expect(effects.fetchUser$).toBeObservable(expected);
     });
 

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -128,6 +128,8 @@ export class UserEffects {
               user,
               accountType: "external",
             }),
+            fromActions.fetchUserIdentityAction({ id: user.id }),
+            fromActions.fetchUserSettingsAction({ id: user.id }),
           ]),
           catchError((error: HttpErrorResponse) =>
             of(fromActions.fetchUserFailedAction({ error }))
@@ -334,9 +336,7 @@ export class UserEffects {
       ofType(fromActions.fetchScicatTokenAction),
       switchMap(() =>
         of(this.userApi.getCurrentToken()).pipe(
-          map((token) =>
-            fromActions.fetchScicatTokenCompleteAction({ token })
-          ),
+          map((token) => fromActions.fetchScicatTokenCompleteAction({ token })),
           catchError(() => of(fromActions.fetchScicatTokenFailedAction()))
         )
       )

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -14,7 +14,11 @@ import { filter } from "rxjs/operators";
 import { selectLoginPageViewModel } from "state-management/selectors/user.selectors";
 import { MatDialog } from "@angular/material/dialog";
 import { PrivacyDialogComponent } from "users/privacy-dialog/privacy-dialog.component";
-import { AppConfig, AppConfigService, OAuth2Endpoint } from "app-config.service";
+import {
+  AppConfig,
+  AppConfigService,
+  OAuth2Endpoint,
+} from "app-config.service";
 
 interface LoginForm {
   username: string;
@@ -86,7 +90,9 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.facility = this.appConfig.facility;
-    this.loginFormPrefix = this.appConfig.externalAuthEndpoint ? this.facility: "Service";
+    this.loginFormPrefix = this.appConfig.externalAuthEndpoint
+      ? this.facility
+      : "Service";
     this.loginFormEnabled = this.appConfig.loginFormEnabled;
     this.oAuth2Endpoints = this.appConfig.oAuth2Endpoints;
 

--- a/src/app/users/user-settings/user-settings.component.html
+++ b/src/app/users/user-settings/user-settings.component.html
@@ -49,11 +49,11 @@
           <th>Groups</th>
           <td>{{ vm.profile.accessGroups }}</td>
         </tr>
-        <tr *ngIf="vm.scicatToken as value">
+        <tr *ngIf="tokenValue">
           <th>SciCat Token</th>
           <td>
-            {{ value }}
-            <span class="copy-button" (click)="onCopy(value)">
+            {{ tokenValue }}
+            <span class="copy-button" (click)="onCopy(tokenValue)">
               <mat-icon matTooltip="Copy token to clipboard">post_add</mat-icon>
             </span>
           </td>

--- a/src/app/users/user-settings/user-settings.component.ts
+++ b/src/app/users/user-settings/user-settings.component.ts
@@ -16,6 +16,7 @@ import { DOCUMENT } from "@angular/common";
 })
 export class UserSettingsComponent implements OnInit {
   vm$ = this.store.select(selectUserSettingsPageViewModel);
+  tokenValue: string;
 
   constructor(
     @Inject(DOCUMENT) private document: Document,
@@ -25,6 +26,10 @@ export class UserSettingsComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.vm$.subscribe(
+      (settings) =>
+        (this.tokenValue = settings.scicatToken.replace("Bearer ", ""))
+    );
     this.store.dispatch(fetchCurrentUserAction());
     this.store.dispatch(fetchScicatTokenAction());
   }


### PR DESCRIPTION
## Description

1. User identity is fetched after you login with OIDC
2. Copy of user token now excludes Bearer
3. Fixed some other bugs

## Motivation

User identity and settings were not queried after you login with OIDC.

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-3085
* https://jira.esss.lu.se/browse/SWAP-3029


