### PR TITLE
Save metadata with a warning for possible invalid units

### DIFF
--- a/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.html
+++ b/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.html
@@ -90,6 +90,10 @@
               <mat-error *ngIf="fieldHasError(i, 'fieldUnit')">
                 A unit is required for quantities
               </mat-error>
+
+              <mat-hint *ngIf="invalidUnitWarning[i]">
+                {{ invalidUnitWarning[i] }}
+              </mat-hint>
             </mat-form-field>
           </div>
           <div class="formColumn" fxFlexAlign="center">

--- a/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.scss
+++ b/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.scss
@@ -6,6 +6,11 @@
   }
 }
 
+::ng-deep mat-hint {
+  white-space: nowrap;
+  color: rgb(179, 0, 0);
+}
+
 @media only screen and (min-width: 1280px) {
   .container {
     .formRow {

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
@@ -4,9 +4,7 @@
 
     <!-- Name Column -->
     <ng-container matColumnDef="name" style="align-content: center">
-      <mat-header-cell *matHeaderCellDef>
-        Name
-      </mat-header-cell>
+      <mat-header-cell *matHeaderCellDef> Name </mat-header-cell>
       <mat-cell *matCellDef="let metadata">
         {{ metadata.name | replaceUnderscore | titlecase }}
       </mat-cell>
@@ -14,26 +12,30 @@
 
     <!-- Value Column -->
     <ng-container matColumnDef="value" style="align-content: center">
-      <mat-header-cell *matHeaderCellDef>
-        Value
-      </mat-header-cell>
+      <mat-header-cell *matHeaderCellDef> Value </mat-header-cell>
       <mat-cell *matCellDef="let metadata">
-          {{ metadata.value }}
+        {{ metadata.value }}
       </mat-cell>
     </ng-container>
 
     <!-- Unit Column -->
     <ng-container matColumnDef="unit" style="align-content: center">
-      <mat-header-cell *matHeaderCellDef>
-        Unit
-      </mat-header-cell>
+      <mat-header-cell *matHeaderCellDef> Unit </mat-header-cell>
       <mat-cell *matCellDef="let metadata">
         <ng-template [ngIf]="metadata.unit.length > 0" [ngIfElse]="noUnit">
-          {{ metadata.unit | prettyUnit }}
+          <span
+            [class.invalid-unit]="!metadata.validUnit"
+            [matTooltip]="
+              !metadata.validUnit
+                ? ' Unrecognized unit, conversion disabled
+              '
+                : ''
+            "
+          >
+            {{ metadata.unit | prettyUnit }}
+          </span>
         </ng-template>
-        <ng-template #noUnit>
-          --
-        </ng-template>
+        <ng-template #noUnit> -- </ng-template>
       </mat-cell>
     </ng-container>
 

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
@@ -1,5 +1,4 @@
 .metadataTable {
-
   .mat-column-name {
     flex: 1 0 7em;
   }
@@ -11,6 +10,10 @@
   .mat-column-unit {
     flex: 1 0 5em;
   }
+}
+
+.invalid-unit {
+  color: rgb(179, 0, 0, 0.8);
 }
 
 @media only screen and (max-width: 1279px) {

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
@@ -22,6 +22,7 @@ export class MetadataViewComponent implements OnInit, OnChanges {
 
   tableData: ScientificMetadataTableData[] = [];
   columnsToDisplay: string[] = ["name", "value", "unit"];
+
   constructor(private unitsService: UnitsService) {}
 
   createMetadataArray(

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
@@ -10,6 +10,7 @@ import {
   ScientificMetadataTableData,
   ScientificMetadata,
 } from "../scientific-metadata.module";
+import { UnitsService } from "shared/services/units.service";
 
 @Component({
   selector: "metadata-view",
@@ -21,9 +22,7 @@ export class MetadataViewComponent implements OnInit, OnChanges {
 
   tableData: ScientificMetadataTableData[] = [];
   columnsToDisplay: string[] = ["name", "value", "unit"];
-
   constructor(private unitsService: UnitsService) {}
-
 
   createMetadataArray(
     metadata: Record<string, any>,
@@ -40,6 +39,11 @@ export class MetadataViewComponent implements OnInit, OnChanges {
           value: metadata[key]["value"],
           unit: metadata[key]["unit"],
         };
+        const validUnit = this.unitsService
+          .getUnits()
+          .includes(metadata[key]["unit"]);
+
+        metadataObject["validUnit"] = validUnit;
       } else {
         metadataObject = {
           name: key,

--- a/src/app/shared/modules/scientific-metadata/scientific-metadata.module.ts
+++ b/src/app/shared/modules/scientific-metadata/scientific-metadata.module.ts
@@ -14,6 +14,7 @@ import { MetadataEditComponent } from "./metadata-edit/metadata-edit.component";
 import { PipesModule } from "shared/pipes/pipes.module";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { FlexModule } from "@ngbracket/ngx-layout";
+import { MatTooltipModule } from "@angular/material/tooltip";
 
 @NgModule({
   declarations: [MetadataViewComponent, MetadataEditComponent],
@@ -26,6 +27,7 @@ import { FlexModule } from "@ngbracket/ngx-layout";
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    MatTooltipModule,
     MatOptionModule,
     MatSelectModule,
     MatTableModule,


### PR DESCRIPTION
## Description

Allow users to save units that can not be recognized by the math-js library.
Added a warning message for invalid unit, so that the user aware that the current unit will not be converted.

## Motivation

Some units are missing in the math-js library and thus cannot be converted. We want to allow users to save those unrecognized units as well. 

## Fixes:

<img width="1090" alt="image" src="https://github.com/SciCatProject/frontend/assets/78078898/fac58d25-9d65-4e35-a910-9174b61b7a92">

<img width="922" alt="image" src="https://github.com/SciCatProject/frontend/assets/78078898/54e6e33a-9749-45e7-bd0d-c1a47753c75c">

## Changes:

* changes made

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

