### PR TITLE
add dataset id to zip data

### DIFF
--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -49,6 +49,7 @@
       #downloadAllForm
     >
       <input type="hidden" name="jwt" [value]="jwt?.jwt" />
+      <input type="hidden" name="dataset" [value]="datasetPid"/>
       <input type="hidden" name="directory" [value]="sourcefolder" />
       <input
         *ngFor="let file of getAllFiles(); index as i"
@@ -79,6 +80,7 @@
       #downloadSelectedForm
     >
       <input type="hidden" name="jwt" [value]="jwt?.jwt" />
+      <input type="hidden" name="dataset" [value]="datasetPid"/>
       <input type="hidden" name="directory" [value]="sourcefolder" />
       <input
         *ngFor="let file of getSelectedFiles(); index as i"


### PR DESCRIPTION
# Description

Add the dataset id as data pushed to the zip service

## Motivation

The dataset id can(together with the jwt that is already passed) be used to validate access to the data.

## Changes:

* add dataset id as hidden field

## Tests included/Docs Updated?

- [ -] Included for each change/fix?
- [ X] Passing? (Merge will not be approved unless this is checked) 
- [ -] Docs updated?
- [- ] New packages used/requires npm install? 
- [- ] Toggle added for new features?
- [- ] Requires update of SciCat backend API?

