### PR TITLE
login form: dont show tab if loginform is disabled

### DIFF
--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -36,12 +36,14 @@
               <br />
             </div>
           </mat-tab>
-          <mat-tab [label]="localLoginLabel">
+          <mat-tab
+            [label]="localLoginLabel"
+            *ngIf="loginFormEnabled"
+	  >
             <div class="internal-login">
               <form
                 [formGroup]="loginForm"
                 (ngSubmit)="onLogin()"
-                *ngIf="loginFormEnabled"
               >
                 <mat-form-field
                   hintLabel="{{ loginFormPrefix }} account username"


### PR DESCRIPTION
If the login form is disabled, don't try to show the local login tab. The logic was placed one element too deep.

Fixes: #1032
Change-Id: I2b1ca995879ee88ccc203c215419e3ab0027940e

## Tests included/Docs Updated?

- [-] Included for each change/fix?
- [X] Passing? (Merge will not be approved unless this is checked) 
- [-] Docs updated?
- [-] New packages used/requires npm install? 
- [-] Toggle added for new features?
- [-] Requires update of SciCat backend API?

