### PR TITLE
fix: truncate observable token size

### DIFF
--- a/src/app/users/user-settings/_user-settings-theme.scss
+++ b/src/app/users/user-settings/_user-settings-theme.scss
@@ -13,6 +13,12 @@
       background-color: mat.get-color-from-palette($header-1, "lighter");
     }
   }
+
+  td {
+    .copy-button {
+      color: mat.get-color-from-palette($primary, "default");
+    }
+  }
 }
 
 @mixin theme($theme) {

--- a/src/app/users/user-settings/user-settings.component.html
+++ b/src/app/users/user-settings/user-settings.component.html
@@ -56,7 +56,7 @@
           <tr *ngIf="tokenValue" data-cy="user-token">
             <th>SciCat Token</th>
             <td>
-              {{ tokenValue }}
+              <span class="token-truncate">{{ tokenValue }}</span>
               <span class="copy-button" (click)="onCopy(tokenValue)">
                 <mat-icon matTooltip="Copy token to clipboard"
                   >post_add</mat-icon

--- a/src/app/users/user-settings/user-settings.component.scss
+++ b/src/app/users/user-settings/user-settings.component.scss
@@ -14,6 +14,14 @@ mat-card {
     margin: 1em 0em;
   }
 
+  .token-truncate {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    max-width: 20ch;
+  }
+
   table {
     th {
       min-width: 10em;
@@ -22,9 +30,9 @@ mat-card {
     }
 
     td {
-      width: 100%;
       padding: 0.5em;
-      display: inline-block;
+      display: flex;
+      align-items: center;
       word-break: break-all;
 
       .copy-button {


### PR DESCRIPTION
## Description
Show token partially for security reason.
<img width="392" alt="image" src="https://github.com/SciCatProject/frontend/assets/78078898/b3531304-7b70-4f0a-96a4-b7b0f396ec05">



## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
- [ ] Requires update of SciCat backend API?

