### PR TITLE
feat: show release version and site on user settings page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scicat-frontend",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "license": "BSD-3-Clause",
   "scripts": {
     "ng": "ng",

--- a/src/app/users/user-settings/user-settings.component.html
+++ b/src/app/users/user-settings/user-settings.component.html
@@ -98,13 +98,13 @@
 
       <mat-card-content>
         <table>
-          <tr *ngIf="settings.datasetCount as value">
-            <th>Dataset Count</th>
-            <td>{{ value }}</td>
+          <tr *ngIf="appVersion">
+            <th>Release Version</th>
+            <td>{{ appVersion }}</td>
           </tr>
-          <tr *ngIf="settings.jobCount as value">
-            <th>Job Count</th>
-            <td>{{ value }}</td>
+          <tr *ngIf="appConfig.facility">
+            <th>Site</th>
+            <td>{{ appConfig.facility }}</td>
           </tr>
         </table>
       </mat-card-content>

--- a/src/app/users/user-settings/user-settings.component.html
+++ b/src/app/users/user-settings/user-settings.component.html
@@ -99,7 +99,7 @@
       <mat-card-content>
         <table>
           <tr *ngIf="appVersion">
-            <th>Release Version</th>
+            <th>Frontend Release Version</th>
             <td>{{ appVersion }}</td>
           </tr>
           <tr *ngIf="appConfig.facility">

--- a/src/app/users/user-settings/user-settings.component.spec.ts
+++ b/src/app/users/user-settings/user-settings.component.spec.ts
@@ -7,8 +7,8 @@ import {
 } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { Store, StoreModule } from "@ngrx/store";
-import { MockConfigService, MockStore } from "shared/MockStubs";
-import { ConfigService } from "shared/services";
+import { MockStore } from "shared/MockStubs";
+import { AppConfigService } from "app-config.service";
 
 import { UserSettingsComponent } from "./user-settings.component";
 import { SharedScicatFrontendModule } from "shared/shared.module";
@@ -25,6 +25,8 @@ describe("UserSettingsComponent", () => {
   let store: MockStore;
   let dispatchSpy;
 
+  const getConfig = () => ({});
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
@@ -40,10 +42,7 @@ describe("UserSettingsComponent", () => {
     });
     TestBed.overrideComponent(UserSettingsComponent, {
       set: {
-        providers: [
-          // needed for config form sub component
-          { provide: ConfigService, useClass: MockConfigService },
-        ],
+        providers: [{ provide: AppConfigService, useValue: { getConfig } }],
       },
     });
     TestBed.compileComponents();

--- a/src/app/users/user-settings/user-settings.component.ts
+++ b/src/app/users/user-settings/user-settings.component.ts
@@ -8,6 +8,8 @@ import {
 import { Message, MessageType } from "state-management/models";
 import { selectUserSettingsPageViewModel } from "state-management/selectors/user.selectors";
 import { DOCUMENT } from "@angular/common";
+import packageJson from "../../../../package.json";
+import { AppConfigService } from "app-config.service";
 
 @Component({
   selector: "app-user-settings",
@@ -16,10 +18,13 @@ import { DOCUMENT } from "@angular/common";
 })
 export class UserSettingsComponent implements OnInit {
   vm$ = this.store.select(selectUserSettingsPageViewModel);
+  appVersion: string | undefined = packageJson.version;
+  appConfig = this.appConfigService.getConfig();
   tokenValue: string;
   show = true;
 
   constructor(
+    public appConfigService: AppConfigService,
     @Inject(DOCUMENT) private document: Document,
     private store: Store,
   ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": "./src/app",
     "outDir": "./dist/out-tsc",
+    "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -19,10 +20,7 @@
     "useDefineForClassFields": false,
     "target": "es2022",
     "module": "es2022",
-    "lib": [
-      "es2022",
-      "dom"
-    ]
+    "lib": ["es2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
## Description

Updated the application version and improved user settings display.

<img width="324" alt="image" src="https://github.com/SciCatProject/frontend/assets/78078898/039b3c19-74ce-44c7-bc8d-ee93c0e9fa38">


## Motivation
Enhance user experience by displaying the current app version and facility site information in the user settings.


## Changes:

- Updated app version to 4.4.0. in package.json
- Displayed appVersion and facility in user settings.
- Enabled JSON module resolution in TypeScript configuration.


## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
