### PR TITLE
refactor: login screen refactored to show external login first

### DIFF
--- a/CI/ESS/e2e/config.e2e.json
+++ b/CI/ESS/e2e/config.e2e.json
@@ -9,6 +9,8 @@
   "editSampleEnabled": true,
   "externalAuthEndpoint": "/auth/msad",
   "facility": "ESS",
+  "facilityLoginLabel": "ESS",
+  "localLoginLabel": "Local",
   "fileColorEnabled": true,
   "fileDownloadEnabled": true,
   "gettingStarted": null,
@@ -99,7 +101,9 @@
   "metadataStructure": "",
   "multipleDownloadAction": "https://scicatfileserver.esss.dk/zip",
   "multipleDownloadEnabled": true,
-  "oAuth2Endpoints": [],
+  "oAuth2Endpoints": [
+    { "authURL": "api/v3/auth/oidc", "displayText": "ESS One Identity" }
+  ],
   "policiesEnabled": true,
   "retrieveDestinations": [],
   "riotBaseUrl": "http://scitest.esss.lu.se/riot",

--- a/cypress/integration/datasets-general.spec.js
+++ b/cypress/integration/datasets-general.spec.js
@@ -78,6 +78,8 @@ describe("Datasets general", () => {
 
       cy.url().should("include", "/login");
 
+      cy.get('mat-tab-group [role="tab"]').contains("Local").click();
+
       cy.get("#usernameInput").type(username).should("have.value", username);
       cy.get("#passwordInput").type(password).should("have.value", password);
 

--- a/cypress/integration/users-login.spec.js
+++ b/cypress/integration/users-login.spec.js
@@ -26,6 +26,8 @@ describe("Users Login", () => {
 
     cy.url().should("include", "/login");
 
+    cy.get('mat-tab-group [role="tab"]').contains("Local").click();
+
     cy.get("#usernameInput").type(username).should("have.value", username);
 
     cy.get("#passwordInput").type("invalid").should("have.value", "invalid");
@@ -64,6 +66,8 @@ describe("Users Login", () => {
 
     cy.url().should("include", "/login");
 
+    cy.get('mat-tab-group [role="tab"]').contains("Local").click();
+
     cy.get("#usernameInput").type(username).should("have.value", username);
 
     cy.get("#passwordInput").type(password).should("have.value", password);
@@ -82,5 +86,4 @@ describe("Users Login", () => {
 
     cy.url().should("include", "/login");
   });
-
 });

--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -15,6 +15,8 @@ const appConfig: AppConfig = {
   editSampleEnabled: true,
   externalAuthEndpoint: "/auth/msad",
   facility: "ESS",
+  facilityLoginLabel: "ESS",
+  localLoginLabel: "Local",
   fileColorEnabled: true,
   fileDownloadEnabled: true,
   gettingStarted: null,
@@ -161,5 +163,4 @@ describe("AppConfigService", () => {
       expect(config).toEqual(appConfig);
     });
   });
-
 });

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -40,6 +40,8 @@ export interface AppConfig {
   editSampleEnabled: boolean;
   externalAuthEndpoint: string | null;
   facility: string | null;
+  facilityLoginLabel: string | null;
+  localLoginLabel: string | null;
   fileColorEnabled: boolean;
   fileDownloadEnabled: boolean;
   gettingStarted: string | null;

--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -13,71 +13,91 @@
         <div fxFlex="auto"></div>
       </div>
       <mat-card-content>
-        <div *ngFor="let endpoint of oAuth2Endpoints">
-          <button
-            class="oauth-login-button"
-            mat-raised-button
-            type="submit"
-            [ngClass]="{ loading: vm.isLoggingIn }"
-            (click)="redirectOIDC(endpoint.authURL)"
-          >
-            <img
-              class="oauth-login-image"
-              *ngIf="endpoint.displayImage"
-              [src]="endpoint.displayImage"
-            />
-            Login with {{ endpoint.displayText }}
-          </button>
-          <br />
-        </div>
-        <br />
-        <form
-          [formGroup]="loginForm"
-          (ngSubmit)="onLogin()"
-          *ngIf="loginFormEnabled"
-        >
-          <mat-form-field hintLabel="{{ loginFormPrefix }} account username">
-            <mat-label> <b> Username</b> </mat-label>
-            <span matPrefix> <mat-icon>person</mat-icon> &nbsp; </span>
-            <input matInput id="usernameInput" formControlName="username" />
-          </mat-form-field>
-
-          <mat-form-field hintLabel="{{ loginFormPrefix }} account password">
-            <mat-label> <b> Password</b> </mat-label>
-            <span matPrefix> <mat-icon>vpn_key</mat-icon> &nbsp; </span>
-            <input
-              matInput
-              id="passwordInput"
-              formControlName="password"
-              [type]="hide ? 'password' : 'text'"
-            />
-            <button
-              mat-icon-button
-              matSuffix
-              type="button"
-              (click)="hide = !hide"
-              [attr.aria-label]="'Hide password'"
-              [attr.aria-pressed]="hide"
+        <mat-tab-group>
+          <mat-tab [label]="facilityLoginLabel" *ngIf="oAuth2Endpoints.length">
+            <div
+              class="external-login"
+              *ngFor="let endpoint of oAuth2Endpoints"
             >
-              <mat-icon>{{ hide ? "visibility_off" : "visibility" }}</mat-icon>
-            </button>
-          </mat-form-field>
-          <p class="privacy-notice" *ngIf="facility === 'ESS'">
-            <small>
-              <a (click)="openPrivacyDialog()">SciCat Privacy Notice</a>
-            </small>
-          </p>
-          <button
-            mat-raised-button
-            class="login-button"
-            type="submit"
-            color="primary"
-            [ngClass]="{ loading: vm.isLoggingIn }"
-          >
-            Log in
-          </button>
-          <mat-checkbox name="rememberMe">Remember me</mat-checkbox>
-        </form>
+              <button
+                class="oauth-login-button"
+                mat-raised-button
+                type="submit"
+                [ngClass]="{ loading: vm.isLoggingIn }"
+                (click)="redirectOIDC(endpoint.authURL)"
+              >
+                <img
+                  class="oauth-login-image"
+                  *ngIf="endpoint.displayImage"
+                  [src]="endpoint.displayImage"
+                />
+                Login with {{ endpoint.displayText }}
+              </button>
+              <br />
+            </div>
+          </mat-tab>
+          <mat-tab [label]="localLoginLabel">
+            <div class="internal-login">
+              <form
+                [formGroup]="loginForm"
+                (ngSubmit)="onLogin()"
+                *ngIf="loginFormEnabled"
+              >
+                <mat-form-field
+                  hintLabel="{{ loginFormPrefix }} account username"
+                >
+                  <mat-label> <b> Username</b> </mat-label>
+                  <span matPrefix> <mat-icon>person</mat-icon> &nbsp; </span>
+                  <input
+                    matInput
+                    id="usernameInput"
+                    formControlName="username"
+                  />
+                </mat-form-field>
+
+                <mat-form-field
+                  hintLabel="{{ loginFormPrefix }} account password"
+                >
+                  <mat-label> <b> Password</b> </mat-label>
+                  <span matPrefix> <mat-icon>vpn_key</mat-icon> &nbsp; </span>
+                  <input
+                    matInput
+                    id="passwordInput"
+                    formControlName="password"
+                    [type]="hide ? 'password' : 'text'"
+                  />
+                  <button
+                    mat-icon-button
+                    matSuffix
+                    type="button"
+                    (click)="hide = !hide"
+                    [attr.aria-label]="'Hide password'"
+                    [attr.aria-pressed]="hide"
+                  >
+                    <mat-icon>{{
+                      hide ? "visibility_off" : "visibility"
+                    }}</mat-icon>
+                  </button>
+                </mat-form-field>
+                <p class="privacy-notice" *ngIf="facility === 'ESS'">
+                  <small>
+                    <a (click)="openPrivacyDialog()">SciCat Privacy Notice</a>
+                  </small>
+                </p>
+                <button
+                  mat-raised-button
+                  class="login-button"
+                  type="submit"
+                  color="primary"
+                  [ngClass]="{ loading: vm.isLoggingIn }"
+                >
+                  Log in
+                </button>
+                <mat-checkbox name="rememberMe">Remember me</mat-checkbox>
+              </form>
+            </div>
+          </mat-tab>
+        </mat-tab-group>
       </mat-card-content>
     </mat-card>
   </div>

--- a/src/app/users/login/login.component.scss
+++ b/src/app/users/login/login.component.scss
@@ -28,7 +28,6 @@
 
         .external-login {
           text-align: center;
-          padding: 1em;
         }
 
         .internal-login {

--- a/src/app/users/login/login.component.scss
+++ b/src/app/users/login/login.component.scss
@@ -10,7 +10,7 @@
     padding-top: 10em;
 
     mat-card {
-      max-width: 300px;
+      max-width: 350px;
       background-color: rgba(255, 255, 255, 0.8);
 
       .facility-logo {
@@ -22,6 +22,19 @@
       }
 
       mat-card-content {
+        ::ng-deep .mat-tab-labels .mat-tab-label {
+          width: 100%;
+        }
+
+        .external-login {
+          text-align: center;
+          padding: 1em;
+        }
+
+        .internal-login {
+          padding: 1em;
+        }
+
         mat-form-field {
           width: 100%;
 
@@ -48,7 +61,6 @@
           margin-top: 1em;
           cursor: pointer;
           display: inline-block;
-
         }
 
         .oauth-login-image {
@@ -63,6 +75,5 @@
         }
       }
     }
-
   }
 }

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -47,6 +47,8 @@ export class LoginComponent implements OnInit, OnDestroy {
   loginFormEnabled = false;
   oAuth2Endpoints: OAuth2Endpoint[] = [];
   loginFormPrefix: string;
+  facilityLoginLabel: string;
+  localLoginLabel: string;
 
   returnUrl: string;
   hide = true;
@@ -90,6 +92,8 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.facility = this.appConfig.facility;
+    this.facilityLoginLabel = this.appConfig.facilityLoginLabel || "External";
+    this.localLoginLabel = this.appConfig.localLoginLabel || "Local";
     this.loginFormPrefix = this.appConfig.externalAuthEndpoint
       ? this.facility
       : "Service";

--- a/src/app/users/users.module.ts
+++ b/src/app/users/users.module.ts
@@ -21,6 +21,7 @@ import { MatInputModule } from "@angular/material/input";
 import { PrivacyDialogComponent } from "./privacy-dialog/privacy-dialog.component";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { AuthCallbackComponent } from "./auth-callback/auth-callback.component";
+import { MatTabsModule } from "@angular/material/tabs";
 
 @NgModule({
   imports: [
@@ -36,6 +37,7 @@ import { AuthCallbackComponent } from "./auth-callback/auth-callback.component";
     MatGridListModule,
     MatIconModule,
     MatInputModule,
+    MatTabsModule,
     MatTooltipModule,
     ReactiveFormsModule,
     SharedScicatFrontendModule,


### PR DESCRIPTION
## Description

Login screen refactored to show external login options first (if any available) with tabular view. Another option for login is local which means login with functional account. Added some e2e tests for it.