### PR TITLE
Fix OIDC login with backend v3.x

### DIFF
--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -131,8 +131,14 @@ export class LoginComponent implements OnInit, OnDestroy {
       // which are parsed here.
       if (params.returnUrl) {
         // dispatching to the loginOIDCAction passes information to eventually be added to Loopback AccessToken
-        const accessToken = params["access-token"];
-        const userId = params["user-id"];
+        let accessToken = params["access-token"];
+        let userId = params["user-id"];
+        // Required for backend v3 compatibility (access-token and user-id are encoded in returnUrl)
+        if (!accessToken && !userId) {
+          const urlqp = new URLSearchParams(params.returnUrl.split("?")[1]);
+          accessToken = urlqp.get("access-token");
+          userId = urlqp.get("user-id");
+        }
         this.store.dispatch(
           loginOIDCAction({ oidcLoginResponse: { accessToken, userId } }),
         );


### PR DESCRIPTION
## Description

OIDC login fails in the frontend when using version > v4.2.1 and backend v3.x

## Motivation

Make OIDC login available with both backends in `scicatlive`
If possible, can you tag a new version with this fix so we can use it asap in `scicatlive`

## Fixes:

#1467 
