### PR TITLE
refactor: decouple default search UI interface logic from backend

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -1,7 +1,11 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { timeout } from "rxjs/operators";
-import { TableColumn } from "state-management/models";
+import {
+  DatasetsListSettings,
+  LabelMaps,
+  TableColumn,
+} from "state-management/models";
 
 export interface OAuth2Endpoint {
   authURL: string;
@@ -91,6 +95,8 @@ export interface AppConfig {
   notificationInterceptorEnabled: boolean;
   pidSearchMethod?: string;
   metadataEditingUnitListDisabled?: boolean;
+  defaultDatasetsListSettings: DatasetsListSettings;
+  labelMaps: LabelMaps;
 }
 
 @Injectable()

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,7 +15,6 @@ import {
   fetchCurrentUserAction,
   loadDefaultSettings,
   logoutAction,
-  setDatasetTableColumnsAction,
 } from "state-management/actions/user.actions";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { Meta, Title } from "@angular/platform-browser";
@@ -73,10 +72,6 @@ export class AppComponent implements OnDestroy, OnInit, AfterViewChecked {
     console.log(LoopBackConfig.getPath());
 
     this.store.dispatch(loadDefaultSettings());
-
-    this.store.dispatch(
-      setDatasetTableColumnsAction({ columns: this.config.localColumns }),
-    );
 
     this.store.dispatch(fetchCurrentUserAction());
     if (window.location.pathname.indexOf("logout") !== -1) {

--- a/src/app/datasets/admin-tab/admin-tab.component.spec.ts
+++ b/src/app/datasets/admin-tab/admin-tab.component.spec.ts
@@ -1,46 +1,52 @@
 import { ComponentFixture, inject, TestBed } from "@angular/core/testing";
 import { Store, StoreModule } from "@ngrx/store";
-import { MockStore } from "@ngrx/store/testing";
 import { Dataset } from "shared/sdk";
 import { AdminTabComponent } from "./admin-tab.component";
 import { MatCardModule } from "@angular/material/card";
+import { of } from "rxjs";
 
 describe("AdminTabComponent", () => {
   let component: AdminTabComponent;
-  let fixture: ComponentFixture<AdminTabComponent>;
-  let store: MockStore;
+  let store: jasmine.SpyObj<Store>;
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       declarations: [AdminTabComponent],
+      providers: [
+        {
+          provide: Store,
+          useValue: jasmine.createSpyObj("Store", [
+            "select",
+            "pipe",
+            "dispatch",
+          ]),
+        },
+      ],
+      imports: [MatCardModule, StoreModule.forRoot({})], // Provide the actual StoreModule or mock Store if needed
+    });
 
-      imports: [MatCardModule, StoreModule.forRoot({})],
-    }).compileComponents();
-  });
+    store = TestBed.inject(Store) as jasmine.SpyObj<Store>;
+    component = TestBed.createComponent(AdminTabComponent).componentInstance;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AdminTabComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-  beforeEach(inject([Store], (mockStore: MockStore) => {
-    store = mockStore;
-  }));
-  afterEach(() => {
-    fixture.destroy();
+    store.select.calls.reset();
   });
   it("should create", () => {
     expect(component).toBeTruthy();
   });
   describe("#resetDataset()", () => {
     it("should return 'undefined' without confirmation", () => {
-      const dispatchSpy = spyOn(store, "dispatch");
-      const pipeSpy = spyOn(store, "pipe");
+      spyOn(window, "confirm").and.returnValue(true);
+
+      const selectSpy = store.select.and.returnValue(
+        of({ email: "test@example.com", username: "testuser" }),
+      );
+      const dispatchSpy = store.dispatch as jasmine.Spy;
+      const pipeSpy = store.select as jasmine.Spy;
       component.dataset = new Dataset();
       const res = component.resetDataset();
 
       expect(res).toBeUndefined();
-      expect(dispatchSpy).toHaveBeenCalledTimes(0);
-      expect(pipeSpy).toHaveBeenCalledTimes(0);
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(pipeSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/datasets/dashboard/dashboard.component.ts
+++ b/src/app/datasets/dashboard/dashboard.component.ts
@@ -160,7 +160,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
   updateColumnSubscription(): void {
     this.subscriptions.push(
       this.loggedIn$.subscribe((status) => {
-        const columns = this.appConfig.localColumns;
+        // NOTE: this.appConfig.localColumns is for backward compatibility.
+        //       it should be removed once localColumns is removed from the appConfig
+        const columns =
+          this.appConfig.defaultDatasetsListSettings.columns ||
+          this.appConfig.localColumns;
         this.store.dispatch(setDatasetTableColumnsAction({ columns }));
         if (!status) {
           this.tableColumns$ = this.store

--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -6,16 +6,22 @@
   <mat-card-content>
     <ng-container *ngIf="filterConfigs$ | async as filterConfigs">
       <ng-container *ngFor="let filterConfig of filterConfigs">
-        <ng-container  *ngIf="filterConfig.visible">
-          <ng-container *ngComponentOutlet="resolveComponentType(filterConfig.type); inputs: { 'clear': clearSearchBar}"></ng-container>
+        <ng-container *ngIf="filterConfig">
+          <ng-container
+            *ngComponentOutlet="
+              renderComponent(filterConfig);
+              inputs: { clear: clearSearchBar }
+            "
+          ></ng-container>
         </ng-container>
       </ng-container>
     </ng-container>
 
-
     <div class="section-container" *ngIf="appConfig.scienceSearchEnabled">
       <ng-container *ngFor="let condition of scientificConditions$ | async">
-        <ng-container *ngComponentOutlet="ConditionFilterComponent; inputs: { condition }"></ng-container>
+        <ng-container
+          *ngComponentOutlet="ConditionFilterComponent; inputs: { condition }"
+        ></ng-container>
       </ng-container>
     </div>
 
@@ -29,7 +35,7 @@
       </button>
     </div>
 
-      <div class="section-container">
+    <div class="section-container">
       <button
         mat-raised-button
         color="primary"
@@ -46,9 +52,9 @@
         class="datasets-filters-clear-all-button"
         (click)="reset()"
       >
-      <mat-icon>undo</mat-icon>
-      Reset Filters
-    </button>
+        <mat-icon>undo</mat-icon>
+        Reset Filters
+      </button>
     </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -131,7 +131,6 @@ export class DatasetsFilterComponent implements OnInit, OnDestroy {
     });
 
     dialogRef.afterClosed().subscribe((result) => {
-      this.cdr.detectChanges();
       if (result) {
         this.store.dispatch(
           updateUserSettingsAction({

--- a/src/app/datasets/datasets-filter/datasets-filter.component.ts
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.ts
@@ -88,7 +88,6 @@ export class DatasetsFilterComponent implements OnInit, OnDestroy {
     private store: Store,
     private asyncPipe: AsyncPipe,
     private viewContainerRef: ViewContainerRef,
-    private cdr: ChangeDetectorRef,
   ) {}
 
   ngOnInit() {

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.html
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.html
@@ -1,24 +1,47 @@
 <h2 mat-dialog-title>Configure Filters</h2>
 <mat-dialog-content class="filter-dialog-content">
-  <span layout="row"><hr flex/>Filters<hr flex/></span>
+  <span layout="row"
+    ><hr flex />
+    Filters
+    <hr flex
+  /></span>
   <mat-nav-list cdkDropList (cdkDropListDropped)="drop($event)">
-    <mat-list-item class="filter-item" *ngFor="let filter of data.filterConfigs" cdkDrag cdkDragHandle>
-      <span class="drag-handle" matTooltip="Drag to reorder" aria-label="Drag handle">
+    <mat-list-item
+      class="filter-item"
+      *ngFor="let filter of data.filterConfigs"
+      cdkDrag
+      cdkDragHandle
+    >
+      <span
+        class="drag-handle"
+        matTooltip="Drag to reorder"
+        aria-label="Drag handle"
+      >
         <mat-icon>sort</mat-icon>
       </span>
       <mat-slide-toggle
         class="filter-toggle"
-        [checked]="filter.visible"
+        [checked]="getChecked(filter)"
         (change)="toggleVisibility(filter)"
-        aria-label="Toggle visibility">
+        aria-label="Toggle visibility"
+      >
       </mat-slide-toggle>
-      <span class="filter-name">{{ getFilterLabel(filter.type) }}</span>
+      <span class="filter-name">{{
+        resolveFilterLabel(data.labelMaps, filter)
+      }}</span>
       <span class="spacer"></span>
     </mat-list-item>
   </mat-nav-list>
-  <span layout="row"><hr flex/>Conditions<hr flex/></span>
+  <span layout="row"
+    ><hr flex />
+    Conditions
+    <hr flex
+  /></span>
   <mat-nav-list>
-    <mat-list-item class="filter-item" *ngFor="let condition of data.conditionConfigs; index as i">
+    <mat-list-item
+      class="filter-item"
+      *ngFor="let condition of data.conditionConfigs; index as i"
+    >
       <mat-slide-toggle
         class="filter-toggle"
         aria-label="Toggle visibility"
@@ -27,45 +50,57 @@
       >
       </mat-slide-toggle>
       <span class="scientific-chip-text">
-            {{ condition.condition.lhs }}
+        {{ condition.condition.lhs }}
         <ng-container [ngSwitch]="condition.condition.relation">
-              <ng-container *ngSwitchCase="'EQUAL_TO_NUMERIC'">
-                &nbsp;=&nbsp;
-              </ng-container>
-              <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
-                &nbsp;=&nbsp;
-              </ng-container>
-              <ng-container *ngSwitchCase="'LESS_THAN'">
-                &nbsp;&lt;&nbsp;
-              </ng-container>
-              <ng-container *ngSwitchCase="'GREATER_THAN'">
-                &nbsp;&gt;&nbsp;
-              </ng-container>
-            </ng-container>
+          <ng-container *ngSwitchCase="'EQUAL_TO_NUMERIC'">
+            &nbsp;=&nbsp;
+          </ng-container>
+          <ng-container *ngSwitchCase="'EQUAL_TO_STRING'">
+            &nbsp;=&nbsp;
+          </ng-container>
+          <ng-container *ngSwitchCase="'LESS_THAN'">
+            &nbsp;&lt;&nbsp;
+          </ng-container>
+          <ng-container *ngSwitchCase="'GREATER_THAN'">
+            &nbsp;&gt;&nbsp;
+          </ng-container>
+        </ng-container>
         {{
           condition.condition.relation === "EQUAL_TO_STRING"
             ? '"' + condition.condition.rhs + '"'
             : condition.condition.rhs
         }}
         {{ condition.condition.unit | prettyUnit }}
-          </span>
+      </span>
       <span class="spacer"></span>
-      <span><mat-icon (click)="editCondition(condition, i)" (keydown)="editCondition(condition, i)">edit</mat-icon></span>
-      <span><mat-icon (click)="removeCondition(condition, i)" (keydown)="removeCondition(condition, i)">delete</mat-icon></span>
+      <span
+        ><mat-icon
+          (click)="editCondition(condition, i)"
+          (keydown)="editCondition(condition, i)"
+          >edit</mat-icon
+        ></span
+      >
+      <span
+        ><mat-icon
+          (click)="removeCondition(condition, i)"
+          (keydown)="removeCondition(condition, i)"
+          >delete</mat-icon
+        ></span
+      >
     </mat-list-item>
   </mat-nav-list>
 </mat-dialog-content>
 <mat-dialog-content>
   <div>
-  <button
-    mat-button
-    color="primary"
-    *ngIf="appConfig.scienceSearchEnabled"
-    (click)="addCondition()"
-  >
-    <mat-icon>add</mat-icon>
-    Add Conditions
-  </button>
+    <button
+      mat-button
+      color="primary"
+      *ngIf="appConfig.scienceSearchEnabled"
+      (click)="addCondition()"
+    >
+      <mat-icon>add</mat-icon>
+      Add Conditions
+    </button>
   </div>
 </mat-dialog-content>
 <mat-dialog-actions>

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.html
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.html
@@ -11,6 +11,10 @@
       *ngFor="let filter of data.filterConfigs"
       cdkDrag
       cdkDragHandle
+      [cdkDragDisabled]="!data.labelMaps[getFilterKey(filter)]"
+      [ngClass]="{
+        'filter-item-disabled': !data.labelMaps[getFilterKey(filter)],
+      }"
     >
       <span
         class="drag-handle"
@@ -24,6 +28,7 @@
         [checked]="getChecked(filter)"
         (change)="toggleVisibility(filter)"
         aria-label="Toggle visibility"
+        [disabled]="!data.labelMaps[getFilterKey(filter)]"
       >
       </mat-slide-toggle>
       <span class="filter-name">{{

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.scss
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.scss
@@ -26,13 +26,18 @@ mat-list-item {
   border-bottom: 1px solid #ccc; /* Adds a subtle line between items for better visual separation */
 }
 
-
 .filter-item {
   display: flex;
   align-items: center; /* Align items vertically in the center */
   justify-content: space-between; /* Spread out the items to fill the horizontal space */
   padding: 8px 16px; /* Add some padding around the items */
   border-bottom: 1px solid #e0e0e0; /* Optional: adds a separator line between items */
+
+  &-disabled {
+    opacity: 0.5; /* Dim the item to indicate it's disabled */
+    pointer-events: none;
+    cursor: not-allowed;
+  }
 }
 
 .filter-toggle {

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from "@angular/core";
+import { ChangeDetectionStrategy, Component, Inject } from "@angular/core";
 import {
   MAT_DIALOG_DATA,
   MatDialog,
@@ -27,11 +27,14 @@ import {
   selector: "app-type-datasets-filter-settings",
   templateUrl: `./datasets-filter-settings.component.html`,
   styleUrls: [`./datasets-filter-settings.component.scss`],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DatasetsFilterSettingsComponent {
   metadataKeys$ = this.store.select(selectMetadataKeys);
 
   appConfig = this.appConfigService.getConfig();
+
+  filterValidationStatus = {};
 
   constructor(
     public dialogRef: MatDialogRef<DatasetsFilterSettingsComponent>,
@@ -130,12 +133,12 @@ export class DatasetsFilterSettingsComponent {
   }
 
   toggleVisibility(filter: FilterConfig): void {
-    const key = Object.keys(filter)[0];
+    const key = this.getFilterKey(filter);
     filter[key] = !filter[key];
   }
 
   getChecked(filter: FilterConfig): boolean {
-    const key = Object.keys(filter)[0];
+    const key = this.getFilterKey(filter);
     return filter[key];
   }
 
@@ -159,8 +162,11 @@ export class DatasetsFilterSettingsComponent {
     labelMaps: Record<string, string>,
     filter: FilterConfig,
   ): string {
-    const key = Object.keys(filter)[0];
-
+    const key = this.getFilterKey(filter);
     return labelMaps[key] || "Unknown filter";
+  }
+
+  getFilterKey(filter: FilterConfig): string {
+    return Object.keys(filter)[0];
   }
 }

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -23,7 +23,6 @@ import {
   FilterConfig,
 } from "../../../shared/modules/filters/filters.module";
 import { getFilterLabel } from "../../../shared/modules/filters/utils";
-import { ScientificCondition } from "../../../state-management/models";
 
 @Component({
   selector: "app-type-datasets-filter-settings",

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Inject } from "@angular/core";
+import { Component, Inject } from "@angular/core";
 import {
   MAT_DIALOG_DATA,
   MatDialog,
@@ -22,7 +22,6 @@ import {
   ConditionConfig,
   FilterConfig,
 } from "../../../shared/modules/filters/filters.module";
-import { getFilterLabel } from "../../../shared/modules/filters/utils";
 
 @Component({
   selector: "app-type-datasets-filter-settings",
@@ -30,8 +29,6 @@ import { getFilterLabel } from "../../../shared/modules/filters/utils";
   styleUrls: [`./datasets-filter-settings.component.scss`],
 })
 export class DatasetsFilterSettingsComponent {
-  protected readonly getFilterLabel = getFilterLabel;
-
   metadataKeys$ = this.store.select(selectMetadataKeys);
 
   appConfig = this.appConfigService.getConfig();
@@ -132,8 +129,14 @@ export class DatasetsFilterSettingsComponent {
     return condition;
   }
 
-  toggleVisibility(filter: FilterConfig) {
-    filter.visible = !filter.visible;
+  toggleVisibility(filter: FilterConfig): void {
+    const key = Object.keys(filter)[0];
+    filter[key] = !filter[key];
+  }
+
+  getChecked(filter: FilterConfig): boolean {
+    const key = Object.keys(filter)[0];
+    return filter[key];
   }
 
   drop(event: CdkDragDrop<string[]>): void {
@@ -150,5 +153,14 @@ export class DatasetsFilterSettingsComponent {
 
   onCancel() {
     this.dialogRef.close();
+  }
+
+  resolveFilterLabel(
+    labelMaps: Record<string, string>,
+    filter: FilterConfig,
+  ): string {
+    const key = Object.keys(filter)[0];
+
+    return labelMaps[key] || "Unknown filter";
   }
 }

--- a/src/app/shared/modules/filters/date-range-filter.component.ts
+++ b/src/app/shared/modules/filters/date-range-filter.component.ts
@@ -5,6 +5,9 @@ import { DateTime } from "luxon";
 import { setDateRangeFilterAction } from "state-management/actions/datasets.actions";
 import { selectCreationTimeFilter } from "state-management/selectors/datasets.selectors";
 import { Store } from "@ngrx/store";
+import { FilterComponentInterface } from "./interface/filter-component.interface";
+import { AppConfigService } from "app-config.service";
+import { getFilterLabel } from "./utils";
 
 interface DateRange {
   begin: string;
@@ -16,7 +19,14 @@ interface DateRange {
   templateUrl: "date-range-filter.component.html",
   styleUrls: ["date-range-filter.component.scss"],
 })
-export class DateRangeFilterComponent extends ClearableInputComponent {
+export class DateRangeFilterComponent
+  extends ClearableInputComponent
+  implements FilterComponentInterface
+{
+  readonly componentName: string = "DateRangeFilter";
+  readonly label: string = "Start Date - End Date";
+
+  appConfig = this.appConfigService.getConfig();
   creationTimeFilter$ = this.store.select(selectCreationTimeFilter);
 
   dateRange: DateRange = {
@@ -24,12 +34,14 @@ export class DateRangeFilterComponent extends ClearableInputComponent {
     end: "",
   };
 
-  constructor(private store: Store) {
+  constructor(
+    private store: Store,
+    private appConfigService: AppConfigService,
+  ) {
     super();
-  }
 
-  get label() {
-    return "Start Date - End Date";
+    const filters = this.appConfig.labelMaps?.filters;
+    this.label = getFilterLabel(filters, this.componentName, this.label);
   }
 
   dateChanged(event: MatDatepickerInputEvent<DateTime>) {

--- a/src/app/shared/modules/filters/date-range-filter.component.ts
+++ b/src/app/shared/modules/filters/date-range-filter.component.ts
@@ -5,7 +5,6 @@ import { DateTime } from "luxon";
 import { setDateRangeFilterAction } from "state-management/actions/datasets.actions";
 import { selectCreationTimeFilter } from "state-management/selectors/datasets.selectors";
 import { Store } from "@ngrx/store";
-import { getFilterLabel } from "./utils";
 
 interface DateRange {
   begin: string;
@@ -30,7 +29,7 @@ export class DateRangeFilterComponent extends ClearableInputComponent {
   }
 
   get label() {
-    return getFilterLabel(this.constructor.name);
+    return "Start Date - End Date";
   }
 
   dateChanged(event: MatDatepickerInputEvent<DateTime>) {

--- a/src/app/shared/modules/filters/filters.module.ts
+++ b/src/app/shared/modules/filters/filters.module.ts
@@ -57,20 +57,20 @@ import { MatAutocompleteModule } from "@angular/material/autocomplete";
 })
 export class FiltersModule {}
 
-export type Filter =
-  | "PidFilter"
-  | "PidFilterContains"
-  | "PidFilterStartsWith"
-  | "LocationFilter"
-  | "GroupFilter"
-  | "TypeFilter"
-  | "KeywordFilter"
-  | "DateRangeFilter"
-  | "TextFilter"
-  | "ConditionFilter";
-
+export enum Filters {
+  PidFilter = "PidFilter",
+  PidFilterContains = "PidFilterContains",
+  PidFilterStartsWith = "PidFilterStartsWith",
+  LocationFilter = "LocationFilter",
+  GroupFilter = "GroupFilter",
+  TypeFilter = "TypeFilter",
+  KeywordFilter = "KeywordFilter",
+  DateRangeFilter = "DateRangeFilter",
+  TextFilter = "TextFilter",
+  ConditionFilter = "ConditionFilter",
+}
 export type FilterConfig = Partial<{
-  [K in Filter]: boolean;
+  [K in Filters]: boolean;
 }>;
 
 export interface ConditionConfig {

--- a/src/app/shared/modules/filters/filters.module.ts
+++ b/src/app/shared/modules/filters/filters.module.ts
@@ -57,22 +57,21 @@ import { MatAutocompleteModule } from "@angular/material/autocomplete";
 })
 export class FiltersModule {}
 
-type Filter =
-  | "PidFilterComponent"
-  | "PidFilterContainsComponent"
-  | "PidFilterStartsWithComponent"
-  | "LocationFilterComponent"
-  | "GroupFilterComponent"
-  | "TypeFilterComponent"
-  | "KeywordFilterComponent"
-  | "DateRangeFilterComponent"
-  | "TextFilterComponent"
-  | "ConditionFilterComponent";
+export type Filter =
+  | "PidFilter"
+  | "PidFilterContains"
+  | "PidFilterStartsWith"
+  | "LocationFilter"
+  | "GroupFilter"
+  | "TypeFilter"
+  | "KeywordFilter"
+  | "DateRangeFilter"
+  | "TextFilter"
+  | "ConditionFilter";
 
-export interface FilterConfig {
-  type: Filter;
-  visible: boolean;
-}
+export type FilterConfig = Partial<{
+  [K in Filter]: boolean;
+}>;
 
 export interface ConditionConfig {
   condition: ScientificCondition;

--- a/src/app/shared/modules/filters/group-filter.component.ts
+++ b/src/app/shared/modules/filters/group-filter.component.ts
@@ -8,18 +8,32 @@ import {
   addGroupFilterAction,
   removeGroupFilterAction,
 } from "state-management/actions/datasets.actions";
-import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
+import {
+  createSuggestionObserver,
+  getFacetCount,
+  getFacetId,
+  getFilterLabel,
+} from "./utils";
 import { BehaviorSubject } from "rxjs";
 import { ClearableInputComponent } from "./clearable-input.component";
+import { AppConfigService } from "app-config.service";
+import { FilterComponentInterface } from "./interface/filter-component.interface";
 
 @Component({
   selector: "app-group-filter",
   templateUrl: "group-filter.component.html",
   styleUrls: ["group-filter.component.scss"],
 })
-export class GroupFilterComponent extends ClearableInputComponent {
+export class GroupFilterComponent
+  extends ClearableInputComponent
+  implements FilterComponentInterface
+{
   protected readonly getFacetId = getFacetId;
   protected readonly getFacetCount = getFacetCount;
+  readonly componentName: string = "GroupFilter";
+  readonly label: string = "Group Filter";
+
+  appConfig = this.appConfigService.getConfig();
 
   groupFilter$ = this.store.select(selectGroupFilter);
 
@@ -32,12 +46,14 @@ export class GroupFilterComponent extends ClearableInputComponent {
     this.groupFilter$,
   );
 
-  constructor(private store: Store) {
+  constructor(
+    private store: Store,
+    private appConfigService: AppConfigService,
+  ) {
     super();
-  }
 
-  get label() {
-    return "Group";
+    const filters = this.appConfig.labelMaps?.filters;
+    this.label = getFilterLabel(filters, this.componentName, this.label);
   }
 
   onGroupInput(event: any) {

--- a/src/app/shared/modules/filters/group-filter.component.ts
+++ b/src/app/shared/modules/filters/group-filter.component.ts
@@ -8,12 +8,7 @@ import {
   addGroupFilterAction,
   removeGroupFilterAction,
 } from "state-management/actions/datasets.actions";
-import {
-  createSuggestionObserver,
-  getFacetCount,
-  getFacetId,
-  getFilterLabel,
-} from "./utils";
+import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
 import { BehaviorSubject } from "rxjs";
 import { ClearableInputComponent } from "./clearable-input.component";
 
@@ -42,7 +37,7 @@ export class GroupFilterComponent extends ClearableInputComponent {
   }
 
   get label() {
-    return getFilterLabel(this.constructor.name);
+    return "Group";
   }
 
   onGroupInput(event: any) {

--- a/src/app/shared/modules/filters/group-filter.component.ts
+++ b/src/app/shared/modules/filters/group-filter.component.ts
@@ -8,7 +8,12 @@ import {
   addGroupFilterAction,
   removeGroupFilterAction,
 } from "state-management/actions/datasets.actions";
-import { createSuggestionObserver, getFacetCount, getFacetId, getFilterLabel } from "./utils";
+import {
+  createSuggestionObserver,
+  getFacetCount,
+  getFacetId,
+  getFilterLabel,
+} from "./utils";
 import { BehaviorSubject } from "rxjs";
 import { ClearableInputComponent } from "./clearable-input.component";
 import { FilterComponentInterface } from "./interface/filter-component.interface";

--- a/src/app/shared/modules/filters/interface/filter-component.interface.ts
+++ b/src/app/shared/modules/filters/interface/filter-component.interface.ts
@@ -1,0 +1,4 @@
+export interface FilterComponentInterface {
+  readonly componentName: string;
+  readonly label: string;
+}

--- a/src/app/shared/modules/filters/keyword-filter.component.ts
+++ b/src/app/shared/modules/filters/keyword-filter.component.ts
@@ -1,11 +1,6 @@
 import { Component, OnDestroy } from "@angular/core";
 import { ClearableInputComponent } from "./clearable-input.component";
-import {
-  createSuggestionObserver,
-  getFacetCount,
-  getFacetId,
-  getFilterLabel,
-} from "./utils";
+import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
 import {
   selectKeywordFacetCounts,
   selectKeywordsFilter,
@@ -61,7 +56,7 @@ export class KeywordFilterComponent
   }
 
   get label() {
-    return getFilterLabel(this.constructor.name);
+    return "Keyword";
   }
 
   onKeywordInput(event: any) {

--- a/src/app/shared/modules/filters/keyword-filter.component.ts
+++ b/src/app/shared/modules/filters/keyword-filter.component.ts
@@ -1,6 +1,11 @@
 import { Component, OnDestroy } from "@angular/core";
 import { ClearableInputComponent } from "./clearable-input.component";
-import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
+import {
+  createSuggestionObserver,
+  getFacetCount,
+  getFacetId,
+  getFilterLabel,
+} from "./utils";
 import {
   selectKeywordFacetCounts,
   selectKeywordsFilter,
@@ -13,6 +18,7 @@ import {
   removeKeywordFilterAction,
 } from "state-management/actions/datasets.actions";
 import { debounceTime, distinctUntilChanged, skipWhile } from "rxjs/operators";
+import { AppConfigService } from "app-config.service";
 
 @Component({
   selector: "app-keyword-filter",
@@ -25,6 +31,10 @@ export class KeywordFilterComponent
 {
   protected readonly getFacetCount = getFacetCount;
   protected readonly getFacetId = getFacetId;
+  readonly componentName: string = "KeywordFilter";
+  readonly label: string = "Keyword Filter";
+
+  appConfig = this.appConfigService.getConfig();
 
   keywordsTerms$ = this.store.select(selectKeywordsTerms);
 
@@ -41,9 +51,14 @@ export class KeywordFilterComponent
     this.keywordsFilter$,
   );
 
-  constructor(private store: Store) {
+  constructor(
+    private store: Store,
+    private appConfigService: AppConfigService,
+  ) {
     super();
 
+    const filters = this.appConfig.labelMaps?.filters;
+    this.label = getFilterLabel(filters, this.componentName, this.label);
     this.subscription = this.keywordsTerms$
       .pipe(
         skipWhile((terms) => terms === ""),
@@ -53,10 +68,6 @@ export class KeywordFilterComponent
       .subscribe((terms) => {
         this.store.dispatch(addKeywordFilterAction({ keyword: terms }));
       });
-  }
-
-  get label() {
-    return "Keyword";
   }
 
   onKeywordInput(event: any) {

--- a/src/app/shared/modules/filters/location-filter.component.ts
+++ b/src/app/shared/modules/filters/location-filter.component.ts
@@ -3,12 +3,7 @@ import {
   selectLocationFacetCounts,
   selectLocationFilter,
 } from "state-management/selectors/datasets.selectors";
-import {
-  createSuggestionObserver,
-  getFacetCount,
-  getFacetId,
-  getFilterLabel,
-} from "./utils";
+import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
 import { BehaviorSubject } from "rxjs";
 import {
   addLocationFilterAction,
@@ -42,7 +37,7 @@ export class LocationFilterComponent extends ClearableInputComponent {
   }
 
   get label() {
-    return getFilterLabel(this.constructor.name);
+    return "Location";
   }
 
   locationSelected(location: string | null) {

--- a/src/app/shared/modules/filters/location-filter.component.ts
+++ b/src/app/shared/modules/filters/location-filter.component.ts
@@ -3,7 +3,12 @@ import {
   selectLocationFacetCounts,
   selectLocationFilter,
 } from "state-management/selectors/datasets.selectors";
-import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
+import {
+  createSuggestionObserver,
+  getFacetCount,
+  getFacetId,
+  getFilterLabel,
+} from "./utils";
 import { BehaviorSubject } from "rxjs";
 import {
   addLocationFilterAction,
@@ -11,15 +16,24 @@ import {
 } from "state-management/actions/datasets.actions";
 import { ClearableInputComponent } from "./clearable-input.component";
 import { Store } from "@ngrx/store";
+import { FilterComponentInterface } from "./interface/filter-component.interface";
+import { AppConfigService } from "app-config.service";
 
 @Component({
   selector: "app-location-filter",
   templateUrl: "location-filter.component.html",
   styleUrls: ["location-filter.component.scss"],
 })
-export class LocationFilterComponent extends ClearableInputComponent {
+export class LocationFilterComponent
+  extends ClearableInputComponent
+  implements FilterComponentInterface
+{
   protected readonly getFacetId = getFacetId;
   protected readonly getFacetCount = getFacetCount;
+  readonly componentName: string = "LocationFilter";
+  readonly label: string = "Location Filter";
+
+  appConfig = this.appConfigService.getConfig();
 
   locationFacetCounts$ = this.store.select(selectLocationFacetCounts);
   locationFilter$ = this.store.select(selectLocationFilter);
@@ -32,12 +46,14 @@ export class LocationFilterComponent extends ClearableInputComponent {
     this.locationFilter$,
   );
 
-  constructor(private store: Store) {
+  constructor(
+    private store: Store,
+    public appConfigService: AppConfigService,
+  ) {
     super();
-  }
 
-  get label() {
-    return "Location";
+    const filters = this.appConfig.labelMaps?.filters;
+    this.label = getFilterLabel(filters, this.componentName, this.label);
   }
 
   locationSelected(location: string | null) {

--- a/src/app/shared/modules/filters/pid-filter-contains.component.ts
+++ b/src/app/shared/modules/filters/pid-filter-contains.component.ts
@@ -7,6 +7,10 @@ import { Component } from "@angular/core";
   styleUrls: ["./pid-filter-contains.component.scss"],
 })
 export class PidFilterContainsComponent extends PidFilterComponent {
+  get label() {
+    return "PID filter (Contains)";
+  }
+
   buildPidTermsCondition(terms: string): { $regex: string } {
     return { $regex: terms };
   }

--- a/src/app/shared/modules/filters/pid-filter-contains.component.ts
+++ b/src/app/shared/modules/filters/pid-filter-contains.component.ts
@@ -7,9 +7,8 @@ import { Component } from "@angular/core";
   styleUrls: ["./pid-filter-contains.component.scss"],
 })
 export class PidFilterContainsComponent extends PidFilterComponent {
-  get label() {
-    return "PID filter (Contains)";
-  }
+  readonly componentName: string = "PidFilter";
+  readonly label: string = "PID filter (Contains)- Not implemented";
 
   buildPidTermsCondition(terms: string): { $regex: string } {
     return { $regex: terms };

--- a/src/app/shared/modules/filters/pid-filter-startsWith.component.ts
+++ b/src/app/shared/modules/filters/pid-filter-startsWith.component.ts
@@ -7,9 +7,8 @@ import { Component } from "@angular/core";
   styleUrls: ["./pid-filter-startsWith.component.scss"],
 })
 export class PidFilterStartsWithComponent extends PidFilterComponent {
-  get label(): string {
-    return "PID filter (Starts With)";
-  }
+  readonly componentName: string = "PidFilter";
+  readonly label: string = "PID filter (Starts With)- Not implemented";
 
   buildPidTermsCondition(terms: string): { $regex: string } {
     return { $regex: `^${terms}` };

--- a/src/app/shared/modules/filters/pid-filter-startsWith.component.ts
+++ b/src/app/shared/modules/filters/pid-filter-startsWith.component.ts
@@ -7,7 +7,9 @@ import { Component } from "@angular/core";
   styleUrls: ["./pid-filter-startsWith.component.scss"],
 })
 export class PidFilterStartsWithComponent extends PidFilterComponent {
-  static kLabel = "PID filter (Starts With)";
+  get label(): string {
+    return "PID filter (Starts With)";
+  }
 
   buildPidTermsCondition(terms: string): { $regex: string } {
     return { $regex: `^${terms}` };

--- a/src/app/shared/modules/filters/pid-filter.component.spec.ts
+++ b/src/app/shared/modules/filters/pid-filter.component.spec.ts
@@ -15,7 +15,7 @@ import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { setPidTermsFilterAction } from "state-management/actions/datasets.actions";
 import { SharedScicatFrontendModule } from "shared/shared.module";
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
-import { MatDialogModule, MatDialog } from "@angular/material/dialog";
+import { MatDialogModule } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";

--- a/src/app/shared/modules/filters/pid-filter.component.ts
+++ b/src/app/shared/modules/filters/pid-filter.component.ts
@@ -8,6 +8,8 @@ import {
 import { debounceTime } from "rxjs/operators";
 import { AppConfigService } from "app-config.service";
 import { ClearableInputComponent } from "./clearable-input.component";
+import { FilterComponentInterface } from "./interface/filter-component.interface";
+import { getFilterLabel } from "./utils";
 
 @Component({
   selector: "app-pid-filter",
@@ -16,10 +18,12 @@ import { ClearableInputComponent } from "./clearable-input.component";
 })
 export class PidFilterComponent
   extends ClearableInputComponent<string>
-  implements OnDestroy
+  implements FilterComponentInterface, OnDestroy
 {
   private pidSubject = new Subject<string>();
   private subscription: Subscription;
+  readonly componentName: string = "PidFilter";
+  readonly label: string = "Pid Filter";
 
   appConfig = this.appConfigService.getConfig();
 
@@ -28,16 +32,15 @@ export class PidFilterComponent
     private store: Store,
   ) {
     super();
+
+    const filters = this.appConfig.labelMaps?.filters;
+    this.label = getFilterLabel(filters, this.componentName, this.label);
     this.subscription = this.pidSubject
       .pipe(debounceTime(500))
       .subscribe((pid) => {
         const condition = !pid ? "" : this.buildPidTermsCondition(pid);
         this.store.dispatch(setPidTermsFilterAction({ pid: condition }));
       });
-  }
-
-  get label() {
-    return "PID filter (Equals)";
   }
 
   buildPidTermsCondition(terms: string): string | { $regex: string } {

--- a/src/app/shared/modules/filters/pid-filter.component.ts
+++ b/src/app/shared/modules/filters/pid-filter.component.ts
@@ -5,10 +5,9 @@ import {
   setPidTermsAction,
   setPidTermsFilterAction,
 } from "state-management/actions/datasets.actions";
-import { debounceTime, distinctUntilChanged, skipWhile } from "rxjs/operators";
+import { debounceTime } from "rxjs/operators";
 import { AppConfigService } from "app-config.service";
 import { ClearableInputComponent } from "./clearable-input.component";
-import { getFilterLabel } from "./utils";
 
 @Component({
   selector: "app-pid-filter",
@@ -38,7 +37,7 @@ export class PidFilterComponent
   }
 
   get label() {
-    return getFilterLabel((this.constructor as typeof PidFilterComponent).name);
+    return "PID filter (Equals)";
   }
 
   buildPidTermsCondition(terms: string): string | { $regex: string } {

--- a/src/app/shared/modules/filters/text-filter.component.ts
+++ b/src/app/shared/modules/filters/text-filter.component.ts
@@ -4,6 +4,9 @@ import { Store } from "@ngrx/store";
 import { setTextFilterAction } from "state-management/actions/datasets.actions";
 import { debounceTime, distinctUntilChanged, skipWhile } from "rxjs/operators";
 import { Subject, Subscription } from "rxjs";
+import { AppConfigService } from "app-config.service";
+import { FilterComponentInterface } from "./interface/filter-component.interface";
+import { getFilterLabel } from "./utils";
 
 @Component({
   selector: "app-text-filter",
@@ -12,14 +15,23 @@ import { Subject, Subscription } from "rxjs";
 })
 export class TextFilterComponent
   extends ClearableInputComponent
-  implements OnDestroy
+  implements FilterComponentInterface, OnDestroy
 {
   private textSubject = new Subject<string>();
+  readonly componentName: string = "TextFilter";
+  readonly label: string = "Text Filter";
 
+  appConfig = this.appConfigService.getConfig();
   subscription: Subscription;
 
-  constructor(private store: Store) {
+  constructor(
+    private store: Store,
+    public appConfigService: AppConfigService,
+  ) {
     super();
+
+    const filters = this.appConfig.labelMaps?.filters;
+    this.label = getFilterLabel(filters, this.componentName, this.label);
     this.subscription = this.textSubject
       .pipe(
         skipWhile((terms) => terms === ""),
@@ -29,10 +41,6 @@ export class TextFilterComponent
       .subscribe((terms) => {
         this.store.dispatch(setTextFilterAction({ text: terms }));
       });
-  }
-
-  get label() {
-    return "Text filter";
   }
 
   textSearchChanged(event: any) {

--- a/src/app/shared/modules/filters/text-filter.component.ts
+++ b/src/app/shared/modules/filters/text-filter.component.ts
@@ -4,7 +4,6 @@ import { Store } from "@ngrx/store";
 import { setTextFilterAction } from "state-management/actions/datasets.actions";
 import { debounceTime, distinctUntilChanged, skipWhile } from "rxjs/operators";
 import { Subject, Subscription } from "rxjs";
-import { getFilterLabel } from "./utils";
 
 @Component({
   selector: "app-text-filter",
@@ -33,7 +32,7 @@ export class TextFilterComponent
   }
 
   get label() {
-    return getFilterLabel(this.constructor.name);
+    return "Text filter";
   }
 
   textSearchChanged(event: any) {

--- a/src/app/shared/modules/filters/type-filter.component.ts
+++ b/src/app/shared/modules/filters/type-filter.component.ts
@@ -1,11 +1,6 @@
 import { Component } from "@angular/core";
 import { ClearableInputComponent } from "./clearable-input.component";
-import {
-  createSuggestionObserver,
-  getFacetCount,
-  getFacetId,
-  getFilterLabel,
-} from "./utils";
+import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
 import {
   selectTypeFacetCounts,
   selectTypeFilter,
@@ -42,7 +37,7 @@ export class TypeFilterComponent extends ClearableInputComponent {
   }
 
   get label() {
-    return getFilterLabel(this.constructor.name);
+    return "Type filter";
   }
 
   onTypeInput(event: any) {

--- a/src/app/shared/modules/filters/type-filter.component.ts
+++ b/src/app/shared/modules/filters/type-filter.component.ts
@@ -1,6 +1,11 @@
 import { Component } from "@angular/core";
 import { ClearableInputComponent } from "./clearable-input.component";
-import { createSuggestionObserver, getFacetCount, getFacetId } from "./utils";
+import {
+  createSuggestionObserver,
+  getFacetCount,
+  getFacetId,
+  getFilterLabel,
+} from "./utils";
 import {
   selectTypeFacetCounts,
   selectTypeFilter,
@@ -11,15 +16,24 @@ import {
   addTypeFilterAction,
   removeTypeFilterAction,
 } from "state-management/actions/datasets.actions";
+import { AppConfigService } from "app-config.service";
+import { FilterComponentInterface } from "./interface/filter-component.interface";
 
 @Component({
   selector: "app-type-filter",
   templateUrl: "type-filter.component.html",
   styleUrls: ["type-filter.component.scss"],
 })
-export class TypeFilterComponent extends ClearableInputComponent {
+export class TypeFilterComponent
+  extends ClearableInputComponent
+  implements FilterComponentInterface
+{
   protected readonly getFacetCount = getFacetCount;
   protected readonly getFacetId = getFacetId;
+  readonly componentName: string = "TypeFilter";
+  readonly label: string = "Type Filter";
+
+  appConfig = this.appConfigService.getConfig();
 
   typeFacetCounts$ = this.store.select(selectTypeFacetCounts);
 
@@ -32,12 +46,14 @@ export class TypeFilterComponent extends ClearableInputComponent {
     this.typeFilter$,
   );
 
-  constructor(private store: Store) {
+  constructor(
+    private store: Store,
+    public appConfigService: AppConfigService,
+  ) {
     super();
-  }
 
-  get label() {
-    return "Type filter";
+    const filters = this.appConfig.labelMaps?.filters;
+    this.label = getFilterLabel(filters, this.componentName, this.label);
   }
 
   onTypeInput(event: any) {

--- a/src/app/shared/modules/filters/type-filter.component.ts
+++ b/src/app/shared/modules/filters/type-filter.component.ts
@@ -1,6 +1,11 @@
 import { Component } from "@angular/core";
 import { ClearableInputComponent } from "./clearable-input.component";
-import { createSuggestionObserver, getFacetCount, getFacetId, getFilterLabel } from "./utils";
+import {
+  createSuggestionObserver,
+  getFacetCount,
+  getFacetId,
+  getFilterLabel,
+} from "./utils";
 import {
   selectTypeFacetCounts,
   selectTypeFilter,
@@ -49,7 +54,7 @@ export class TypeFilterComponent
 
     const filters = this.appConfig.labelMaps?.filters;
     this.label = getFilterLabel(filters, this.componentName, this.label);
-
+  }
   onTypeInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.typeInput$.next(value);

--- a/src/app/shared/modules/filters/utils.ts
+++ b/src/app/shared/modules/filters/utils.ts
@@ -31,18 +31,14 @@ export function getFacetCount(facetCount: FacetCount): number {
   return facetCount.count;
 }
 
-const labelMap: Map<string, string> = new Map([
-  ["DateRangeFilterComponent", "Start Date - End Date"],
-  ["GroupFilterComponent", "Group"],
-  ["KeywordFilterComponent", "Keyword"],
-  ["LocationFilterComponent", "Location"],
-  ["PidFilterStartsWithComponent", "PID filter (Starts With)"],
-  ["PidFilterComponent", "PID filter (Equals)"],
-  ["PidFilterContainsComponent", "PID filter (Contains)"],
-  ["TextFilterComponent", "Text filter"],
-  ["TypeFilterComponent", "Type filter"],
-]);
+export function getFilterLabel(
+  filters: Record<string, string> | undefined,
+  componentName: string,
+  defaultLabel: string,
+): string {
+  if (!filters || !componentName || !filters[componentName]) {
+    return defaultLabel;
+  }
 
-export function getFilterLabel(type: string): string {
-  return labelMap.get(type) || "Default Label";
+  return filters[componentName];
 }

--- a/src/app/shared/sdk/services/custom/User.ts
+++ b/src/app/shared/sdk/services/custom/User.ts
@@ -314,6 +314,106 @@ export class UserApi extends BaseLoopBackApi {
   }
 
   /**
+   * Update settings of this model.
+   *
+   * @param {any} id User id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `User` object.)
+   * </em>
+   */
+  public partialUpdateSettings(
+    id: any,
+    data: any = {},
+    customHeaders?: Function,
+  ): Observable<any> {
+    let _method: string = "PATCH";
+    let _url: string =
+      LoopBackConfig.getPath() +
+      "/" +
+      LoopBackConfig.getApiVersion() +
+      "/Users/:id/settings";
+    let _routeParams: any = {
+      id: id,
+    };
+
+    let _postBody: any = {
+      data: data,
+    };
+
+    let _urlParams: any = {};
+    let result = this.request(
+      _method,
+      _url,
+      _routeParams,
+      _urlParams,
+      _postBody,
+      null,
+      customHeaders,
+    );
+    return result;
+  }
+
+  /**
+   * Update settings of this model.
+   *
+   * @param {any} id User id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `User` object.)
+   * </em>
+   */
+  public partialUpdateExternalSettings(
+    id: any,
+    data: any = {},
+    customHeaders?: Function,
+  ): Observable<any> {
+    let _method: string = "PATCH";
+    let _url: string =
+      LoopBackConfig.getPath() +
+      "/" +
+      LoopBackConfig.getApiVersion() +
+      "/Users/:id/settings/external";
+    let _routeParams: any = {
+      id: id,
+    };
+
+    let _postBody: any = {
+      data: data,
+    };
+
+    let _urlParams: any = {};
+    let result = this.request(
+      _method,
+      _url,
+      _routeParams,
+      _urlParams,
+      _postBody,
+      null,
+      customHeaders,
+    );
+    return result;
+  }
+
+  /**
    * Deletes settings of this model.
    *
    * @param {any} id User id
@@ -1278,7 +1378,7 @@ export class UserApi extends BaseLoopBackApi {
       LoopBackConfig.getPath() +
       "/" +
       LoopBackConfig.getApiVersion() +
-      "/Users/login";
+      "/auth/login";
     let _routeParams: any = {};
     let _postBody: any = {
       credentials: credentials,

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -30,6 +30,10 @@ export {
 };
 
 import { DatasetInterface } from "shared/sdk";
+import {
+  ConditionConfig,
+  FilterConfig,
+} from "shared/modules/filters/filters.module";
 export { DatasetInterface };
 
 export interface Settings {
@@ -44,6 +48,16 @@ export interface TableColumn {
   order: number;
   type: "standard" | "custom";
   enabled: boolean;
+}
+
+export interface LabelMaps {
+  [key: string]: Record<string, string>;
+}
+
+export interface DatasetsListSettings {
+  columns: TableColumn[];
+  filters: FilterConfig[];
+  conditions: ConditionConfig[];
 }
 
 export enum MessageType {

--- a/src/app/state-management/reducers/user.reducer.ts
+++ b/src/app/state-management/reducers/user.reducer.ts
@@ -76,7 +76,7 @@ const reducer = createReducer(
     (state, { userSettings }): UserState => {
       const { datasetCount, jobCount, columns } = userSettings;
       const settings = { ...state.settings, datasetCount, jobCount };
-      if (columns.length > 0) {
+      if (columns?.length > 0) {
         return { ...state, settings, columns };
       } else {
         return { ...state, settings };

--- a/src/app/state-management/state/user.store.ts
+++ b/src/app/state-management/state/user.store.ts
@@ -4,15 +4,6 @@ import {
   ConditionConfig,
   FilterConfig,
 } from "../../shared/modules/filters/filters.module";
-import { LocationFilterComponent } from "../../shared/modules/filters/location-filter.component";
-import { PidFilterComponent } from "../../shared/modules/filters/pid-filter.component";
-import { PidFilterContainsComponent } from "../../shared/modules/filters/pid-filter-contains.component";
-import { PidFilterStartsWithComponent } from "../../shared/modules/filters/pid-filter-startsWith.component";
-import { GroupFilterComponent } from "../../shared/modules/filters/group-filter.component";
-import { TypeFilterComponent } from "../../shared/modules/filters/type-filter.component";
-import { KeywordFilterComponent } from "../../shared/modules/filters/keyword-filter.component";
-import { DateRangeFilterComponent } from "../../shared/modules/filters/date-range-filter.component";
-import { TextFilterComponent } from "../../shared/modules/filters/text-filter.component";
 
 // NOTE It IS ok to make up a state of other sub states
 export interface UserState {
@@ -68,14 +59,13 @@ export const initialUserState: UserState = {
   columns: [],
 
   filters: [
-    { type: "LocationFilterComponent", visible: true },
-    { type: "PidFilterComponent", visible: true },
-    { type: "PidFilterContainsComponent", visible: false },
-    { type: "PidFilterStartsWithComponent", visible: false },
-    { type: "GroupFilterComponent", visible: true },
-    { type: "TypeFilterComponent", visible: true },
-    { type: "KeywordFilterComponent", visible: true },
-    { type: "DateRangeFilterComponent", visible: true },
+    { LocationFilter: true },
+    { PidFilter: true },
+    { GroupFilter: true },
+    { TypeFilter: true },
+    { KeywordFilter: true },
+    { DateRangeFilter: true },
+    { TextFilter: true },
   ],
 
   conditions: [],

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -26,86 +26,6 @@
   "jupyterHubUrl": "https://jupyterhub.esss.lu.se/",
   "landingPage": "doi.ess.eu/detail/",
   "lbBaseURL": "http://127.0.0.1:3000",
-  "localColumns": [
-    {
-      "name": "select",
-      "order": 0,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "pid",
-      "order": 1,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "datasetName",
-      "order": 2,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "runNumber",
-      "order": 3,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "sourceFolder",
-      "order": 4,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "size",
-      "order": 5,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "creationTime",
-      "order": 6,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "type",
-      "order": 7,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "image",
-      "order": 8,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "metadata",
-      "order": 9,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "proposalId",
-      "order": 10,
-      "type": "standard",
-      "enabled": true
-    },
-    {
-      "name": "ownerGroup",
-      "order": 11,
-      "type": "standard",
-      "enabled": false
-    },
-    {
-      "name": "dataStatus",
-      "order": 12,
-      "type": "standard",
-      "enabled": false
-    }
-  ],
   "logbookEnabled": true,
   "loginFormEnabled": true,
   "maxDirectDownloadSize": 5000000000,
@@ -152,7 +72,7 @@
       "label": "Download Selected",
       "files": "selected",
       "mat_icon": "download",
-      "type": "form",      
+      "type": "form",
       "url": "https://www.scicat.info/download/selected",
       "target": "_blank",
       "enabled": "#Selected && #SizeLimit",
@@ -164,7 +84,7 @@
       "label": "Notebook All",
       "files": "all",
       "icon": "/assets/icons/jupyter_logo.png",
-      "type": "form",      
+      "type": "form",
       "url": "https://www.scicat.info/notebook/all",
       "target": "_blank",
       "authorization": ["#datasetAccess", "#datasetPublic"]
@@ -175,11 +95,114 @@
       "label": "Notebook Selected",
       "files": "selected",
       "icon": "/assets/icons/jupyter_logo.png",
-      "type": "form",      
+      "type": "form",
       "url": "https://www.scicat.info/notebook/selected",
       "target": "_blank",
       "enabled": "#Selected",
       "authorization": ["#datasetAccess", "#datasetPublic"]
     }
-  ]
+  ],
+  "labelMaps": {
+    "filters": {
+      "LocationFilter": "Location",
+      "PidFilter": "Pid",
+      "GroupFilter": "Group",
+      "TypeFilter": "Type",
+      "KeywordFilter": "Keyword",
+      "DateRangeFilter": "Start Date - End Date",
+      "TextFilter": "Text"
+    }
+  },
+  "defaultDatasetsListSettings": {
+    "columns": [
+      {
+        "name": "select",
+        "order": 0,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "pid",
+        "order": 1,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "datasetName",
+        "order": 2,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "runNumber",
+        "order": 3,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "sourceFolder",
+        "order": 4,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "size",
+        "order": 5,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "creationTime",
+        "order": 6,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "type",
+        "order": 7,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "image",
+        "order": 8,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "metadata",
+        "order": 9,
+        "type": "standard",
+        "enabled": false
+      },
+      {
+        "name": "proposalId",
+        "order": 10,
+        "type": "standard",
+        "enabled": true
+      },
+      {
+        "name": "ownerGroup",
+        "order": 11,
+        "type": "standard",
+        "enabled": false
+      },
+      {
+        "name": "dataStatus",
+        "order": 12,
+        "type": "standard",
+        "enabled": false
+      }
+    ],
+    "filters": [
+      { "LocationFilter": true },
+      { "PidFilter": true },
+      { "GroupFilter": true },
+      { "TypeFilter": true },
+      { "KeywordFilter": true },
+      { "DateRangeFilter": true },
+      { "TextFilter": true }
+    ],
+    "conditions": []
+  }
 }


### PR DESCRIPTION
## Description
This PR aims to separate frontend configuration from the backend, making the frontend more autonomous and reducing backend dependencies.

NOTE: Once its merged, tests need to be modified.

## Motivation
To improve flexibility and maintainability while reducing unnecessary backend dependencies.

## Changes:
- Replaced references to localColumns with defaultDatasetsListSettings.columns with backward compatibility .
- Added defaultDatasetsListSettings to AppConfig for default filters, columns, and conditions in the dataset list.
- Introduced labelMaps to store filter labels in AppConfig. If not provided, fallback to `component.instance.label`.
- Removed get default settings endpoint.

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
