### PR TITLE
fix: solved form submission in datafiles actions

### DIFF
--- a/src/app/datasets/datafiles-actions/datafiles-action.component.spec.ts
+++ b/src/app/datasets/datafiles-actions/datafiles-action.component.spec.ts
@@ -21,6 +21,8 @@ import { ActionDataset } from "./datafiles-action.interfaces";
 describe("1000: DatafilesActionComponent", () => {
   let component: DatafilesActionComponent;
   let fixture: ComponentFixture<DatafilesActionComponent>;
+  let htmlForm: HTMLFormElement;
+  let htmlInput: HTMLInputElement;
 
   const actionsConfig = [
     {
@@ -129,14 +131,20 @@ describe("1000: DatafilesActionComponent", () => {
     id: "4ac45f3e-4d79-11ef-856c-6339dab93bee",
   });
 
-  const browserWindowMock = {
-    document: {
-      write() {},
-      body: {
-        setAttribute() {},
-      },
-    },
-  } as unknown as Window;
+  // const browserWindowMock = {
+  //   document: {
+  //     write() {},
+  //     body: {
+  //       setAttribute() {},
+  //     },
+  //   },
+  // } as unknown as Window;
+
+  beforeAll(() => {
+    htmlForm = document.createElement("form");
+    (htmlForm as HTMLFormElement).submit = () => {};
+    htmlInput = document.createElement("input");
+  });
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -494,9 +502,22 @@ describe("1000: DatafilesActionComponent", () => {
     });
   });
 
-  function getFakeElement(elementType: string): HTMLElement {
-    const element = new MockHtmlElement(elementType);
-    return element as unknown as HTMLElement;
+  function createFakeElement(elementType: string): HTMLElement {
+    //const element = new MockHtmlElement(elementType);
+    //return element as unknown as HTMLElement;
+    let element: HTMLElement = null;
+
+    switch (elementType) {
+      case "form":
+        element = htmlForm.cloneNode(true) as HTMLElement;
+        break;
+      case "input":
+        element = htmlInput.cloneNode(true) as HTMLElement;
+        break;
+      default:
+        element = null;
+    }
+    return element;
   }
 
   it("0400: Form submission should have all files when Download All is clicked", async () => {
@@ -505,8 +526,9 @@ describe("1000: DatafilesActionComponent", () => {
       maxSizeType.higher,
       selectedFilesType.none,
     );
-    spyOn(document, "createElement").and.callFake(getFakeElement);
-    spyOn(window, "open").and.returnValue(browserWindowMock);
+
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+    //spyOn(window, "open").and.returnValue(browserWindowMock);
 
     component.perform_action();
 
@@ -526,13 +548,13 @@ describe("1000: DatafilesActionComponent", () => {
       maxSizeType.higher,
       selectedFilesType.none,
     );
-    spyOn(document, "createElement").and.callFake(getFakeElement);
-    spyOn(window, "open").and.returnValue(browserWindowMock);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+    //spyOn(window, "open").and.returnValue(browserWindowMock);
 
     component.perform_action();
 
-    expect(component.form.action).toEqual(
-      actionsConfig[actionSelectorType.download_all].url,
+    expect(component.form.action.replace(/\/$/, "")).toEqual(
+      actionsConfig[actionSelectorType.download_all].url.replace(/\/$/, ""),
     );
   });
 
@@ -542,8 +564,8 @@ describe("1000: DatafilesActionComponent", () => {
       maxSizeType.higher,
       selectedFilesType.none,
     );
-    spyOn(document, "createElement").and.callFake(getFakeElement);
-    spyOn(window, "open").and.returnValue(browserWindowMock);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+    //spyOn(window, "open").and.returnValue(browserWindowMock);
 
     component.perform_action();
 
@@ -566,8 +588,8 @@ describe("1000: DatafilesActionComponent", () => {
       maxSizeType.higher,
       selectedFile,
     );
-    spyOn(document, "createElement").and.callFake(getFakeElement);
-    spyOn(window, "open").and.returnValue(browserWindowMock);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+    //spyOn(window, "open").and.returnValue(browserWindowMock);
 
     component.perform_action();
 
@@ -592,8 +614,8 @@ describe("1000: DatafilesActionComponent", () => {
       maxSizeType.higher,
       selectedFilesType.none,
     );
-    spyOn(document, "createElement").and.callFake(getFakeElement);
-    spyOn(window, "open").and.returnValue(browserWindowMock);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+    //spyOn(window, "open").and.returnValue(browserWindowMock);
 
     component.perform_action();
 
@@ -613,13 +635,13 @@ describe("1000: DatafilesActionComponent", () => {
       maxSizeType.higher,
       selectedFilesType.none,
     );
-    spyOn(document, "createElement").and.callFake(getFakeElement);
-    spyOn(window, "open").and.returnValue(browserWindowMock);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+    //spyOn(window, "open").and.returnValue(browserWindowMock);
 
     component.perform_action();
 
-    expect(component.form.action).toEqual(
-      actionsConfig[actionSelectorType.notebook_all].url,
+    expect(component.form.action.replace(/\/$/, "")).toEqual(
+      actionsConfig[actionSelectorType.notebook_all].url.replace(/\/$/, ""),
     );
   });
 
@@ -630,8 +652,8 @@ describe("1000: DatafilesActionComponent", () => {
       maxSizeType.higher,
       selectedFile,
     );
-    spyOn(document, "createElement").and.callFake(getFakeElement);
-    spyOn(window, "open").and.returnValue(browserWindowMock);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+    //spyOn(window, "open").and.returnValue(browserWindowMock);
 
     component.perform_action();
 

--- a/src/app/datasets/datafiles-actions/datafiles-action.component.ts
+++ b/src/app/datasets/datafiles-actions/datafiles-action.component.ts
@@ -32,8 +32,6 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
   selectedTotalFileSize = 0;
   numberOfFileSelected = 0;
 
-  form: HTMLFormElement;
-
   constructor(private userApi: UserApi) {
     this.userApi.jwt().subscribe((jwt) => {
       this.jwt = jwt.jwt;
@@ -111,36 +109,66 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
   }
 
   perform_action() {
-    this.form = document.createElement("form");
-    this.form.target = this.actionConfig.target;
-    this.form.method = this.actionConfig.method;
-    this.form.action = this.actionConfig.url;
+    const action_type = this.actionConfig.type || "form";
+    switch (action_type) {
+      case "form":
+      default:
+        return this.type_form();
+    }
+  }
 
-    this.form.appendChild(
+  type_form() {
+    const form = document.createElement("form");
+    form.target = this.actionConfig.target || "_self";
+    form.method = this.actionConfig.method || "POST";
+    form.action = this.actionConfig.url;
+    form.style.display = "none";
+
+    form.appendChild(
       this.add_input("auth_token", this.userApi.getCurrentToken().id),
     );
 
-    this.form.appendChild(this.add_input("jwt", this.jwt));
+    form.appendChild(this.add_input("jwt", this.jwt));
 
-    this.form.appendChild(this.add_input("dataset", this.actionDataset.pid));
+    form.appendChild(this.add_input("dataset", this.actionDataset.pid));
 
-    this.form.appendChild(
+    form.appendChild(
       this.add_input("directory", this.actionDataset.sourceFolder),
     );
 
-    for (const [index, item] of this.files.entries()) {
+    let index = 0;
+    for (const item of this.files) {
       if (
         this.actionConfig.files === "all" ||
         (this.actionConfig.files === "selected" && item.selected)
       ) {
-        this.form.appendChild(
-          this.add_input("files[" + index + "]", item.path),
-        );
+        form.appendChild(this.add_input("files[" + index + "]", item.path));
+        index = index + 1;
       }
     }
 
-    //document.body.appendChild(form);
-    this.form.submit();
-    window.open("", "view");
+    document.body.appendChild(form);
+    form.submit();
+    document.body.removeChild(form);
+
+    return true;
   }
+
+  /*
+   * future development
+   *
+  type_fetch() {
+    const data = new URLSearchParams();
+    for (const pair of new FormData(formElement)) {
+      data.append(pair[0], pair[1]);
+    }
+
+    fetch(url, {
+      method: 'post',
+      body: data,
+    })
+    .then(…);
+    }
+  }
+   */
 }

--- a/src/app/datasets/datafiles-actions/datafiles-action.component.ts
+++ b/src/app/datasets/datafiles-actions/datafiles-action.component.ts
@@ -27,10 +27,11 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
   visible = true;
   use_mat_icon = false;
   use_icon = false;
-  //disabled = false;
   disabled_condition = "false";
   selectedTotalFileSize = 0;
   numberOfFileSelected = 0;
+
+  form: HTMLFormElement = null;
 
   constructor(private userApi: UserApi) {
     this.userApi.jwt().subscribe((jwt) => {
@@ -90,10 +91,6 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
     ).length;
   }
 
-  // compute_disabled() {
-  //   this.disabled = eval(this.disabled_condition);
-  // }
-
   get disabled() {
     this.update_status();
     this.prepare_disabled_condition();
@@ -118,21 +115,25 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
   }
 
   type_form() {
-    const form = document.createElement("form");
-    form.target = this.actionConfig.target || "_self";
-    form.method = this.actionConfig.method || "POST";
-    form.action = this.actionConfig.url;
-    form.style.display = "none";
+    if (this.form !== null) {
+      document.body.removeChild(this.form);
+    }
 
-    form.appendChild(
+    this.form = document.createElement("form");
+    this.form.target = this.actionConfig.target || "_self";
+    this.form.method = this.actionConfig.method || "POST";
+    this.form.action = this.actionConfig.url;
+    this.form.style.display = "none";
+
+    this.form.appendChild(
       this.add_input("auth_token", this.userApi.getCurrentToken().id),
     );
 
-    form.appendChild(this.add_input("jwt", this.jwt));
+    this.form.appendChild(this.add_input("jwt", this.jwt));
 
-    form.appendChild(this.add_input("dataset", this.actionDataset.pid));
+    this.form.appendChild(this.add_input("dataset", this.actionDataset.pid));
 
-    form.appendChild(
+    this.form.appendChild(
       this.add_input("directory", this.actionDataset.sourceFolder),
     );
 
@@ -142,14 +143,15 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
         this.actionConfig.files === "all" ||
         (this.actionConfig.files === "selected" && item.selected)
       ) {
-        form.appendChild(this.add_input("files[" + index + "]", item.path));
+        this.form.appendChild(
+          this.add_input("files[" + index + "]", item.path),
+        );
         index = index + 1;
       }
     }
 
-    document.body.appendChild(form);
-    form.submit();
-    document.body.removeChild(form);
+    document.body.appendChild(this.form);
+    this.form.submit();
 
     return true;
   }

--- a/src/app/datasets/datafiles-actions/datafiles-action.interfaces.ts
+++ b/src/app/datasets/datafiles-actions/datafiles-action.interfaces.ts
@@ -5,6 +5,7 @@ export interface ActionConfig {
   files: string;
   mat_icon?: string;
   icon?: string;
+  type?: string;
   url: string;
   target: string;
   authorization: string[];

--- a/src/app/datasets/datafiles-actions/datafiles-actions.component.ts
+++ b/src/app/datasets/datafiles-actions/datafiles-actions.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { ActionConfig, ActionDataset } from "./datafiles-action.interfaces";
 import { DataFiles_File } from "datasets/datafiles/datafiles.interfaces";
 import { AppConfigService } from "app-config.service";

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -140,7 +140,8 @@
       "label": "Download All",
       "files": "all",
       "mat_icon": "download",
-      "url": "",
+      "type": "form",
+      "url": "https://www.scicat.info/download/all",
       "target": "_blank",
       "enabled": "#SizeLimit",
       "authorization": ["#datasetAccess", "#datasetPublic"]
@@ -151,7 +152,8 @@
       "label": "Download Selected",
       "files": "selected",
       "mat_icon": "download",
-      "url": "",
+      "type": "form",      
+      "url": "https://www.scicat.info/download/selected",
       "target": "_blank",
       "enabled": "#Selected && #SizeLimit",
       "authorization": ["#datasetAccess", "#datasetPublic"]
@@ -162,7 +164,8 @@
       "label": "Notebook All",
       "files": "all",
       "icon": "/assets/icons/jupyter_logo.png",
-      "url": "",
+      "type": "form",      
+      "url": "https://www.scicat.info/notebook/all",
       "target": "_blank",
       "authorization": ["#datasetAccess", "#datasetPublic"]
     },
@@ -172,7 +175,8 @@
       "label": "Notebook Selected",
       "files": "selected",
       "icon": "/assets/icons/jupyter_logo.png",
-      "url": "",
+      "type": "form",      
+      "url": "https://www.scicat.info/notebook/selected",
       "target": "_blank",
       "enabled": "#Selected",
       "authorization": ["#datasetAccess", "#datasetPublic"]


### PR DESCRIPTION
## Description
this PR solves the datafiles actions bug highlighted in #1550. The only method supported is by form and it is submitted. I also changed the code to expand in the future to other actions type like using fetch api.

## Motivation
When we added datafiles actions we did not attached the form to the body therefore was not submitted. 

## Fixes:
- datafiles-action files

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\] _Not needed_
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [] Does it require a specific version of the backend
- which version of the backend is required: 
