### PR TITLE
Assign default values on retrieve and change title

### DIFF
--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -168,7 +168,6 @@ describe("ArchivingService", () => {
             title: "Retrieve to",
             question: "",
             choice: { 
-              title: "", 
               options: destinations 
             },
             option: destinations[0].option

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -164,10 +164,34 @@ describe("ArchivingService", () => {
         {
           width: "auto",
           data: {
-            title: "Really retrieve?",
+            title: "Retrieve to",
             question: "",
-            choice: { title: "Optionally select destination", options: destinations }
-          }
+            choice: { 
+              title: "Optionally select destination", 
+              options: destinations 
+            },
+          },
+        }
+      );
+    });
+  });
+
+  describe("#retriveDialogOptions() with non empty retrieveDestinations", () => {
+    it("should return the dialog options when retrieving", () => {
+      let destinations: RetrieveDestinations[];
+      destinations = [{option: 'option1'}, {option: 'option2'}];
+      expect(service.retriveDialogOptions(destinations)).toEqual(
+        {
+          width: "auto",
+          data: {
+            title: "Retrieve to",
+            question: "",
+            choice: { 
+              title: "", 
+              options: destinations 
+            },
+            option: destinations[0].option
+          },
         }
       );
     });

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -159,25 +159,6 @@ describe("ArchivingService", () => {
 
   describe("#retriveDialogOptions()", () => {
     it("should return the dialog options when retrieving", () => {
-      const destinations = [new RetrieveDestinations(), new RetrieveDestinations()];
-      expect(service.retriveDialogOptions(destinations)).toEqual(
-        {
-          width: "auto",
-          data: {
-            title: "Retrieve to",
-            question: "",
-            choice: { 
-              title: "Optionally select destination", 
-              options: destinations 
-            },
-          },
-        }
-      );
-    });
-  });
-
-  describe("#retriveDialogOptions() with non empty retrieveDestinations", () => {
-    it("should return the dialog options when retrieving", () => {
       let destinations: RetrieveDestinations[];
       destinations = [{option: 'option1'}, {option: 'option2'}];
       expect(service.retriveDialogOptions(destinations)).toEqual(

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -160,7 +160,7 @@ describe("ArchivingService", () => {
   describe("#retriveDialogOptions()", () => {
     it("should return the dialog options when retrieving", () => {
       let destinations: RetrieveDestinations[];
-      destinations = [{option: 'option1'}, {option: 'option2'}];
+      destinations = [{option: "option1"}, {option: "option2"}];
       expect(service.retriveDialogOptions(destinations)).toEqual(
         {
           width: "auto",

--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -117,15 +117,17 @@ export class ArchivingService {
   public retriveDialogOptions(
     retrieveDestinations: RetrieveDestinations[] = []
   ): object {
+    const firstRetrieveOption = retrieveDestinations?.[0]?.option;
     return {
       width: "auto",
       data: {
-        title: "Really retrieve?",
+        title: "Retrieve to",
         question: "",
         choice: {
-          title: "Optionally select destination",
+          title: firstRetrieveOption? "": "Optionally select destination",
           options: retrieveDestinations,
         },
+        ...(firstRetrieveOption? {option: firstRetrieveOption}: {})
       },
     };
   }

--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -117,17 +117,15 @@ export class ArchivingService {
   public retriveDialogOptions(
     retrieveDestinations: RetrieveDestinations[] = []
   ): object {
-    const firstRetrieveOption = retrieveDestinations?.[0]?.option;
     return {
       width: "auto",
       data: {
         title: "Retrieve to",
         question: "",
         choice: {
-          title: firstRetrieveOption,
           options: retrieveDestinations,
         },
-        option: firstRetrieveOption
+        option: retrieveDestinations?.[0]?.option
       },
     };
   }

--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -124,10 +124,10 @@ export class ArchivingService {
         title: "Retrieve to",
         question: "",
         choice: {
-          title: firstRetrieveOption? "": "Optionally select destination",
+          title: firstRetrieveOption,
           options: retrieveDestinations,
         },
-        ...(firstRetrieveOption? {option: firstRetrieveOption}: {})
+        option: firstRetrieveOption
       },
     };
   }

--- a/src/app/shared/modules/dialog/dialog.component.html
+++ b/src/app/shared/modules/dialog/dialog.component.html
@@ -8,7 +8,6 @@
 
 <div *ngIf="data.choice?.options?.length > 0">
   <mat-form-field>
-    <mat-label>{{data.choice.title}}</mat-label>
     <mat-select [(ngModel)]="data.option">
       <mat-option *ngFor="let choice of data.choice.options"
         [value]="choice.option" [matTooltip]="choice.tooltip">{{choice.option}}</mat-option>


### PR DESCRIPTION
## Description

When selecting the retrieve option the first option is preselected

## Motivation

When selecting the retrieve option the first option should be pre-selected and be the value of the first entry. For the same reason, the title is more explicit

## Changes:

* src/app/datasets/archiving.service.ts applies a default 

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

