### PR TITLE
fix: click origdatablock in Files page without dataset redirects to w…

### DIFF
--- a/src/app/shared/modules/shared-table/shared-table.component.html
+++ b/src/app/shared/modules/shared-table/shared-table.component.html
@@ -113,7 +113,7 @@
           ><a
             [ngClass]="{ disabled: !row.datasetExist }"
             [routerLink]="['/datasets/', getPropertyByPath(row, column.id)]"
-            >{{ row.datasetExist ? getPropertyByPath(row, column.id) : "-" }}</a
+            >{{ getPropertyByPath(row, column.id) }}</a
           >
         </ng-container>
         <ng-container *ngSwitchDefault class="ellipsis">

--- a/src/app/shared/modules/shared-table/shared-table.component.html
+++ b/src/app/shared/modules/shared-table/shared-table.component.html
@@ -5,18 +5,28 @@
 </div>
 
 <!-- title -->
-<div *ngIf=title class="shared-table-title">
-  <div>{{title}}</div>
+<div *ngIf="title" class="shared-table-title">
+  <div>{{ title }}</div>
 </div>
 
 <!-- Top ToolBar Start-->
 <div class="table-toolbar" fxLayout="row" fxLayoutAlign="space-between center">
   <mat-form-field [formGroup]="filterForm" appearance="standard">
     <mat-icon matPrefix>search</mat-icon>
-    <input type="text" matInput placeholder="global word-search" formControlName="globalSearch">
+    <input
+      type="text"
+      matInput
+      placeholder="global word-search"
+      formControlName="globalSearch"
+    />
   </mat-form-field>
 
-  <mat-paginator [length]="dataSource.count$ | async" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" showFirstLastButtons>
+  <mat-paginator
+    [length]="dataSource.count$ | async"
+    [pageSize]="pageSize"
+    [pageSizeOptions]="pageSizeOptions"
+    showFirstLastButtons
+  >
   </mat-paginator>
   <button mat-icon-button (click)="exportToExcel()">
     <mat-icon>cloud_download</mat-icon>
@@ -32,7 +42,7 @@
   </button>
   <mat-menu #menu="matMenu">
     <button mat-menu-item (click)="toggleHideFilterFlag()">
-      <span>{{ hideFilterFlag? 'Show Filters' :'Hide Filters'}}</span>
+      <span>{{ hideFilterFlag ? "Show Filters" : "Hide Filters" }}</span>
     </button>
     <button mat-menu-item (click)="resetFilters()">
       <span>Reset Filters</span>
@@ -42,12 +52,22 @@
 <!-- Top ToolBar End -->
 
 <!-- Table Definition Start -->
-<mat-table #dataTable class="mat-elevation-z2" [dataSource]="dataSource" matSort matSortStart="desc" multiTemplateDataRows>
-
+<mat-table
+  #dataTable
+  class="mat-elevation-z2"
+  [dataSource]="dataSource"
+  matSort
+  matSortStart="desc"
+  multiTemplateDataRows
+>
   <!-- Toggle Button For Hidden Filters Start -->
   <ng-container matColumnDef="hidden-filter-trigger">
-    <mat-header-cell  *matHeaderCellDef="let row" class="trigger-column">
-      <span class="btnToggleExpand" (click)="toggleExpandFlag($event,'filters')" [ngClass]="[expandedElement['filters'] ?  'active' : 'inActive']"></span>
+    <mat-header-cell *matHeaderCellDef="let row" class="trigger-column">
+      <span
+        class="btnToggleExpand"
+        (click)="toggleExpandFlag($event, 'filters')"
+        [ngClass]="[expandedElement['filters'] ? 'active' : 'inActive']"
+      ></span>
     </mat-header-cell>
   </ng-container>
   <!-- Toggle Button For Hidden Filter End -->
@@ -57,30 +77,49 @@
     <mat-header-cell *matHeaderCellDef class="trigger-column first-header-cell">
       <mat-icon>menu</mat-icon>
     </mat-header-cell>
