### PR TITLE
fix: depandabot yaml wrong format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,29 +20,29 @@ updates:
     groups:
       angular:
         patterns:
-        - "@angular*"
+          - "@angular*"
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
       eslint:
         patterns:
-        - "*eslint*"
+          - "*eslint*"
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
       ngrx:
         patterns:
-        - "@ngrx/*"
+          - "@ngrx/*"
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
       types:
         patterns:
-        - "types/*"
-        - "@types/*
+          - "types/*"
+          - "@types/*"
         update-types:
-        - "minor"
-        - "patch"
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "@angular*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot couldn't parse the config file at .github/dependabot.yml. The error raised was:

`(<unknown>): did not find expected key while parsing a block mapping at line 40 column 9`