### PR TITLE
go to /login once logged out directly in the action and not in the component

### DIFF
--- a/scripts/local.proxy.config.json
+++ b/scripts/local.proxy.config.json
@@ -1,8 +1,8 @@
 {
   "/api/v3/*": {
-  "target": "http://localhost:3000",
-  "secure": false,
-  "logLevel": "debug",
-  "changeOrigin": true
-}
+    "target": "http://localhost:3000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true
+  }
 }

--- a/src/app/_layout/app-header/app-header.component.ts
+++ b/src/app/_layout/app-header/app-header.component.ts
@@ -38,8 +38,6 @@ export class AppHeaderComponent implements OnInit {
 
   logout(): void {
     this.store.dispatch(logoutAction());
-
-    this.router.navigateByUrl("/login");
   }
 
   ngOnInit() {

--- a/src/app/state-management/effects/user.effects.spec.ts
+++ b/src/app/state-management/effects/user.effects.spec.ts
@@ -422,7 +422,7 @@ describe("UserEffects", () => {
 
       expect(effects.logoutNavigate$).toBeObservable(actions);
       expect(router.navigate).toHaveBeenCalledTimes(1);
-      expect(router.navigate).toHaveBeenCalledWith([""]);
+      expect(router.navigate).toHaveBeenCalledWith(["/login"]);
     });
   });
 

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -223,7 +223,7 @@ export class UserEffects {
     () => {
       return this.actions$.pipe(
         ofType(fromActions.logoutCompleteAction),
-        tap(() => this.router.navigate([""]))
+        tap(() => this.router.navigate(["/login"]))
       );
     },
     { dispatch: false }


### PR DESCRIPTION
## Description

Use the login route after logout is completed instead of calling it twice.

## Motivation

Login route was called twice instead of making it the right way. This was because the logout endpoint wasn't returning any response. But that is fixed here: https://github.com/SciCatProject/scicat-backend-next/pull/518

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

