### PR TITLE
Added pid to the main dataset table

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.html
+++ b/src/app/datasets/dataset-table/dataset-table.component.html
@@ -59,6 +59,24 @@
       </mat-cell>
     </ng-container>
 
+    <!-- Pid Column -->
+    <ng-container
+      matColumnDef="standard_pid"
+      style="align-content: center;"
+    >
+      <mat-header-cell *matHeaderCellDef mat-sort-header>
+        <div fxLayout="column" style="align-items: center;">
+          <div>
+            <mat-icon>perm_identity</mat-icon>
+          </div>
+          <div>Pid</div>
+        </div>
+      </mat-header-cell>
+      <mat-cell class="datasetName" *matCellDef="let dataset">
+        {{ dataset.pid }}
+      </mat-cell>
+    </ng-container>
+  
     <!-- Name Column -->
     <ng-container
       matColumnDef="standard_datasetName"

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -26,68 +26,74 @@
       "enabled": true
     },
     {
-      "name": "datasetName",
+      "name": "pid",
       "order": 1,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "runNumber",
+      "name": "datasetName",
       "order": 2,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "sourceFolder",
+      "name": "runNumber",
       "order": 3,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "size",
+      "name": "sourceFolder",
       "order": 4,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "creationTime",
+      "name": "size",
       "order": 5,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "type",
+      "name": "creationTime",
       "order": 6,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "image",
+      "name": "type",
       "order": 7,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "metadata",
+      "name": "image",
       "order": 8,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "proposalId",
+      "name": "metadata",
       "order": 9,
       "type": "standard",
       "enabled": true
     },
     {
-      "name": "ownerGroup",
+      "name": "proposalId",
       "order": 10,
+      "type": "standard",
+      "enabled": true
+    },
+    {
+      "name": "ownerGroup",
+      "order": 11,
       "type": "standard",
       "enabled": false
     },
     {
       "name": "dataStatus",
-      "order": 11,
+      "order": 12,
       "type": "standard",
       "enabled": false
     }


### PR DESCRIPTION
## Description
This PR add the dataset pid as a possible column in the dtaset list

## Motivation
When looking at a list of datasets, at times is useful to be able to visualize the pid of the dataset.

## Changes:

* changed default configuration to include pid
* added element to dataset list element

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

