### PR TITLE
fix: condition box breaks out issue

### DIFF
--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -181,29 +181,32 @@
 
       <mat-chip-listbox class="scientific-chips" aria-orientation="vertical">
         <mat-chip-option
+          class="scientific-chip"
           *ngFor="let condition of scientificConditions$ | async; index as i"
         >
-          {{ condition.lhs }}
-          <ng-container [ngSwitch]="condition.relation">
-            <ng-container *ngSwitchCase="'EQUAL_TO_NUMERIC'">
-              &nbsp;=&nbsp;
+          <span class="scientific-chip-text">
+            {{ condition.lhs }}
+            <ng-container [ngSwitch]="condition.relation">
+              <ng-container *ngSwitchCase="'EQUAL_TO_NUMERIC'">
+                &nbsp;=&nbsp;
+              </ng-container>
+              <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
+                &nbsp;=&nbsp;
+              </ng-container>
+              <ng-container *ngSwitchCase="'LESS_THAN'">
+                &nbsp;&lt;&nbsp;
+              </ng-container>
+              <ng-container *ngSwitchCase="'GREATER_THAN'">
+                &nbsp;&gt;&nbsp;
+              </ng-container>
             </ng-container>
-            <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
-              &nbsp;=&nbsp;
-            </ng-container>
-            <ng-container *ngSwitchCase="'LESS_THAN'">
-              &nbsp;&lt;&nbsp;
-            </ng-container>
-            <ng-container *ngSwitchCase="'GREATER_THAN'">
-              &nbsp;&gt;&nbsp;
-            </ng-container>
-          </ng-container>
-          {{
-            condition.relation === "EQUAL_TO_STRING"
-              ? '"' + condition.rhs + '"'
-              : condition.rhs
-          }}
-          {{ condition.unit | prettyUnit }}
+            {{
+              condition.relation === "EQUAL_TO_STRING"
+                ? '"' + condition.rhs + '"'
+                : condition.rhs
+            }}
+            {{ condition.unit | prettyUnit }}
+          </span>
           <mat-icon matChipRemove (click)="removeCondition(condition, i)"
             >cancel</mat-icon
           >

--- a/src/app/datasets/datasets-filter/datasets-filter.component.scss
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.scss
@@ -25,6 +25,15 @@ mat-card {
         margin: 0;
       }
     }
+
+    .scientific-chip {
+      height: auto;
+    }
+
+    .scientific-chip-text {
+      white-space: normal;
+      word-break: break-all;
+    }
   }
 
   .section-container:first-child {


### PR DESCRIPTION
## Description

#1297
Fixed condition filter box breaks out when text is too long

## Fixes
**Before**
![image](https://github.com/SciCatProject/frontend/assets/78078898/d0e55236-63ea-4764-9e9a-d55369ae3825)

**After**

<img width="733" alt="image" src="https://github.com/SciCatProject/frontend/assets/78078898/2a375a44-2164-4277-b3c0-20710b37b00d">