-    <mat-cell *matCellDef="let row; let i = dataIndex;" class="trigger-column">
-      <span (click)="toggleExpandFlag($event, row.uniqueId);"
-        [ngClass]="[expandedElement[row.uniqueId] ?  'active' : 'inActive']" class="btnToggleExpand"></span>
+    <mat-cell *matCellDef="let row; let i = dataIndex" class="trigger-column">
+      <span
+        (click)="toggleExpandFlag($event, row.uniqueId)"
+        [ngClass]="[expandedElement[row.uniqueId] ? 'active' : 'inActive']"
+        class="btnToggleExpand"
+      ></span>
     </mat-cell>
   </ng-container>
   <!-- Toggle Button Button For Hidden Columns End -->
 
   <!-- Cell Definition For Visible Columns Start -->
-  <ng-container [matColumnDef]="column.id" *ngFor="let column of visibleColumns">
-    <mat-header-cell *matHeaderCellDef class="col-name shared-table-{{column.matchMode}} first-header-cell">
+  <ng-container
+    [matColumnDef]="column.id"
+    *ngFor="let column of visibleColumns"
+  >
+    <mat-header-cell
+      *matHeaderCellDef
+      class="col-name shared-table-{{ column.matchMode }} first-header-cell"
+    >
       <div fxLayout="row" fxLayoutAlign="space-between center">
         <mat-icon>{{ column.icon }}</mat-icon>
-        <span mat-sort-header [disabled]="!column.canSort">{{ column.label | titleCase }}</span>
+        <span mat-sort-header [disabled]="!column.canSort">{{
+          column.label | titleCase
+        }}</span>
       </div>
     </mat-header-cell>
 
     <mat-cell *matCellDef="let row" [fxFlex]="column.width + 'px'">
       <ng-container [ngSwitch]="column.type">
-        <ng-container *ngSwitchCase="'image'"><img [src]=row[column.id] /></ng-container>
-        <ng-container *ngSwitchCase="'dataseturl'"><a
-            [routerLink]="['/datasets/',getPropertyByPath(row,column.id)]">{{ getPropertyByPath(row,column.id) }}</a>
+        <ng-container *ngSwitchCase="'image'"
+          ><img [src]="row[column.id]"
+        /></ng-container>
+        <ng-container *ngSwitchCase="'dataseturl'"
+          ><a
+            [ngClass]="{ disabled: !row.datasetExist }"
+            [routerLink]="['/datasets/', getPropertyByPath(row, column.id)]"
+            >{{ row.datasetExist ? getPropertyByPath(row, column.id) : "-" }}</a
+          >
         </ng-container>
         <ng-container *ngSwitchDefault class="ellipsis">
-          {{ getPropertyByPath(row,column.id) | newDynamicPipe: column.format }}
+          {{
+            getPropertyByPath(row, column.id) | newDynamicPipe: column.format
+          }}
         </ng-container>
       </ng-container>
     </mat-cell>
@@ -89,19 +128,34 @@
 
   <!-- Cell Definition For Hidden Columns Start -->
   <ng-container matColumnDef="hidden">
-    <mat-cell *matCellDef="let row;let i = dataIndex;" class="matCell" fxLayout="column" fxLayoutAlign="center start">
+    <mat-cell
+      *matCellDef="let row; let i = dataIndex"
+      class="matCell"
+      fxLayout="column"
+      fxLayoutAlign="center start"
+    >
       <p *ngFor="let hiddenColumn of hiddenColumns" fxLayout="row" class="m8">
-        <strong>
-          {{ hiddenColumn.label }}:
-        </strong>
+        <strong> {{ hiddenColumn.label }}: </strong>
         <span>
           <ng-container [ngSwitch]="hiddenColumn.type">
-            <ng-container *ngSwitchCase="'image'"><img [src]=row[hiddenColumn.id] /></ng-container>
-            <ng-container *ngSwitchCase="'dataseturl'"><a
-                [routerLink]="['/datasets/',getPropertyByPath(row,hiddenColumn.id)]">{{ getPropertyByPath(row,hiddenColumn.id) }}</a>
+            <ng-container *ngSwitchCase="'image'"
+              ><img [src]="row[hiddenColumn.id]"
+            /></ng-container>
+            <ng-container *ngSwitchCase="'dataseturl'"
+              ><a
+                [routerLink]="[
+                  '/datasets/',
+                  getPropertyByPath(row, hiddenColumn.id)
+                ]"
+                >{{ getPropertyByPath(row, hiddenColumn.id) }}</a
+              >
             </ng-container>
             <ng-container *ngSwitchDefault>
