### PR TITLE
fix: fit-content causing strecthed out profile image

### DIFF
--- a/src/app/users/user-settings/user-settings.component.scss
+++ b/src/app/users/user-settings/user-settings.component.scss
@@ -12,7 +12,6 @@ mat-card {
 
   .profile-image {
     margin: 1em 0em;
-    width: fit-content;
   }
 
   table {


### PR DESCRIPTION
## Description
`width: fit-content` attribute causing stretched profile image on safari(17.2.1) and firefox(115.8.0esr)
![image](https://github.com/SciCatProject/frontend/assets/78078898/b73f0206-ec83-44f2-a943-9068ad64d001)

![image](https://github.com/SciCatProject/frontend/assets/78078898/9cd335ea-f05c-442d-ba04-03b95d0b9569)



## Fixes:

Removed `width: fit-content` from .profile-image CSS class

## Changes:

src/app/users/user-settings/user-settings.component.scss
## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

