### PR TITLE
Hide empty 'Input Datasets' on details page

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -306,16 +306,16 @@
                 </div>
               </td>
             </tr>
-            <tr *ngIf="dataset['inputDatasets'] as value">
+            <tr *ngIf="dataset['inputDatasets'] && dataset['inputDatasets'].length > 0">
               <th>Input Datasets</th>
               <td>
-                <div *ngFor="let datasetPid of value">
+                <div *ngFor="let datasetPid of dataset['inputDatasets']">
                   <span>
                     <a [routerLink]="['/datasets/', datasetPid]">
                       {{ datasetPid }}
                     </a>
                   </span>
-                  <span *ngIf="value.indexOf(datasetPid) < value.length - 1"
+                  <span *ngIf="dataset['inputDatasets'].indexOf(datasetPid) < dataset['inputDatasets'].length - 1"
                     >,
                   </span>
                 </div>


### PR DESCRIPTION
## Description

When a dataset doesn't have input datasets, the API returns an empty array. The dataset details would show the label 'Input datasets' without any items/link.
This patch hides the label if the array is empty.