-              {{ getPropertyByPath(row,hiddenColumn.id) | newDynamicPipe: hiddenColumn.format }}</ng-container>
+              {{
+                getPropertyByPath(row, hiddenColumn.id)
+                  | newDynamicPipe: hiddenColumn.format
+              }}</ng-container
+            >
           </ng-container>
         </span>
       </p>
@@ -110,21 +164,50 @@
   <!-- Cell Definition For Visible Columns End -->
 
   <!-- Cell Definition For Visible Filter Start -->
-  <ng-container matColumnDef="{{column.id}}-filter" *ngFor="let column of visibleColumns">
+  <ng-container
+    matColumnDef="{{ column.id }}-filter"
+    *ngFor="let column of visibleColumns"
+  >
     <mat-header-cell *matHeaderCellDef="let row">
-      <mat-form-field [formGroup]="filterForm" appearance="outline" *ngIf="column.matchMode === 'between'" class="max-width">
+      <mat-form-field
+        [formGroup]="filterForm"
+        appearance="outline"
+        *ngIf="column.matchMode === 'between'"
+        class="max-width"
+      >
         <mat-date-range-input [rangePicker]="rangePicker">
-          <input name="{{ column.id + '.start' }}" matStartDate placeholder="Start date" [formControlName]="column.id + '.start'"
-            >
-          <input name="{{ column.id + '.end'}}" matEndDate placeholder="End date" [formControlName]="column.id + '.end'">
+          <input
+            name="{{ column.id + '.start' }}"
+            matStartDate
+            placeholder="Start date"
+            [formControlName]="column.id + '.start'"
+          />
+          <input
+            name="{{ column.id + '.end' }}"
+            matEndDate
+            placeholder="End date"
+            [formControlName]="column.id + '.end'"
+          />
         </mat-date-range-input>
-        <mat-datepicker-toggle matSuffix [for]="rangePicker"></mat-datepicker-toggle>
-        <mat-date-range-picker #rangePicker>
-        </mat-date-range-picker>
+        <mat-datepicker-toggle
+          matSuffix
+          [for]="rangePicker"
+        ></mat-datepicker-toggle>
+        <mat-date-range-picker #rangePicker> </mat-date-range-picker>
       </mat-form-field>
 
-      <mat-form-field [formGroup]="filterForm" appearance="outline" *ngIf="column.matchMode !== 'between'">
-        <input [formControlName]="column.id" matInput autocomplete="off" name="{{ column.id }}" placeholder="{{ column.matchMode }}" />
+      <mat-form-field
+        [formGroup]="filterForm"
+        appearance="outline"
+        *ngIf="column.matchMode !== 'between'"
+      >
+        <input
+          [formControlName]="column.id"
+          matInput
+          autocomplete="off"
+          name="{{ column.id }}"
+          placeholder="{{ column.matchMode }}"
+        />
       </mat-form-field>
     </mat-header-cell>
   </ng-container>
@@ -132,21 +215,56 @@
 
   <!-- Cell Definition For Hidden Filter Start -->
   <ng-container matColumnDef="hidden-filter">
-    <mat-header-cell *matHeaderCellDef="let row" fxLayout="row" fxLayoutAlign="start" class="over-flow-scroll">
-      <div *ngFor="let hiddenColumn of hiddenColumns" fxLayout="column" class="padding-right-1em">
+    <mat-header-cell
+      *matHeaderCellDef="let row"
+      fxLayout="row"
+      fxLayoutAlign="start"
+      class="over-flow-scroll"
+    >
+      <div
+        *ngFor="let hiddenColumn of hiddenColumns"
+        fxLayout="column"
+        class="padding-right-1em"
+      >
         <p>
