### PR TITLE
Fix metadata display in table

### DIFF
--- a/src/app/shared/pipes/json-head.pipe.ts
+++ b/src/app/shared/pipes/json-head.pipe.ts
@@ -35,7 +35,7 @@ export class JsonHeadPipe implements PipeTransform {
       key2 = " ";
       val2 = " ";
     }
-    outputString = key1 + ":" + val1 + "\n" + key2 + ":" + val2;
+    outputString = key1 + ":" + (val1?.value.toString() || val1)+ "\n" + key2 + ":" + val2;
     if (key1 === undefined) {
       outputString = "No metadata found";
     }


### PR DESCRIPTION
## Description

Avoid display  just 'Object' for string metadata in the dataset  table

## Motivation

Background on use case, changes needed


## Changes:

* use a logic similar the detail page display

## Tests included/Docs Updated?

- [-] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [-] Docs updated?
- [-] New packages used/requires npm install? 
- [-] Toggle added for new features?
- [-] Requires update of SciCat backend API?

