### PR TITLE
Change dataset details page PID text to a input field with copy button

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -68,7 +68,7 @@
               <th>PID</th>
               <td>
                 <mat-form-field class="full-width">
-                  <input matInput type="text" [value]="dataset.pid">
+                  <input matInput type="text" [value]="dataset.pid" disabled>
                   <button matSuffix mat-icon-button aria-label="copy" (click)="copyIntoClipboard(dataset.pid)">
                     <mat-icon>content_copy</mat-icon>
                   </button>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -66,7 +66,14 @@
             </tr>
             <tr>
               <th>PID</th>
-              <td>{{ dataset.pid }}</td>
+              <td>
+                <mat-form-field class="full-width">
+                  <input matInput type="text" [value]="dataset.pid">
+                  <button matSuffix mat-icon-button aria-label="copy" (click)="copyIntoClipboard(dataset.pid)">
+                    <mat-icon>content_copy</mat-icon>
+                  </button>
+                </mat-form-field>
+              </td>
             </tr>
             <tr *ngIf="dataset.type as value">
               <th>Type</th>

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -39,6 +39,8 @@ import {
   FormGroup,
   Validators,
 } from "@angular/forms";
+import {Clipboard} from "@angular/cdk/clipboard";
+
 /**
  * Component to show details for a data set, using the
  * form component
@@ -318,6 +320,6 @@ export class DatasetDetailComponent
   }
 
   copyIntoClipboard(pid: string) {
-    this.clipboard.writeText(pid);
+    this.clipboard.copy(pid);
   }
 }

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -82,7 +82,8 @@ export class DatasetDetailComponent
     public dialog: MatDialog,
     private store: Store,
     private router: Router,
-    private fb: FormBuilder
+    private fb: FormBuilder,
+    private clipboard: Clipboard
   ) {}
 
   ngOnInit() {
@@ -314,5 +315,9 @@ export class DatasetDetailComponent
     this.subscriptions.forEach((subscription) => {
       subscription.unsubscribe();
     });
+  }
+
+  copyIntoClipboard(pid: string) {
+    this.clipboard.writeText(pid);
   }
 }


### PR DESCRIPTION
## Description

On the detail page of a dataset is a PID. Normaly the user needs to select manually the PID. This PR adds a input field with simple copy option. 

## Motivation

To deliver more easy a dataset PID add a UX improvement.

## Fixes:

* Nothing

## Changes:

* UX improvement

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [X] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

Before:
![image](https://user-images.githubusercontent.com/6745190/232890927-d1d865bb-ab04-4c55-93bc-8aaa6efcc57b.png)

After:
![image](https://user-images.githubusercontent.com/6745190/232890769-f1952a25-0ba3-4844-a829-5fd56b603cba.png)

