### PR TITLE
fix: created proposal-logbook component & fixed few bugs

### DIFF
--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.html
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="!proposal_logbook && vm$ | async as vm">
+<ng-container *ngIf="vm$ | async as vm">
   <div *ngIf="(vm.logbook | keyvalue)?.length !== 0 && dataset && vm.logbook?.roomId">
     <div fxLayout="row" fxLayout.lt-lg="column">
       <div fxFlex="14">
@@ -62,74 +62,6 @@
   <ng-template [ngIf]="!(vm.logbook | keyvalue)?.length">
     <mat-card class="no-logbook-message">
       <mat-icon>info</mat-icon> No logbook available. 
-    </mat-card>
-  </ng-template>
-</ng-container>
-
-<ng-container *ngIf="proposal_logbook">
-  <div *ngIf="(proposal_logbook.logbook | keyvalue)?.length !== 0 && proposal_dataset && proposal_logbook.logbook?.roomId">
-    <div fxLayout="row" fxLayout.lt-lg="column">
-      <div fxFlex="14">
-        <mat-card class="big-filter">
-          <div class="title">Filter</div>
-          <app-search-bar [prefilledValue]="proposal_logbook.filters.textSearch"
-            (search)="onTextSearchChange(proposal_dataset.pid, $event)"
-            (searchBarFocus)="onTextSearchChange(proposal_dataset.pid, $event)">
-          </app-search-bar>
-          <logbook-filter [filters]="proposal_logbook.filters"
-            (filterSelect)="onFilterSelect(proposal_dataset.pid, $event)">
-          </logbook-filter>
-        </mat-card>
-
-        <div class="small-filter">
-          <app-search-bar [prefilledValue]="proposal_logbook.filters.textSearch"
-            (search)="onTextSearchChange(proposal_dataset.pid, $event)"
-            (searchBarFocus)="onTextSearchChange(proposal_dataset.pid, $event)">
-          </app-search-bar>
-
-          <mat-expansion-panel>
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                <div class="title">Filter</div>
-              </mat-panel-title>
-            </mat-expansion-panel-header>
-            <logbook-filter [filters]="proposal_logbook.filters"
-              (filterSelect)="onFilterSelect(proposal_dataset.pid, $event)">
-            </logbook-filter>
-          </mat-expansion-panel>
-        </div>
-        <div fxLayout="column" fxLayout.lt-lg="row">
-          <div fxFlex="49">
-            <a href="{{ appConfig.riotBaseUrl }}/#/room/{{ proposal_logbook.logbook?.roomId }}"
-              target="_blank" rel="noopener noreferrer">
-              <mat-card class="card-button">
-                <mat-icon> chat_bubble_outline </mat-icon> Go to chat
-              </mat-card>
-            </a>
-          </div>
-          <div fxFlex="auto"></div>
-          <div class="reverse-card" fxFlex="49">
-            <mat-card class="card-button"
-              (click)="proposal_logbook.logbook.messages.reverse()">
-              <mat-icon> swap_vert </mat-icon> Reverse
-            </mat-card>
-          </div>
-        </div>
-      </div>
-      <div fxFlex="85" class="details-container">
-        <app-logbooks-detail [logbook]="proposal_logbook.logbook"
-          [entriesCount]="proposal_logbook.entriesCount" [entriesPerPage]="proposal_logbook.entriesPerPage"
-          [currentPage]="proposal_logbook.currentPage"
-          (pageChange)="onPageChange(proposal_dataset.pid, $event)"
-          (sortChange)="onSortChange(proposal_dataset.pid, $event)">
-        </app-logbooks-detail>
-      </div>
-    </div>
-  </div>
-
-  <ng-template [ngIf]="!(proposal_logbook.logbook | keyvalue)?.length ">
-    <mat-card class="no-logbook-message">
-      <mat-icon>info</mat-icon> No logbook available.
     </mat-card>
   </ng-template>
 </ng-container>

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
@@ -49,9 +49,6 @@ export class LogbooksDashboardComponent
   implements OnInit, OnDestroy, AfterViewChecked {
   vm$ = this.store.select(selectLogbooksDashboardPageViewModel);
 
-  @Input() proposal_logbook: LogbookData;
-  @Input() proposal_dataset: TableData;
-
   dataset: Dataset | undefined = undefined;
   appConfig = this.appConfigService.getConfig();
 
@@ -68,7 +65,6 @@ export class LogbooksDashboardComponent
 
   applyRouterState(pid: string, filters: LogbookFilters) {
     console.log("Rerouting to Dataset Logbook");
-    if (this.proposal_logbook) return;
 
     this.router.navigate(["/datasets", pid, "logbook"], {
       queryParams: { args: JSON.stringify(filters) },
@@ -76,12 +72,10 @@ export class LogbooksDashboardComponent
   }
 
   onTextSearchChange(pid: string, query: string) {
-    const queryText = query.trim();
-    
-    if(queryText.length > 0){
-      this.store.dispatch(setTextFilterAction({ textSearch: queryText }));
-      this.store.dispatch(fetchDatasetLogbookAction({ pid }));
-    }
+    // TODO: query.length return undefined when it is empty
+    const queryText = query.length ? query : "";
+    this.store.dispatch(setTextFilterAction({ textSearch: queryText }));
+    this.store.dispatch(fetchDatasetLogbookAction({ pid }));
   }
 
   onFilterSelect(pid: string, filters: LogbookFilters) {

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
@@ -31,7 +31,6 @@ import {
 import { AppConfigService } from "app-config.service";
 import { selectCurrentDataset } from "state-management/selectors/datasets.selectors";
 import { OwnershipService } from "shared/services/ownership.service";
-import { TableData } from "proposals/view-proposal-page/view-proposal-page.component";
 
 export interface LogbookData {
   logbook: Logbook;

--- a/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
+++ b/src/app/logbooks/logbooks-dashboard/logbooks-dashboard.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   OnInit,
   OnDestroy,
-  Input,
   ChangeDetectorRef,
   AfterViewChecked,
 } from "@angular/core";

--- a/src/app/proposals/proposal-logbook/proposal-logbook.component.html
+++ b/src/app/proposals/proposal-logbook/proposal-logbook.component.html
@@ -1,0 +1,67 @@
+<ng-container *ngIf="logbook">
+  <div *ngIf="(logbook.logbook | keyvalue)?.length !== 0 && logbook.logbook?.name">
+    <div fxLayout="row" fxLayout.lt-lg="column">
+      <div fxFlex="14">
+        <mat-card class="big-filter">
+          <div class="title">Filter</div>
+          <app-search-bar [prefilledValue]="logbook.filters.textSearch"
+            (search)="onTextSearchChange(logbook.logbook?.name, $event)"
+            (searchBarFocus)="onTextSearchChange(logbook.logbook?.name, $event)">
+          </app-search-bar>
+          <logbook-filter [filters]="logbook.filters"
+            (filterSelect)="onFilterSelect(logbook.logbook?.name, $event)">
+          </logbook-filter>
+        </mat-card>
+
+        <div class="small-filter">
+          <app-search-bar [prefilledValue]="logbook.filters.textSearch"
+            (search)="onTextSearchChange(logbook.logbook?.name, $event)"
+            (searchBarFocus)="onTextSearchChange(logbook.logbook?.name, $event)">
+          </app-search-bar>
+
+          <mat-expansion-panel>
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <div class="title">Filter</div>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <logbook-filter [filters]="logbook.filters"
+              (filterSelect)="onFilterSelect(logbook.logbook?.name, $event)">
+            </logbook-filter>
+          </mat-expansion-panel>
+        </div>
+        <div fxLayout="column" fxLayout.lt-lg="row">
+          <div fxFlex="49">
+            <a href="{{ appConfig.riotBaseUrl }}/#/room/{{ logbook.logbook?.roomId }}"
+              target="_blank" rel="noopener noreferrer">
+              <mat-card class="card-button">
+                <mat-icon> chat_bubble_outline </mat-icon> Go to chat
+              </mat-card>
+            </a>
+          </div>
+          <div fxFlex="auto"></div>
+          <div class="reverse-card" fxFlex="49">
+            <mat-card class="card-button"
+              (click)="logbook.logbook.messages.reverse()">
+              <mat-icon> swap_vert </mat-icon> Reverse
+            </mat-card>
+          </div>
+        </div>
+      </div>
+      <div fxFlex="85" class="details-container">
+        <app-logbooks-detail [logbook]="logbook.logbook"
+          [entriesCount]="logbook.entriesCount" [entriesPerPage]="logbook.entriesPerPage"
+          [currentPage]="logbook.currentPage"
+          (pageChange)="onPageChange(logbook.logbook?.name, $event)"
+          (sortChange)="onSortChange(logbook.logbook?.name, $event)">
+        </app-logbooks-detail>
+      </div>
+    </div>
+  </div>
+
+  <ng-template [ngIf]="!(logbook.logbook | keyvalue)?.length ">
+    <mat-card class="no-logbook-message">
+      <mat-icon>info</mat-icon> No logbook available.
+    </mat-card>
+  </ng-template>
+</ng-container>

--- a/src/app/proposals/proposal-logbook/proposal-logbook.component.scss
+++ b/src/app/proposals/proposal-logbook/proposal-logbook.component.scss
@@ -1,0 +1,58 @@
+mat-card {
+  margin: 1em;
+
+  mat-icon {
+    vertical-align: middle;
+  }
+}
+
+.title {
+  font-size: 1.25em;
+}
+
+.card-button {
+  margin: 1em;
+  text-align: center;
+}
+
+.card-button:hover {
+  cursor: pointer;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.details-container {
+  margin-top: 1em;
+}
+
+@media only screen and (min-width: 1280px) {
+  .big-filter {
+    margin-top: 5em;
+  }
+
+  .small-filter {
+    display: none;
+  }
+
+  .reverse-card {
+    display: none;
+  }
+}
+
+@media only screen and (max-width: 1279px) {
+  .big-filter {
+    display: none;
+  }
+
+  .small-filter {
+    margin: 1em 1em 1em 1em;
+  }
+
+  .card-button {
+    margin: 1em 1em 1em 1em;
+  }
+}
+
+.no-logbook-message {
+  margin-top: 4em;
+  text-align: center;
+}

--- a/src/app/proposals/proposal-logbook/proposal-logbook.component.spec.ts
+++ b/src/app/proposals/proposal-logbook/proposal-logbook.component.spec.ts
@@ -1,0 +1,191 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import {
+  ComponentFixture,
+  TestBed,
+  inject,
+  waitForAsync,
+} from "@angular/core/testing";
+
+import { ProposalLogbookComponent } from "./proposal-logbook.component";
+import { Store, StoreModule } from "@ngrx/store";
+import { MockStore, MockActivatedRoute } from "shared/MockStubs";
+import { ActivatedRoute } from "@angular/router";
+import {
+  setTextFilterAction,
+  setDisplayFiltersAction,
+  changePageAction,
+  sortByColumnAction,
+  fetchLogbookAction,
+} from "state-management/actions/logbooks.actions";
+import { Logbook, LogbookInterface } from "shared/sdk";
+import { LogbookFilters } from "state-management/models";
+import { RouterTestingModule } from "@angular/router/testing";
+
+import {
+  PageChangeEvent,
+  SortChangeEvent,
+} from "shared/modules/table/table.component";
+import { MatCardModule } from "@angular/material/card";
+import { MatIconModule } from "@angular/material/icon";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { AppConfigService } from "app-config.service";
+
+const getConfig = () => ({
+  riotBaseUrl: "https://riot.base.com",
+});
+
+describe("DashboardComponent", () => {
+  let component: ProposalLogbookComponent;
+  let fixture: ComponentFixture<ProposalLogbookComponent>;
+
+  let store: MockStore;
+  let dispatchSpy;
+
+  const logbookData: LogbookInterface = {
+    name: "testLogbook",
+    roomId: "testId",
+    messages: [{ message: "test1" }, { message: "test2" }],
+  };
+  const logbook = new Logbook(logbookData);
+
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        schemas: [NO_ERRORS_SCHEMA],
+        declarations: [ProposalLogbookComponent],
+        imports: [
+          BrowserAnimationsModule,
+          MatCardModule,
+          MatExpansionModule,
+          MatIconModule,
+          RouterTestingModule.withRoutes([]),
+          StoreModule.forRoot({}),
+        ],
+      });
+      TestBed.overrideComponent(ProposalLogbookComponent, {
+        set: {
+          providers: [
+            { provide: ActivatedRoute, useClass: MockActivatedRoute },
+            { provide: AppConfigService, useValue: { getConfig } },
+          ],
+        },
+      }).compileComponents();
+
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProposalLogbookComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  beforeEach(inject([Store], (mockStore: MockStore) => {
+    store = mockStore;
+  }));
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe("#onTextSearchChange()", () => {
+    it("should dispatch a setTextFilterAction and a fetchLogbookAction", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const textSearch = "test";
+      component.onTextSearchChange(logbook.name, textSearch);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        setTextFilterAction({ textSearch })
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        fetchLogbookAction({
+          name: logbook.name,
+        })
+      );
+    });
+  });
+
+  describe("#onFilterSelect()", () => {
+    it("should dispatch a setFilterAction and a fetchFilteredEntriesAction", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const filters: LogbookFilters = {
+        textSearch: "",
+        showBotMessages: false,
+        showImages: true,
+        showUserMessages: true,
+        sortField: "timestamp:desc",
+        skip: 0,
+        limit: 25,
+      };
+      const { showBotMessages, showImages, showUserMessages } = filters;
+
+      component.onFilterSelect(logbook.name, filters);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        setDisplayFiltersAction({
+          showBotMessages,
+          showImages,
+          showUserMessages,
+        })
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        fetchLogbookAction({
+          name: logbook.name,
+        })
+      );
+    });
+  });
+
+  describe("#onPageChange()", () => {
+    it("should dispatch a changePageAction and a fetchLogbookAction", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const event: PageChangeEvent = {
+        pageIndex: 1,
+        pageSize: 25,
+        length: 100,
+      };
+
+      component.onPageChange(logbook.name, event);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        changePageAction({ page: event.pageIndex, limit: event.pageSize })
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        fetchLogbookAction({ name: logbook.name })
+      );
+    });
+  });
+
+  describe("#onSortChange()", () => {
+    it("should dispatch a sortByColumnAction and a fetchLogbookAction", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const event: SortChangeEvent = {
+        active: "test",
+        direction: "asc",
+      };
+
+      component.onSortChange(logbook.name, event);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        sortByColumnAction({ column: event.active, direction: event.direction })
+      );
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        fetchLogbookAction({ name: logbook.name })
+      );
+    });
+  });
+});

