### PR TITLE
Removed headers filter from loopbackApi

### DIFF
--- a/src/app/shared/sdk/lb.config.ts
+++ b/src/app/shared/sdk/lb.config.ts
@@ -24,8 +24,8 @@ export class LoopBackConfig {
   private static version: string | number = "api/v3";
   private static authPrefix: string = "";
   private static debug: boolean = true;
-  private static filterOn: string = "headers";
-  private static whereOn: string = "headers";
+  private static filterOn: string = "url";
+  private static whereOn: string = "url";
   private static secure: boolean = false;
   private static withCredentials: boolean = false;
 
@@ -65,24 +65,8 @@ export class LoopBackConfig {
     LoopBackConfig.filterOn = "url";
   }
 
-  public static filterOnHeaders(): void {
-    LoopBackConfig.filterOn = "headers";
-  }
-
   public static whereOnUrl(): void {
     LoopBackConfig.whereOn = "url";
-  }
-
-  public static whereOnHeaders(): void {
-    LoopBackConfig.whereOn = "headers";
-  }
-
-  public static isHeadersFilteringSet(): boolean {
-    return LoopBackConfig.filterOn === "headers";
-  }
-
-  public static isHeadersWhereSet(): boolean {
-    return LoopBackConfig.whereOn === "headers";
   }
 
   public static setSecureWebSockets(): void {

--- a/src/app/shared/sdk/services/core/base.service.ts
+++ b/src/app/shared/sdk/services/core/base.service.ts
@@ -124,30 +124,17 @@ export abstract class BaseLoopBackApi {
 
       // Separate filter object from url params and add to search query
       if (urlParams.filter) {
-        if (LoopBackConfig.isHeadersFilteringSet()) {
-          headers = headers.append("filter", JSON.stringify(urlParams.filter));
-        } else {
-          queryString = `?filter=${encodeURIComponent(
-            JSON.stringify(urlParams.filter),
-          )}`;
-        }
+        queryString = `?filter=${encodeURIComponent(
+          JSON.stringify(urlParams.filter),
+        )}`;
         delete urlParams.filter;
       }
 
       // Separate where object from url params and add to search query
       if (urlParams.where) {
-        if (LoopBackConfig.isHeadersWhereSet()) {
-          /**
-          CODE BELOW WILL GENERATE THE FOLLOWING ISSUES:
-          - https://github.com/mean-expert-official/loopback-sdk-builder/issues/356
-          - https://github.com/mean-expert-official/loopback-sdk-builder/issues/328 
-          **/
-          headers = headers.append("where", JSON.stringify(urlParams.where));
-        } else {
-          queryString = `?where=${encodeURIComponent(
-            JSON.stringify(urlParams.where),
-          )}`;
-        }
+        queryString = `?where=${encodeURIComponent(
+          JSON.stringify(urlParams.where),
+        )}`;
         delete urlParams.where;
       }
 


### PR DESCRIPTION
## Description

For better compatibility, visibility, and ease of use headers filter are removed and will no longer be supported by scicat backend

## Motivation

Couple of reasons to remove header filters as following:

- `Limited Visibility and Debugging`: Headers are less visible than query parameters or request bodies, complicating debugging and logging.
- `Convention and Consistency`: In RESTful APIs, headers are conventionally used for control-related metadata like content type or authentication, not for business logic like filter parameters. Using them for filters goes against standard practices.
- `Security Concerns`: Using headers for business logic can expose APIs to overlooked security vulnerabilities.



## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