-          <strong>{{hiddenColumn.label}}</strong>
-        <span>
-          <mat-form-field [formGroup]="filterForm" appearance="outline" *ngIf="hiddenColumn.matchMode==='between'" class="max-width">
-            <mat-date-range-input [rangePicker]="rangePicker">
-              <input  matStartDate placeholder="Start date" [formControlName]="hiddenColumn.id + '.start'">
-              <input matEndDate placeholder="End date" [formControlName]="hiddenColumn.id + '.end'">
-            </mat-date-range-input>
-            <mat-datepicker-toggle matSuffix [for]="rangePicker"></mat-datepicker-toggle>
+          <strong>{{ hiddenColumn.label }}</strong>
+          <span>
+            <mat-form-field
+              [formGroup]="filterForm"
+              appearance="outline"
+              *ngIf="hiddenColumn.matchMode === 'between'"
+              class="max-width"
+            >
+              <mat-date-range-input [rangePicker]="rangePicker">
+                <input
+                  matStartDate
+                  placeholder="Start date"
+                  [formControlName]="hiddenColumn.id + '.start'"
+                />
+                <input
+                  matEndDate
+                  placeholder="End date"
+                  [formControlName]="hiddenColumn.id + '.end'"
+                />
+              </mat-date-range-input>
+              <mat-datepicker-toggle
+                matSuffix
+                [for]="rangePicker"
+              ></mat-datepicker-toggle>
               <mat-date-range-picker #rangePicker></mat-date-range-picker>
             </mat-form-field>
-            <mat-form-field [formGroup]="filterForm" appearance="outline" *ngIf="hiddenColumn.matchMode !== 'between'">
-              <input [formControlName]="hiddenColumn.id" matInput autocomplete="off" name="{{ hiddenColumn.id }}" placeholder="{{ hiddenColumn.matchMode }}" />
+            <mat-form-field
+              [formGroup]="filterForm"
+              appearance="outline"
+              *ngIf="hiddenColumn.matchMode !== 'between'"
+            >
+              <input
+                [formControlName]="hiddenColumn.id"
+                matInput
+                autocomplete="off"
+                name="{{ hiddenColumn.id }}"
+                placeholder="{{ hiddenColumn.matchMode }}"
+              />
             </mat-form-field>
           </span>
         </p>
@@ -155,22 +273,40 @@
   </ng-container>
   <!-- Cell Definition For Hidden Filters End -->
 
-  <mat-header-row *matHeaderRowDef="visibleColumnsIds; sticky: true" class="matHeaderRow first-header-row"></mat-header-row>
+  <mat-header-row
+    *matHeaderRowDef="visibleColumnsIds; sticky: true"
+    class="matHeaderRow first-header-row"
+  ></mat-header-row>
 
   <!-- Row definition for filter columns -->
-  <mat-header-row *matHeaderRowDef="getFilterColumns(); sticky: true" [class.hidden]="hideFilterFlag"></mat-header-row>
+  <mat-header-row
+    *matHeaderRowDef="getFilterColumns(); sticky: true"
+    [class.hidden]="hideFilterFlag"
+  ></mat-header-row>
 
   <!-- Row definition for hidden filter columns on small screen -->
-  <mat-header-row *matHeaderRowDef="['hidden-filter']; sticky: true" [@detailExpand]="getExpandFlag('filters')"></mat-header-row>
+  <mat-header-row
+    *matHeaderRowDef="['hidden-filter']; sticky: true"
+    [@detailExpand]="getExpandFlag('filters')"
+  ></mat-header-row>
 
-  <mat-row *matRowDef="let row; let i = dataIndex; columns: visibleColumnsIds;" class="matRowVisible visible-row-{{row.uniqueId}}" (click)="onRowClick(row)"></mat-row>
+  <mat-row
+    *matRowDef="let row; let i = dataIndex; columns: visibleColumnsIds"
+    class="matRowVisible visible-row-{{ row.uniqueId }}"
+    (click)="onRowClick(row)"
+  ></mat-row>
 
   <!-- Body row definition for hidden columns -->
-  <mat-row *matRowDef="let row; let i = dataIndex; columns: ['hidden'];"
-    [@detailExpand]="getExpandFlag(row.uniqueId)" style="overflow: hidden;"
-    class="matRowHidden hidden-row-{{row.uniqueId}} hidColLength-{{hiddenColumns.length}}"
+  <mat-row
+    *matRowDef="let row; let i = dataIndex; columns: ['hidden']"
+    [@detailExpand]="getExpandFlag(row.uniqueId)"
+    style="overflow: hidden"
+    class="matRowHidden hidden-row-{{ row.uniqueId }} hidColLength-{{
+      hiddenColumns.length
+    }}"
     [class.hidden]="getExpandFlag(row.uniqueId) === 'collapsed'"
