### PR TITLE
fixes #1553

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN npm ci
 COPY . /frontend/
 RUN npx ng build
 
-FROM nginx:1.25-alpine
+FROM nginx:1.27-alpine
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /frontend/dist/ /usr/share/nginx/html/
 COPY scripts/nginx.conf /etc/nginx/nginx.conf
-EXPOSE 80
+USER 1000
+EXPOSE 8080

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -2,10 +2,8 @@
 #   * Official English Documentation: http://nginx.org/en/docs/
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
 
-user nginx;
 worker_processes auto;
-error_log /var/log/nginx/error.log;
-pid /run/nginx.pid;
+pid /tmp/nginx.pid;
 
 # Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;
@@ -18,9 +16,13 @@ http {
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
-
-    access_log  /var/log/nginx/access.log  main;
-
+                      
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;   
+    
     sendfile            on;
     tcp_nopush          on;
     tcp_nodelay         on;

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -33,8 +33,8 @@ http {
     default_type        application/octet-stream;
 
     server {
-        listen       80 default_server;
-        listen       [::]:80 default_server;
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
         server_name  _;
         root         /usr/share/nginx/html;
 


### PR DESCRIPTION
as described in the issue, the user does not need to be `root`, even for _nginx_.
This PR sets the `nginx.conf` the way the official [docs](https://hub.docker.com/_/nginx) describe what is needed to run as a rootless user.