### PR TITLE
Fix archive/retrieve for new BE

### DIFF
--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -38,7 +38,6 @@ export class ArchivingService {
     const data = {
       jobParams,
       emailJobInitiator: user.email,
-      creationTime: new Date(),
       // Revise this, files == []...? See earlier version of this method in dataset-table component for context
       datasetList: datasets.map((dataset) => ({
         pid: dataset.pid,


### PR DESCRIPTION
CreationDate is always handled by backend now and results in an Error 400 (property creationTime should not exist)


Short description of the pull request

## Fixes:

* Don't set creation date on archive/retrieve job creation

- [ - ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ - ] Docs updated?
- [ - ] New packages used/requires npm install? 
- [ - ] Toggle added for new features?
- [ - ] Requires update of SciCat backend API?

