### PR TITLE
fix: Related Datasets Loading and Pagination Issues

### DIFF
--- a/src/app/datasets/related-datasets/related-datasets.component.html
+++ b/src/app/datasets/related-datasets/related-datasets.component.html
@@ -3,9 +3,9 @@
     [data]="vm.relatedDatasets"
     [columns]="tableColumns"
     [paginate]="tablePaginate"
-    [currentPage]="vm.relatedDatasetsFilters.skip"
+    [currentPage]="currentPage$ | async"
     [dataCount]="vm.relatedDatasetsCount"
-    [dataPerPage]="vm.relatedDatasetsFilters.limit"
+    [dataPerPage]="datasetsPerPage$ | async"
     (pageChange)="onPageChange($event)"
     (rowClick)="onRowClick($event)"
   ></app-table>

--- a/src/app/datasets/related-datasets/related-datasets.component.ts
+++ b/src/app/datasets/related-datasets/related-datasets.component.ts
@@ -12,7 +12,11 @@ import {
   changeRelatedDatasetsPageAction,
   fetchRelatedDatasetsAction,
 } from "state-management/actions/datasets.actions";
-import { selectRelatedDatasetsPageViewModel } from "state-management/selectors/datasets.selectors";
+import {
+  selectRelatedDatasetsCurrentPage,
+  selectRelatedDatasetsPageViewModel,
+  selectRelatedDatasetsPerPage,
+} from "state-management/selectors/datasets.selectors";
 
 @Component({
   selector: "app-related-datasets",
@@ -26,6 +30,8 @@ export class RelatedDatasetsComponent {
       relatedDatasets: this.formatTableData(vm.relatedDatasets),
     })),
   );
+  currentPage$ = this.store.select(selectRelatedDatasetsCurrentPage);
+  datasetsPerPage$ = this.store.select(selectRelatedDatasetsPerPage);
 
   tablePaginate = true;
   tableColumns: TableColumn[] = [

--- a/src/app/shared/sdk/models/BaseModels.ts
+++ b/src/app/shared/sdk/models/BaseModels.ts
@@ -1,10 +1,13 @@
 /* eslint-disable */
 
+import { FilterLimits } from "shared/services/scicat-data-service";
+
 declare var Object: any;
 export interface LoopBackFilter {
   fields?: any;
   include?: any;
   limit?: any;
+  limits?: FilterLimits;
   order?: any;
   skip?: any;
   offset?: any;

--- a/src/app/state-management/effects/datasets.effects.spec.ts
+++ b/src/app/state-management/effects/datasets.effects.spec.ts
@@ -95,6 +95,7 @@ describe("DatasetEffects", () => {
             "destroyByIdAttachments",
             "reduceDataset",
             "appendToArrayField",
+            "count",
           ]),
         },
       ],
