### PR TITLE
add auth token to zip service

### DIFF
--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -48,6 +48,7 @@
       style="display: inline"
       #downloadAllForm
     >
+      <input type="hidden" name="auth_token" [value]="auth_token" />
       <input type="hidden" name="jwt" [value]="jwt?.jwt" />
       <input type="hidden" name="dataset" [value]="datasetPid"/>
       <input type="hidden" name="directory" [value]="sourcefolder" />
@@ -80,6 +81,7 @@
       #downloadSelectedForm
     >
       <input type="hidden" name="jwt" [value]="jwt?.jwt" />
+      <input type="hidden" name="auth_token" [value]="auth_token" />
       <input type="hidden" name="dataset" [value]="datasetPid"/>
       <input type="hidden" name="directory" [value]="sourcefolder" />
       <input

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -85,6 +85,7 @@ export class DatafilesComponent
   maxFileSize: number | null = this.appConfig.maxDirectDownloadSize;
   sftpHost: string | null = this.appConfig.sftpHost;
   jwt: any;
+  auth_token:any;
 
   tableColumns: TableColumn[] = [
     {
@@ -116,7 +117,7 @@ export class DatafilesComponent
     private store: Store,
     private cdRef: ChangeDetectorRef,
     private dialog: MatDialog,
-    private userApi: UserApi
+    private userApi: UserApi,
   ) {}
 
   onPageChange(event: PageChangeEvent) {
@@ -231,6 +232,8 @@ export class DatafilesComponent
   }
 
   downloadFiles(form: "downloadAllForm" | "downloadSelectedForm") {
+    this.auth_token = this.userApi.getCurrentToken().id;
+    this[`${form}Element`].nativeElement.auth_token.value= this.auth_token;
     if (!this.jwt) {
       this.subscriptions.push(
         this.userApi.jwt().subscribe((jwt) => {


### PR DESCRIPTION
## Description

To allow the zip-service full evaluation of data access permissions the JWT seems not to be sufficient

## Motivation

In order to allow the zipservice access to the dataset api, the auth token is required, the jwt was not sufficient in this case.


Probably the use of a 'simple form' should also be replaced with an ajax post request, I'll look into this.

## Fixes:

*  add the auth token to the passed data

## Tests included/Docs Updated?

- [ - ] Included for each change/fix?
- [ X ] Passing? (Merge will not be approved unless this is checked) 
- [ - ] Docs updated?
- [ - ] New packages used/requires npm install? 
- [ - ] Toggle added for new features?
- [ - ] Requires update of SciCat backend API?

