### PR TITLE
changed permissions to make dataset public according to new casl model

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -163,7 +163,6 @@ export class DatasetDetailComponent
     return this._hasUnsavedChanges;
   }
 
-  /*
   isPI(): boolean {
     if (this.user && this.dataset) {
       if (this.user.username === "admin") {
@@ -188,7 +187,6 @@ export class DatasetDetailComponent
     }
     return false;
   }
-  */
 
   onClickKeyword(keyword: string) {
     this.store.dispatch(clearFacetsAction());


### PR DESCRIPTION
## Description
This PR allow to make a dataset public to any user who is an admin or is part of the group that owns the dataset.

## Motivation
The current frontend is still following the old backend permission model and allows to publish a dataset only the user which email is listed as PI (which in the new BE we do not use this field as such) or the user named admin.
With BE 4.x admin users can be configured and the user name does not indicate if it is an admin or not. Also, any user that belongs to the group listed as dataset owner should be able to make such change.

## Changes:
* src/app/datasets/dataset-detail/dataset-detail.component.html
* src/app/datasets/dataset-detail/dataset-detail.component.ts

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