-    [ngClass]="expandedElement[row.uniqueId] ? 'expanded' : 'collapsed'">
+    [ngClass]="expandedElement[row.uniqueId] ? 'expanded' : 'collapsed'"
+  >
   </mat-row>
 </mat-table>
 <!-- Table Definition End -->

--- a/src/app/shared/modules/shared-table/shared-table.component.scss
+++ b/src/app/shared/modules/shared-table/shared-table.component.scss
@@ -1,32 +1,42 @@
 .m8 {
   margin: 8px;
 }
-.padding-right-1em{
+.padding-right-1em {
   padding-right: 1em;
 }
-::ng-deep .table-toolbar{
-  .mat-paginator-range-label{
+::ng-deep .table-toolbar {
+  .mat-paginator-range-label {
     // Hide range label on small screen
     @media only screen and (max-width: 1279px) {
       display: none;
     }
   }
-  mat-form-field{
+  mat-form-field {
     flex-grow: 1;
   }
 }
 
-.over-flow-scroll{
+.over-flow-scroll {
   overflow-x: scroll;
 }
 
-::ng-deep .table-toolbar mat-form-field.mat-form-field-appearance-standard .mat-form-field-flex {
-  padding-top:0;
+::ng-deep
+  .table-toolbar
+  mat-form-field.mat-form-field-appearance-standard
+  .mat-form-field-flex {
+  padding-top: 0;
 }
 
 // Align search icon with placeholder
-::ng-deep .table-toolbar mat-form-field .mat-form-field-prefix, .mat-form-field-suffix {
+::ng-deep .table-toolbar mat-form-field .mat-form-field-prefix,
+.mat-form-field-suffix {
   align-self: flex-end;
+}
+
+.disabled {
+  color: black;
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 .expanded {
@@ -47,7 +57,7 @@
 }
 
 .btnToggleExpand.active:before {
-  content: '-';
+  content: "-";
   background-color: red;
 }
 
@@ -65,9 +75,9 @@
   box-sizing: content-box;
   text-align: center;
   text-indent: 0 !important;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: "Courier New", Courier, monospace;
   line-height: 14px;
-  content: '+';
+  content: "+";
   background-color: green;
 }
 
@@ -80,7 +90,7 @@
   transform: translateX(-50%) translateY(-50%);
 }
 
-mat-cell>span.ellipsis {
+mat-cell > span.ellipsis {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -92,19 +102,20 @@ div.shared-table-title {
   font-size: 20px;
 }
 
-.trigger-column{
+.trigger-column {
   max-width: 36px;
 }
 
 //Styling for filter columns and row
 ::ng-deep .mat-table {
-  mat-header-cell, mat-cell{
+  mat-header-cell,
+  mat-cell {
     padding-right: 1em;
   }
-  mat-form-field{
-    width:100%;
+  mat-form-field {
+    width: 100%;
   }
-  .mat-cell{
+  .mat-cell {
     word-break: break-word;
   }
   .mat-form-field-appearance-outline {
@@ -119,7 +130,7 @@ div.shared-table-title {
     padding-bottom: 0em;
   }
   // Align Start date and End date
-  .mat-date-range-input-container{
+  .mat-date-range-input-container {
     align-items: inherit;
   }
 }

--- a/src/app/shared/modules/shared-table/shared-table.component.scss
+++ b/src/app/shared/modules/shared-table/shared-table.component.scss
@@ -35,6 +35,7 @@
 
 .disabled {
   color: black;
+  text-decoration: line-through;
   opacity: 0.3;
   pointer-events: none;
 }


### PR DESCRIPTION
…rong page

## Description

In the Files page, disabled anchor tag on-click effect based on the boolean value of datasetExist field for origDatablock.

## Motivation

If an originalDatablock is not attached to any dataset, it should not be clickable and should be highlighted

## Fixes:
<img width="1646" alt="image" src="https://github.com/SciCatProject/frontend/assets/78078898/de1d8961-e1cb-4198-8e2b-f205729bc001">




## Changes:

https://github.com/SciCatProject/scicat-backend-next/pull/507

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