@@ -329,15 +330,15 @@ describe("DatasetEffects", () => {
 
   describe("fetchRelatedDatasetsCount$", () => {
     it("should result in a fetchRelatedDatasetsCountCompleteAction", () => {
-      const relatedDatasets = [dataset];
+      const count = 3;
       const action = fromActions.fetchRelatedDatasetsAction();
       const outcome = fromActions.fetchRelatedDatasetsCountCompleteAction({
-        count: relatedDatasets.length,
+        count,
       });
 
       actions = hot("-a", { a: action });
-      const response = cold("-a|", { a: relatedDatasets });
-      datasetApi.find.and.returnValue(response);
+      const response = cold("-a|", { a: { count } });
+      datasetApi.count.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchRelatedDatasetsCount$).toBeObservable(expected);
@@ -348,7 +349,7 @@ describe("DatasetEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-#", {});
-      datasetApi.find.and.returnValue(response);
+      datasetApi.count.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchRelatedDatasetsCount$).toBeObservable(expected);

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -238,9 +238,9 @@ export class DatasetEffects {
           };
         }
         return this.datasetApi.count(queryFilter).pipe(
-          map((datasets) =>
+          map(({ count }) =>
             fromActions.fetchRelatedDatasetsCountCompleteAction({
-              count: datasets.count,
+              count,
             }),
           ),
           catchError(() =>

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -191,9 +191,11 @@ export class DatasetEffects {
       switchMap(([_, dataset, filters]) => {
         const queryFilter: LoopBackFilter = {
           where: {},
-          skip: filters.skip,
-          limit: filters.limit,
-          order: filters.sortField,
+          limits: {
+            skip: filters.skip,
+            limit: filters.limit,
+            order: filters.sortField,
+          },
         };
         if (dataset.type === "raw") {
           queryFilter.where = {
@@ -235,10 +237,10 @@ export class DatasetEffects {
             pid: { $in: (dataset as unknown as DerivedDataset).inputDatasets },
           };
         }
-        return this.datasetApi.find(queryFilter).pipe(
+        return this.datasetApi.count(queryFilter).pipe(
           map((datasets) =>
             fromActions.fetchRelatedDatasetsCountCompleteAction({
-              count: datasets.length,
+              count: datasets.count,
             }),
           ),
           catchError(() =>

--- a/src/app/state-management/selectors/datasets.selectors.spec.ts
+++ b/src/app/state-management/selectors/datasets.selectors.spec.ts
@@ -403,12 +403,41 @@ describe("test dataset selectors", () => {
       ).toEqual({
         relatedDatasets: [],
         relatedDatasetsCount: 0,
-        relatedDatasetsFilters: {
-          skip: 0,
-          limit: 25,
-          sortField: "creationTime:desc",
-        },
       });
+    });
+  });
+
+  describe("selectRelatedDatasetsFilters", () => {
+    it("should return the current related datasets filters", () => {
+      expect(
+        fromDatasetSelectors.selectRelatedDatasetsFilters.projector(
+          initialDatasetState,
+        ),
+      ).toEqual({
+        skip: 0,
+        limit: 25,
+        sortField: "creationTime:desc",
+      });
+    });
+  });
+
+  describe("selectRelatedDatasetsCurrentPage", () => {
+    it("should return the current related datasets page", () => {
+      expect(
+        fromDatasetSelectors.selectRelatedDatasetsCurrentPage.projector(
+          initialDatasetState.relatedDatasetsFilters,
+        ),
+      ).toEqual(0);
+    });
+  });
+
+  describe("selectRelatedDatasetsPerPage", () => {
+    it("should return the current related datasets per page", () => {
+      expect(
+        fromDatasetSelectors.selectRelatedDatasetsPerPage.projector(
+          initialDatasetState.relatedDatasetsFilters,
+        ),
+      ).toEqual(25);
     });
   });
 

--- a/src/app/state-management/selectors/datasets.selectors.ts
+++ b/src/app/state-management/selectors/datasets.selectors.ts
@@ -239,14 +239,23 @@ export const selectOpenwhiskResult = createSelector(
 
 export const selectRelatedDatasetsPageViewModel = createSelector(
   selectDatasetState,
-  ({ relatedDatasets, relatedDatasetsCount, relatedDatasetsFilters }) => ({
+  ({ relatedDatasets, relatedDatasetsCount }) => ({
     relatedDatasets,
     relatedDatasetsCount,
-    relatedDatasetsFilters,
   }),
 );
 
 export const selectRelatedDatasetsFilters = createSelector(
   selectDatasetState,
   (state) => state.relatedDatasetsFilters,
+);
+
+export const selectRelatedDatasetsCurrentPage = createSelector(
+  selectRelatedDatasetsFilters,
+  (filters) => filters.skip / filters.limit,
+);
+
+export const selectRelatedDatasetsPerPage = createSelector(
+  selectRelatedDatasetsFilters,
+  (filters) => filters.limit,
 );


### PR DESCRIPTION
## Description

This change addresses issues with the loading and pagination of Related Datasets.

## Motivation

The original code used the wrong interface for data retrieval, resulting in incorrect limit parameters and fetching all available data. Additionally, pagination was incorrect due to the use of wrong parameters.

## Fixes:

https://jira.esss.lu.se/browse/SWAP-3633

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

