### PR TITLE
fix: do not make PUT/POST UserSettings request on visiting datasets table

### DIFF
--- a/src/app/logbooks/logbooks-detail/logbooks-detail.component.html
+++ b/src/app/logbooks/logbooks-detail/logbooks-detail.component.html
@@ -44,7 +44,7 @@
         </div>
       </mat-header-cell>
       <mat-cell *matCellDef="let message">
-        {{ message.sender | slice: 1:message.sender.indexOf(":") }}
+        {{ message.senderName }}
       </mat-cell>
     </ng-container>
 
@@ -113,7 +113,7 @@
           </mat-expansion-panel-header>
           <div>
             <div class="sender">
-              {{ message.sender | slice: 1:message.sender.indexOf(":") }},
+              {{ message.senderName }},
               {{ message.origin_server_ts | date: "HH:mm" }}:
             </div>
             <div>
@@ -162,7 +162,7 @@
               "
             >
               <div class="sender">
-                {{ value.sender | slice: 1:value.sender.indexOf(":") }},
+                {{ value.senderName }},
                 {{ value.origin_server_ts | date: "HH:mm" }}:
               </div>
               <div>

--- a/src/app/state-management/effects/datasets.effects.spec.ts
+++ b/src/app/state-management/effects/datasets.effects.spec.ts
@@ -23,7 +23,6 @@ import {
 import {
   loadingAction,
   loadingCompleteAction,
-  addCustomColumnsAction,
   updateUserSettingsAction,
 } from "state-management/actions/user.actions";
 import { ScientificCondition } from "state-management/models";

--- a/src/app/state-management/effects/datasets.effects.spec.ts
+++ b/src/app/state-management/effects/datasets.effects.spec.ts
@@ -272,21 +272,6 @@ describe("DatasetEffects", () => {
     });
   });
 
-  describe("addMetadataColumns$", () => {
-    it("should dispatch an addColumnAction", () => {
-      const metadataKeys = ["test"];
-      const action = fromActions.fetchMetadataKeysCompleteAction({
-        metadataKeys,
-      });
-      const outcome = addCustomColumnsAction({ names: ["test"] });
-
-      actions = hot("-a", { a: action });
-
-      const expected = cold("-b", { b: outcome });
-      expect(effects.addMetadataColumns$).toBeObservable(expected);
-    });
-  });
-
   describe("fetchDataset$", () => {
     const pid = "testPid";
 

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -120,15 +120,6 @@ export class DatasetEffects {
     );
   });
 
-  // addMetadataColumns$ = createEffect(() => {
-  //   return this.actions$.pipe(
-  //     ofType(fromActions.fetchMetadataKeysCompleteAction),
-  //     switchMap(({ metadataKeys }) =>
-  //       of(addCustomColumnsAction({ names: metadataKeys }))
-  //     )
-  //   );
-  // });
-
   fetchDataset$ = createEffect(() => {
     return this.actions$.pipe(
       ofType(fromActions.fetchDatasetAction),

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -33,7 +33,6 @@ import {
   logoutCompleteAction,
   loadingAction,
   loadingCompleteAction,
-  addCustomColumnsAction,
   updateUserSettingsAction,
 } from "state-management/actions/user.actions";
 
@@ -121,14 +120,14 @@ export class DatasetEffects {
     );
   });
 
-  addMetadataColumns$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(fromActions.fetchMetadataKeysCompleteAction),
-      switchMap(({ metadataKeys }) =>
-        of(addCustomColumnsAction({ names: metadataKeys }))
-      )
-    );
-  });
+  // addMetadataColumns$ = createEffect(() => {
+  //   return this.actions$.pipe(
+  //     ofType(fromActions.fetchMetadataKeysCompleteAction),
+  //     switchMap(({ metadataKeys }) =>
+  //       of(addCustomColumnsAction({ names: metadataKeys }))
+  //     )
+  //   );
+  // });
 
   fetchDataset$ = createEffect(() => {
     return this.actions$.pipe(

--- a/src/app/state-management/effects/user.effects.spec.ts
+++ b/src/app/state-management/effects/user.effects.spec.ts
@@ -636,18 +636,6 @@ describe("UserEffects", () => {
         expect(effects.updateUserColumns$).toBeObservable(expected);
       });
     });
-
-    describe("ofType addCustomColumnsCompleteAction", () => {
-      it("should dispatch an updateUserSettingsAction", () => {
-        const action = fromActions.addCustomColumnsCompleteAction();
-        const outcome = fromActions.updateUserSettingsAction({ property });
-
-        actions = hot("-a", { a: action });
-
-        const expected = cold("-b", { b: outcome });
-        expect(effects.updateUserColumns$).toBeObservable(expected);
-      });
-    });
   });
 
   describe("updateUserSettings$", () => {

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -305,7 +305,6 @@ export class UserEffects {
         fromActions.selectColumnAction,
         fromActions.deselectColumnAction,
         fromActions.deselectAllCustomColumnsAction,
-        fromActions.addCustomColumnsCompleteAction
       ),
       concatLatestFrom(() => this.columns$),
       map(([action, columns]) => columns),


### PR DESCRIPTION
## Description

Update of user settings was done on every visit of the dataset table. We prevent that and fix some unnecessary actions.

## Motivation

Update user settings called unnecessary on every visit of main page

## Fixes:

* https://jira.esss.lu.se/browse/SWAP-3174

## Changes:

* changes made

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