--- a/src/app/proposals/proposal-logbook/proposal-logbook.component.ts
+++ b/src/app/proposals/proposal-logbook/proposal-logbook.component.ts
@@ -1,0 +1,100 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  Input,
+  ChangeDetectorRef,
+  AfterViewChecked,
+} from "@angular/core";
+import { Store } from "@ngrx/store";
+import { Logbook } from "shared/sdk";
+import { Subscription } from "rxjs";
+import { selectCurrentLogbook, selectLogbooksDashboardPageViewModel } from "state-management/selectors/logbooks.selectors";
+import {
+  fetchLogbookAction,
+  setTextFilterAction,
+  setDisplayFiltersAction,
+  changePageAction,
+  sortByColumnAction,
+  clearLogbookAction,
+} from "state-management/actions/logbooks.actions";
+import { LogbookFilters } from "state-management/models";
+
+
+import {
+  PageChangeEvent,
+  SortChangeEvent,
+} from "shared/modules/table/table.component";
+import { AppConfigService } from "app-config.service";
+
+export interface LogbookData {
+  logbook: Logbook;
+  entriesCount: number;
+  entriesPerPage: number;
+  currentPage: number;
+  filters: LogbookFilters;
+}
+@Component({
+  selector: "app-proposal-logbook",
+  templateUrl: "./proposal-logbook.component.html",
+  styleUrls: ["./proposal-logbook.component.scss"],
+})
+export class ProposalLogbookComponent
+  implements OnInit, OnDestroy, AfterViewChecked {
+  appConfig = this.appConfigService.getConfig();
+  subscriptions: Subscription[] = [];
+
+  @Input() logbook: LogbookData;
+
+  constructor(
+    public appConfigService: AppConfigService,
+    private cdRef: ChangeDetectorRef,
+    private store: Store,
+  ) {}
+
+  onTextSearchChange(proposalId: string, query: string ) {
+    // TODO: query.length return undefined when it is empty
+    const queryText = query.length ? query : "";
+    this.store.dispatch(setTextFilterAction({ textSearch: queryText }));
+    this.store.dispatch(fetchLogbookAction({ name:proposalId }));
+  }
+
+  onFilterSelect(proposalId: string, filters: LogbookFilters) {
+    const { showBotMessages, showImages, showUserMessages } = filters;
+
+    this.store.dispatch(
+      setDisplayFiltersAction({ showBotMessages, showImages, showUserMessages })
+    );
+    this.store.dispatch(fetchLogbookAction({ name:proposalId }));
+  }
+
+  onPageChange(proposalId: string, event: PageChangeEvent) {
+    this.store.dispatch(
+      changePageAction({ page: event.pageIndex, limit: event.pageSize })
+    );
+    this.store.dispatch(fetchLogbookAction({ name:proposalId }));
+  }
+
+  onSortChange(proposalId: string, event: SortChangeEvent) {
+    const { active: column, direction } = event;
+    this.store.dispatch(sortByColumnAction({ column, direction }));
+    this.store.dispatch(fetchLogbookAction({ name:proposalId }));
+  }
+
+  ngOnInit() {
+    this.subscriptions.push(
+      this.store.select(selectCurrentLogbook).subscribe((logbook) => {
+        this.store.dispatch(fetchLogbookAction({name:logbook.name}));
+      })
+    );
+  }
+
+  ngAfterViewChecked() {
+    this.cdRef.detectChanges();
+  }
+
+  ngOnDestroy() {
+    this.store.dispatch(clearLogbookAction());
+    this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+  }
+}

