### PR TITLE
fix: fetchCurrentUser does not validate token expiration time

### DIFF
--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -85,9 +85,9 @@ export class UserEffects {
           this.configService.getConfig().accessTokenPrefix;
         const token = new SDKToken({
           id: accessTokenPrefix + oidcLoginResponse.accessToken,
-          userId: oidcLoginResponse.userId ,
+          userId: oidcLoginResponse.userId,
           ttl: oidcLoginResponse.ttl,
-          created: oidcLoginResponse.created
+          created: oidcLoginResponse.created,
         });
         this.loopBackAuth.setToken(token);
         return this.userApi.findById<User>(oidcLoginResponse.userId).pipe(
@@ -115,7 +115,7 @@ export class UserEffects {
           id: accessTokenPrefix + adLoginResponse.access_token,
           userId: adLoginResponse.userId,
           ttl: adLoginResponse.ttl,
-          created: adLoginResponse.created
+          created: adLoginResponse.created,
         });
         this.loopBackAuth.setToken(token);
         return this.userApi.findById<User>(adLoginResponse.userId).pipe(
@@ -240,15 +240,15 @@ export class UserEffects {
     return this.actions$.pipe(
       ofType(fromActions.fetchCurrentUserAction),
       filter(() => {
-        const { created, ttl, id } = this.userApi.getCurrentToken()
+        const { created, ttl, id } = this.userApi.getCurrentToken();
 
-        const currentTimeStamp = Math.floor(new Date().getTime())
-        const createdTimeStamp = Math.floor(new Date(created).getTime())
-        const expirationTimeStamp = (+createdTimeStamp) + (+ttl * 1000);
-        const isTokenExpired = currentTimeStamp >= expirationTimeStamp 
+        const currentTimeStamp = Math.floor(new Date().getTime());
+        const createdTimeStamp = Math.floor(new Date(created).getTime());
+        const expirationTimeStamp = +createdTimeStamp + +ttl * 1000;
+        const isTokenExpired = currentTimeStamp >= expirationTimeStamp;
 
-        if(id && isTokenExpired){
-          this.loopBackAuth.clear()
+        if (id && isTokenExpired) {
+          this.loopBackAuth.clear();
         }
 
         return this.userApi.isAuthenticated();

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -247,7 +247,7 @@ export class UserEffects {
         const expirationTimeStamp = +createdTimeStamp + +ttl * 1000;
         const isTokenExpired = currentTimeStamp >= expirationTimeStamp;
 
-        if (id && isTokenExpired) {
+        if (id && ttl && isTokenExpired) {
           this.loopBackAuth.clear();
         }
 

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -85,7 +85,9 @@ export class UserEffects {
           this.configService.getConfig().accessTokenPrefix;
         const token = new SDKToken({
           id: accessTokenPrefix + oidcLoginResponse.accessToken,
-          userId: oidcLoginResponse.userId,
+          userId: oidcLoginResponse.userId ,
+          ttl: oidcLoginResponse.ttl,
+          created: oidcLoginResponse.created
         });
         this.loopBackAuth.setToken(token);
         return this.userApi.findById<User>(oidcLoginResponse.userId).pipe(
@@ -112,6 +114,8 @@ export class UserEffects {
         const token = new SDKToken({
           id: accessTokenPrefix + adLoginResponse.access_token,
           userId: adLoginResponse.userId,
+          ttl: adLoginResponse.ttl,
+          created: adLoginResponse.created
         });
         this.loopBackAuth.setToken(token);
         return this.userApi.findById<User>(adLoginResponse.userId).pipe(
@@ -236,7 +240,18 @@ export class UserEffects {
     return this.actions$.pipe(
       ofType(fromActions.fetchCurrentUserAction),
       filter(() => {
-        return this.userApi.getCurrentId() !== "null";
+        const { created, ttl, id } = this.userApi.getCurrentToken()
+
+        const currentTimeStamp = Math.floor(new Date().getTime())
+        const createdTimeStamp = Math.floor(new Date(created).getTime())
+        const expirationTimeStamp = (+createdTimeStamp) + (+ttl * 1000);
+        const isTokenExpired = currentTimeStamp >= expirationTimeStamp 
+
+        if(id && isTokenExpired){
+          this.loopBackAuth.clear()
+        }
+
+        return this.userApi.isAuthenticated();
       }),
       switchMap(() =>
         this.userApi.getCurrent().pipe(

--- a/src/app/users/auth-callback/auth-callback.component.ts
+++ b/src/app/users/auth-callback/auth-callback.component.ts
@@ -23,21 +23,27 @@ export class AuthCallbackComponent implements OnInit {
       // External authentication will redirect to this component with a access-token and user-id query parameter
       const accessToken = params["access-token"];
       const userId = params["user-id"];
-      const parsedToken = this.parseJwt( params["access-token"])
-      const ttl = parsedToken.exp - parsedToken.iat
+      const parsedToken = this.parseJwt(params["access-token"]);
+      const ttl = parsedToken.exp - parsedToken.iat;
       const created = new Date(parsedToken.iat * 1000);
-      
 
       if (accessToken && userId) {
         // If the user is authenticated, we will store the access token and user id in the store
         this.store.dispatch(
-          loginOIDCAction({ oidcLoginResponse: { accessToken, userId, ttl, created} }),
+          loginOIDCAction({
+            oidcLoginResponse: { accessToken, userId, ttl, created },
+          }),
         );
 
         // We will also fetch the user from the backend
         this.store.dispatch(
           fetchUserAction({
-            adLoginResponse: { access_token: accessToken, userId: userId, ttl:ttl, created:created },
+            adLoginResponse: {
+              access_token: accessToken,
+              userId: userId,
+              ttl: ttl,
+              created: created,
+            },
           }),
         );
 
@@ -47,13 +53,19 @@ export class AuthCallbackComponent implements OnInit {
       }
     });
   }
-  
-  private parseJwt(token:string){
-    const base64Url = token.split('.')[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    const jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(''));
+
+  private parseJwt(token: string) {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+      window
+        .atob(base64)
+        .split("")
+        .map(function (c) {
+          return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+        })
+        .join(""),
+    );
 
     return JSON.parse(jsonPayload);
   }

--- a/src/app/users/auth-callback/auth-callback.component.ts
+++ b/src/app/users/auth-callback/auth-callback.component.ts
@@ -23,17 +23,21 @@ export class AuthCallbackComponent implements OnInit {
       // External authentication will redirect to this component with a access-token and user-id query parameter
       const accessToken = params["access-token"];
       const userId = params["user-id"];
+      const parsedToken = this.parseJwt( params["access-token"])
+      const ttl = parsedToken.exp - parsedToken.iat
+      const created = new Date(parsedToken.iat * 1000);
+      
 
       if (accessToken && userId) {
         // If the user is authenticated, we will store the access token and user id in the store
         this.store.dispatch(
-          loginOIDCAction({ oidcLoginResponse: { accessToken, userId } }),
+          loginOIDCAction({ oidcLoginResponse: { accessToken, userId, ttl, created} }),
         );
 
         // We will also fetch the user from the backend
         this.store.dispatch(
           fetchUserAction({
-            adLoginResponse: { access_token: accessToken, userId: userId },
+            adLoginResponse: { access_token: accessToken, userId: userId, ttl:ttl, created:created },
           }),
         );
 
@@ -42,5 +46,15 @@ export class AuthCallbackComponent implements OnInit {
         this.router.navigateByUrl(returnUrl || "/");
       }
     });
+  }
+  
+  private parseJwt(token:string){
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+
+    return JSON.parse(jsonPayload);
   }
 }

--- a/src/app/users/auth-callback/auth-callback.component.ts
+++ b/src/app/users/auth-callback/auth-callback.component.ts
@@ -18,6 +18,21 @@ export class AuthCallbackComponent implements OnInit {
     private router: Router,
   ) {}
 
+  private parseJwt(token: string) {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+      window
+        .atob(base64)
+        .split("")
+        .map(function (c) {
+          return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+        })
+        .join(""),
+    );
+
+    return JSON.parse(jsonPayload);
+  }
   ngOnInit(): void {
     this.route.queryParams.subscribe((params) => {
       // External authentication will redirect to this component with a access-token and user-id query parameter
@@ -52,21 +67,5 @@ export class AuthCallbackComponent implements OnInit {
         this.router.navigateByUrl(returnUrl || "/");
       }
     });
-  }
-
-  private parseJwt(token: string) {
-    const base64Url = token.split(".")[1];
-    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
-    const jsonPayload = decodeURIComponent(
-      window
-        .atob(base64)
-        .split("")
-        .map(function (c) {
-          return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
-        })
-        .join(""),
-    );
-
-    return JSON.parse(jsonPayload);
   }
 }


### PR DESCRIPTION
## Description

When a user logs in, the loopbackAuth mechanism stores the authentication token in the browser's cookies. However, it fails to automatically remove this token once it has expired. Consequently, when the FetchCurrentUser action attempts to retrieve the user's profile from the backend using this expired JWT token, it results in a 401 Unauthorized error due to the token's invalidity.

## Motivation

Background on use case, changes needed

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

