### PR TITLE
fix: fix metadata wrong type if string has number value

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -51,7 +51,8 @@ import {
   styleUrls: ["./dataset-detail.component.scss"],
 })
 export class DatasetDetailComponent
-  implements OnInit, OnDestroy, EditableComponent {
+  implements OnInit, OnDestroy, EditableComponent
+{
   private subscriptions: Subscription[] = [];
   private _hasUnsavedChanges = false;
   form: FormGroup;

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -51,8 +51,7 @@ import {
   styleUrls: ["./dataset-detail.component.scss"],
 })
 export class DatasetDetailComponent
-  implements OnInit, OnDestroy, EditableComponent
-{
+  implements OnInit, OnDestroy, EditableComponent {
   private subscriptions: Subscription[] = [];
   private _hasUnsavedChanges = false;
   form: FormGroup;

--- a/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.spec.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.spec.ts
@@ -145,6 +145,25 @@ describe("MetadataEditComponent", () => {
       expect(component.items.at(0).get("fieldUnit").status).toEqual("DISABLED");
     });
 
+    it("should add typed metadata from the provided metadata object to the FormGroup array", () => {
+      expect(component.items.length).toEqual(0);
+
+      component.metadata = {
+        testName: {
+          value: "123",
+          unit: "",
+        },
+      };
+
+      component.addCurrentMetadata();
+
+      expect(component.items.length).toEqual(1);
+      expect(component.items.at(0).get("fieldName").value).toEqual("testName");
+      expect(component.items.at(0).get("fieldType").value).toEqual("string");
+      expect(component.items.at(0).get("fieldValue").value).toEqual("123");
+      expect(component.items.at(0).get("fieldUnit").value).toEqual("");
+    });
+
     it("should do nothing if the metadata object is undefined", () => {
       expect(component.items.length).toEqual(0);
       expect(component.metadata).toBeUndefined();

--- a/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
@@ -20,6 +20,7 @@ import { UnitsService } from "shared/services/units.service";
 import { startWith, map } from "rxjs/operators";
 import { Observable } from "rxjs";
 import { ScientificMetadata } from "../scientific-metadata.module";
+import { DateTime } from "luxon";
 
 @Component({
   selector: "metadata-edit",
@@ -112,17 +113,17 @@ export class MetadataEditComponent implements OnInit, OnChanges {
               fieldValue: Number(this.metadata[key]["value"]),
               fieldUnit: this.metadata[key]["unit"],
             });
-          } else if (isNaN(Date.parse(this.metadata[key]["value"]))) {
+          } else if (DateTime.fromISO(this.metadata[key]["value"]).isValid) {
             field = this.formBuilder.group({
               fieldName: key,
-              fieldType: "string",
+              fieldType: "date",
               fieldValue: this.metadata[key]["value"],
               fieldUnit: this.metadata[key]["unit"],
             });
           } else {
             field = this.formBuilder.group({
               fieldName: key,
-              fieldType: "date",
+              fieldType: "string",
               fieldValue: this.metadata[key]["value"],
               fieldUnit: this.metadata[key]["unit"],
             });

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.spec.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.spec.ts
@@ -9,15 +9,13 @@ describe("MetadataViewComponent", () => {
   let component: MetadataViewComponent;
   let fixture: ComponentFixture<MetadataViewComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        schemas: [NO_ERRORS_SCHEMA],
-        imports: [MatTableModule, PipesModule],
-        declarations: [MetadataViewComponent],
-      }).compileComponents();
-    })
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [MatTableModule, PipesModule],
+      declarations: [MetadataViewComponent],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MetadataViewComponent);
@@ -97,6 +95,19 @@ describe("MetadataViewComponent", () => {
 
       expect(isDate).toEqual(false);
     });
+
+    it("should return false if scientificMetadata value is a string of numbers", () => {
+      const metadata = {
+        name: "test",
+        value: "123",
+        unit: "",
+      };
+
+      const isDate = component.isDate(metadata);
+
+      expect(isDate).toEqual(false);
+    });
+
     it("should return true if scientificMetadata item is a date string", () => {
       const metadata = {
         name: "today",

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
@@ -3,14 +3,18 @@ import {
   OnInit,
   Input,
   OnChanges,
-  SimpleChange
+  SimpleChange,
 } from "@angular/core";
-import { ScientificMetadataTableData, ScientificMetadata } from "../scientific-metadata.module";
+import { DateTime } from "luxon";
+import {
+  ScientificMetadataTableData,
+  ScientificMetadata,
+} from "../scientific-metadata.module";
 
 @Component({
   selector: "metadata-view",
   templateUrl: "./metadata-view.component.html",
-  styleUrls: ["./metadata-view.component.scss"]
+  styleUrls: ["./metadata-view.component.scss"],
 })
 export class MetadataViewComponent implements OnInit, OnChanges {
   @Input() metadata: Record<string, unknown> = {};
@@ -18,21 +22,23 @@ export class MetadataViewComponent implements OnInit, OnChanges {
   tableData: ScientificMetadataTableData[] = [];
   columnsToDisplay: string[] = ["name", "value", "unit"];
 
-  createMetadataArray(metadata: Record<string, any>): ScientificMetadataTableData[] {
+  createMetadataArray(
+    metadata: Record<string, any>
+  ): ScientificMetadataTableData[] {
     const metadataArray: ScientificMetadataTableData[] = [];
-    Object.keys(metadata).forEach(key => {
+    Object.keys(metadata).forEach((key) => {
       let metadataObject: ScientificMetadataTableData;
       if ("value" in (metadata[key] as ScientificMetadata)) {
         metadataObject = {
           name: key,
           value: metadata[key]["value"],
-          unit: metadata[key]["unit"]
+          unit: metadata[key]["unit"],
         };
       } else {
         metadataObject = {
           name: key,
           value: JSON.stringify(metadata[key]),
-          unit: ""
+          unit: "",
         };
       }
       metadataArray.push(metadataObject);
@@ -47,7 +53,7 @@ export class MetadataViewComponent implements OnInit, OnChanges {
     if (typeof scientificMetadata.value === "number") {
       return false;
     }
-    if (isNaN(Date.parse(scientificMetadata.value))) {
+    if (!DateTime.fromISO(scientificMetadata.value).isValid) {
       return false;
     }
     return true;


### PR DESCRIPTION
## Description

This PR fixes the bug where string field gets converted to date if you enter numeric value.

## Motivation

If you choose string field type and add a numeric value it gets converted to date type.

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-3146

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