--- a/src/app/proposals/proposal-logbook/proposal-logbook.component.ts
+++ b/src/app/proposals/proposal-logbook/proposal-logbook.component.ts
@@ -9,7 +9,7 @@ import {
 import { Store } from "@ngrx/store";
 import { Logbook } from "shared/sdk";
 import { Subscription } from "rxjs";
-import { selectCurrentLogbook, selectLogbooksDashboardPageViewModel } from "state-management/selectors/logbooks.selectors";
+import { selectCurrentLogbook } from "state-management/selectors/logbooks.selectors";
 import {
   fetchLogbookAction,
   setTextFilterAction,

--- a/src/app/proposals/proposals.module.ts
+++ b/src/app/proposals/proposals.module.ts
@@ -34,6 +34,7 @@ import { MatDatepickerModule } from "@angular/material/datepicker";
 import { MatNativeDateModule } from "@angular/material/core";
 import { LogbookEffects } from "state-management/effects/logbooks.effects";
 import { logbooksReducer } from "state-management/reducers/logbooks.reducer";
+import { ProposalLogbookComponent } from "./proposal-logbook/proposal-logbook.component";
 
 @NgModule({
   imports: [
@@ -65,6 +66,7 @@ import { logbooksReducer } from "state-management/reducers/logbooks.reducer";
     ProposalDetailComponent,
     ProposalFilterComponent,
     ProposalDashboardComponent,
+    ProposalLogbookComponent
   ],
   exports: [],
   providers: [DatePipe, FileSizePipe, SlicePipe],

--- a/src/app/proposals/view-proposal-page/view-proposal-page.component.html
+++ b/src/app/proposals/view-proposal-page/view-proposal-page.component.html
@@ -33,6 +33,6 @@
       Logbook
     </ng-template>
 
-    <app-logbooks-dashboard [proposal_logbook]="proposal_logbook$ | async" [proposal_dataset]="tableData[0]"></app-logbooks-dashboard>
+    <app-proposal-logbook [logbook]='logbook$ | async'></app-proposal-logbook>
   </mat-tab>
 </mat-tab-group>

--- a/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
+++ b/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
@@ -36,7 +36,7 @@ export interface TableData {
 })
 export class ViewProposalPageComponent implements OnInit, OnDestroy {
   vm$ = this.store.select(selectViewProposalPageViewModel);
-  proposal_logbook$ = this.store.select(selectLogbooksDashboardPageViewModel);
+  logbook$ = this.store.select(selectLogbooksDashboardPageViewModel);
   appConfig = this.appConfigService.getConfig();
 
   proposal: Proposal = new Proposal();


### PR DESCRIPTION
## Description

- feat: created new logbook component for proposal page
- fix: fixed logbook doesn't display issue when proposal have no dataset.
- fix: fixed logbook filter search bar bug  - when search query is empty, it returns event method instead of string value.


## Motivation
New proposal logbook component makes api call based on only proposal id.
Using mixed logic of dataset pid & proposal id based logbook call increases complexity of the component and makes the code hard to maintain.


## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

