### PR TITLE
Update frontend to match with release-jobs backend

### DIFF
--- a/src/app/datasets/admin-tab/admin-tab.component.ts
+++ b/src/app/datasets/admin-tab/admin-tab.component.ts
@@ -45,24 +45,11 @@ export class AdminTabComponent implements OnInit, OnDestroy {
         .subscribe((user) => {
           if (user && this.dataset) {
             const job = new Job();
-            job.emailJobInitiator = user.email;
-            job.jobParams = {};
-            job.jobParams["username"] = user.username;
-            job.creationTime = new Date();
+            job.createdBy = user.username;
+            job.DateTime = new Date();
             job.type = "reset";
-            const fileObj: FileObject = {
-              pid: "",
-              files: [],
-            };
-            const fileList: string[] = [];
-            fileObj.pid = this.dataset["pid"];
-            if (this.dataset["datablocks"]) {
-              this.dataset["datablocks"].map((d) => {
-                fileList.push(d["archiveId"]);
-              });
-            }
-            fileObj.files = fileList;
-            job.datasetList = [fileObj];
+            job.jobParams = {};
+            job.jobParams["datasetIds"] = [this.dataset["pid"]];
             console.log(job);
             this.store.dispatch(submitJobAction({ job }));
           }

--- a/src/app/datasets/admin-tab/admin-tab.component.ts
+++ b/src/app/datasets/admin-tab/admin-tab.component.ts
@@ -46,7 +46,7 @@ export class AdminTabComponent implements OnInit, OnDestroy {
           if (user && this.dataset) {
             const job = new Job();
             job.createdBy = user.username;
-            job.DateTime = new Date();
+            job.createdAt = new Date();
             job.type = "reset";
             job.jobParams = {};
             job.jobParams["datasetIds"] = [this.dataset["pid"]];

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -90,7 +90,7 @@ describe("ArchivingService", () => {
       const job = new Job({
         jobParams: { datasetIds: datasetList },
         createdBy: user.username,
-        DateTime: new Date(),
+        createdAt: new Date(),
         type: "archive",
       });
       const createJobSpy = spyOn<any, string>(

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -48,10 +48,9 @@ describe("ArchivingService", () => {
     it("should create a new object of type Job", () => {
       const user = new User({ username: "testName", email: "test@email.com" });
       const datasets = [new Dataset()];
-      const datasetList = datasets.map((dataset) => ({
-        pid: dataset.pid,
-        files: [],
-      }));
+      const datasetList = datasets.map((dataset) => (
+        dataset.pid
+      ));
       const archive = true;
       const destinationPath = { destinationPath: "/test/path/" };
 
@@ -63,9 +62,8 @@ describe("ArchivingService", () => {
       );
 
       expect(job).toBeInstanceOf(Job);
-      expect(job["emailJobInitiator"]).toEqual("test@email.com");
-      expect(job["jobParams"]["username"]).toEqual("testName");
-      expect(job["datasetList"]).toEqual(datasetList);
+      expect(job["createdBy"]).toEqual("testName");
+      expect(job["jobParams"]["datasetIds"]).toEqual(datasetList);
       expect(job["type"]).toEqual("archive");
     });
   });
@@ -85,16 +83,14 @@ describe("ArchivingService", () => {
 
       const user = new User({ username: "testName", email: "test@email.com" });
       const datasets = [new Dataset()];
-      const datasetList = datasets.map((dataset) => ({
-        pid: dataset.pid,
-        files: [],
-      }));
+      const datasetList = datasets.map((dataset) => (
+        dataset.pid
+      ));
       const archive = true;
       const job = new Job({
-        jobParams: { username: user.username },
-        emailJobInitiator: user.email,
-        creationTime: new Date(),
-        datasetList,
+        jobParams: { datasetIds: datasetList },
+        createdBy: user.username,
+        DateTime: new Date(),
         type: "archive",
       });
       const createJobSpy = spyOn<any, string>(

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -48,9 +48,7 @@ describe("ArchivingService", () => {
     it("should create a new object of type Job", () => {
       const user = new User({ username: "testName", email: "test@email.com" });
       const datasets = [new Dataset()];
-      const datasetList = datasets.map((dataset) => (
-        dataset.pid
-      ));
+      const datasetList = datasets.map((dataset) => dataset.pid);
       const archive = true;
       const destinationPath = { destinationPath: "/test/path/" };
 
@@ -83,9 +81,7 @@ describe("ArchivingService", () => {
 
       const user = new User({ username: "testName", email: "test@email.com" });
       const datasets = [new Dataset()];
-      const datasetList = datasets.map((dataset) => (
-        dataset.pid
-      ));
+      const datasetList = datasets.map((dataset) => dataset.pid);
       const archive = true;
       const job = new Job({
         jobParams: { datasetIds: datasetList },

--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -27,7 +27,9 @@ export class ArchivingService {
   ): Job {
     const extra = archive ? {} : destinationPath;
     const jobParams = {
-      username: user.username,
+      datasetIds: datasets.map((dataset) => (
+        dataset.pid
+      )),
       ...extra,
     };
 
@@ -37,12 +39,8 @@ export class ArchivingService {
 
     const data = {
       jobParams,
-      emailJobInitiator: user.email,
+      createdBy: user.username,
       // Revise this, files == []...? See earlier version of this method in dataset-table component for context
-      datasetList: datasets.map((dataset) => ({
-        pid: dataset.pid,
-        files: [],
-      })),
       type: archive ? "archive" : "retrieve",
     };
 

--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -27,9 +27,7 @@ export class ArchivingService {
   ): Job {
     const extra = archive ? {} : destinationPath;
     const jobParams = {
-      datasetIds: datasets.map((dataset) => (
-        dataset.pid
-      )),
+      datasetIds: datasets.map((dataset) => dataset.pid),
       ...extra,
     };
 

--- a/src/app/datasets/datafiles-actions/datafiles-action.component.spec.ts
+++ b/src/app/datasets/datafiles-actions/datafiles-action.component.spec.ts
@@ -177,7 +177,7 @@ describe("1000: DatafilesActionComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DatafilesActionComponent);
     component = fixture.componentInstance;
-    component.files = structuredClone(actionFiles);
+    component.files = JSON.parse(JSON.stringify(actionFiles));
     component.actionConfig = actionsConfig[0];
     component.actionDataset = actionDataset;
     component.maxFileSize = lowerMaxFileSizeLimit;
@@ -476,7 +476,7 @@ describe("1000: DatafilesActionComponent", () => {
         component.maxFileSize = lowerMaxFileSizeLimit;
         break;
     }
-    component.files = structuredClone(actionFiles);
+    component.files = JSON.parse(JSON.stringify(actionFiles));
     switch (selectedFiles) {
       case selectedFilesType.file1:
         component.files[0].selected = true;

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -268,15 +268,14 @@ export class DatafilesComponent
       if (email) {
         this.getSelectedFiles();
         const data = {
-          emailJobInitiator: email,
-          creationTime: new Date(),
+          createdBy: email,
+          DateTime: new Date(),
           type: "public",
-          datasetList: [
-            {
-              pid: this.datasetPid,
-              files: this.getSelectedFiles(),
-            },
-          ],
+          jobParams: {
+            datasetIds: [
+              this.datasetPid,
+            ],
+          },
         };
         const job = new Job(data);
         this.store.dispatch(submitJobAction({ job }));

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -272,9 +272,7 @@ export class DatafilesComponent
           createdAt: new Date(),
           type: "public",
           jobParams: {
-            datasetIds: [
-              this.datasetPid,
-            ],
+            datasetIds: [this.datasetPid],
           },
         };
         const job = new Job(data);

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -269,7 +269,7 @@ export class DatafilesComponent
         this.getSelectedFiles();
         const data = {
           createdBy: email,
-          DateTime: new Date(),
+          createdAt: new Date(),
           type: "public",
           jobParams: {
             datasetIds: [

--- a/src/app/jobs/jobs-dashboard-new/jobs-dashboard-new.component.ts
+++ b/src/app/jobs/jobs-dashboard-new/jobs-dashboard-new.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   OnDestroy,
 } from "@angular/core";
+import { Router } from "@angular/router";
 import { SciCatDataSource } from "../../shared/services/scicat.datasource";
 import { ScicatDataService } from "../../shared/services/scicat-data-service";
 import { ExportExcelService } from "../../shared/services/export-excel.service";
@@ -30,11 +31,11 @@ export class JobsDashboardNewComponent implements OnDestroy, AfterViewChecked {
       hideOrder: 0,
     },
     {
-      id: "emailJobInitiator",
-      label: "Initiator",
+      id: "createdBy",
+      label: "Creator",
       icon: "person",
       canSort: true,
-      matchMode: "contains",
+      matchMode: "is",
       hideOrder: 1,
     },
     {
@@ -46,7 +47,7 @@ export class JobsDashboardNewComponent implements OnDestroy, AfterViewChecked {
       hideOrder: 2,
     },
     {
-      id: "creationTime",
+      id: "DateTime",
       icon: "schedule",
       label: "Created at local time",
       format: "date medium ",
@@ -64,21 +65,12 @@ export class JobsDashboardNewComponent implements OnDestroy, AfterViewChecked {
       hideOrder: 4,
     },
     {
-      id: "jobStatusMessage",
+      id: "statusCode",
       icon: "traffic",
       label: "Status",
-      format: "json",
       canSort: true,
       matchMode: "contains",
       hideOrder: 5,
-    },
-    {
-      id: "datasetList",
-      icon: "list",
-      label: "Datasets",
-      format: "json",
-      canSort: true,
-      hideOrder: 6,
     },
     {
       id: "jobResultObject",
@@ -102,6 +94,7 @@ export class JobsDashboardNewComponent implements OnDestroy, AfterViewChecked {
     private cdRef: ChangeDetectorRef,
     private dataService: ScicatDataService,
     private exportService: ExportExcelService,
+    private router: Router,
   ) {
     this.dataSource = new SciCatDataSource(
       this.appConfigService,
@@ -120,9 +113,7 @@ export class JobsDashboardNewComponent implements OnDestroy, AfterViewChecked {
   }
 
   onRowClick(job: Job) {
-    // currently deactivated, no extra data available
-    /*     console.log("Row clicked:", job);
     const id = encodeURIComponent(job.id);
-    this.router.navigateByUrl("/user/jobs/" + id); */
+    this.router.navigateByUrl("/user/jobs/" + id);
   }
 }

--- a/src/app/jobs/jobs-dashboard-new/jobs-dashboard-new.component.ts
+++ b/src/app/jobs/jobs-dashboard-new/jobs-dashboard-new.component.ts
@@ -47,7 +47,7 @@ export class JobsDashboardNewComponent implements OnDestroy, AfterViewChecked {
       hideOrder: 2,
     },
     {
-      id: "DateTime",
+      id: "createdAt",
       icon: "schedule",
       label: "Created at local time",
       format: "date medium ",

--- a/src/app/jobs/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/src/app/jobs/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -100,8 +100,8 @@ describe("JobsDashboardComponent", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
       const mode = JobViewMode.myJobs;
-      component.email = "test@email.com";
-      const viewMode = { emailJobInitiator: component.email };
+      component.username = "testName";
+      const viewMode = { createdBy: component.username };
       component.onModeChange(mode);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(1);

--- a/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
+++ b/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
@@ -48,7 +48,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
 
   jobs: JobsTableData[] = [];
   profile: any;
-  email = "";
+  username = "";
 
   subscriptions: Subscription[] = [];
 
@@ -96,13 +96,13 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     if (jobs) {
       tableData = jobs.map((job) => ({
         id: job.id,
-        initiator: job.emailJobInitiator,
+        initiator: job.createdBy,
         type: job.type,
         createdAt: this.datePipe.transform(
-          job.creationTime,
+          job.DateTime,
           "yyyy-MM-dd HH:mm",
         ),
-        statusMessage: job.jobStatusMessage,
+        statusMessage: job.statusMessage,
       }));
     }
     return tableData;
@@ -129,7 +129,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
         break;
       }
       case JobViewMode.myJobs: {
-        viewMode = { emailJobInitiator: this.email };
+        viewMode = { createdBy: this.username };
         break;
       }
       default: {
@@ -154,11 +154,11 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     // map column names back to original names
     switch (event.active) {
       case "statusMessage": {
-        event.active = "jobStatusMessage";
+        event.active = "statusMessage";
         break;
       }
       case "initiator": {
-        event.active = "emailJobInitiator";
+        event.active = "createdBy";
         break;
       }
       default: {
@@ -181,13 +181,13 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.store.select(selectCurrentUser).subscribe((current) => {
         if (current) {
-          this.email = current.email;
+          this.username = current.username;
 
           if (!current.realm) {
             this.store.select(selectProfile).subscribe((profile) => {
               if (profile) {
                 this.profile = profile;
-                this.email = profile.email;
+                this.username = profile.username;
               }
               this.onModeChange(JobViewMode.myJobs);
             });

--- a/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
+++ b/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
@@ -99,7 +99,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
         initiator: job.createdBy,
         type: job.type,
         createdAt: this.datePipe.transform(
-          job.DateTime,
+          job.createdAt,
           "yyyy-MM-dd HH:mm",
         ),
         statusMessage: job.statusMessage,

--- a/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
+++ b/src/app/jobs/jobs-dashboard/jobs-dashboard.component.ts
@@ -98,10 +98,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
         id: job.id,
         initiator: job.createdBy,
         type: job.type,
-        createdAt: this.datePipe.transform(
-          job.createdAt,
-          "yyyy-MM-dd HH:mm",
-        ),
+        createdAt: this.datePipe.transform(job.createdAt, "yyyy-MM-dd HH:mm"),
         statusMessage: job.statusMessage,
       }));
     }

--- a/src/app/jobs/jobs-detail/jobs-detail.component.html
+++ b/src/app/jobs/jobs-detail/jobs-detail.component.html
@@ -4,10 +4,17 @@
       <table>
         <tr>
           <th>
-            <mat-icon> mail </mat-icon>
-            Email Job Initiator
+            <mat-icon> person </mat-icon>
+            Created By
           </th>
-          <td>{{ job.emailJobInitiator }}</td>
+          <td>{{ job.createdBy }}</td>
+        </tr>
+        <tr>
+          <th>
+            <mat-icon> mail </mat-icon>
+            Contact Email
+          </th>
+          <td>{{ job.contactEmail }}</td>
         </tr>
         <tr *ngIf="job.type as value">
           <th>
@@ -16,56 +23,82 @@
           </th>
           <td>{{ value }}</td>
         </tr>
-        <tr *ngIf="job.creationTime as value">
+        <tr *ngIf="job.DateTime as value">
           <th>
-            <mat-icon> brightness_high </mat-icon>
-            Creation Time
+            <mat-icon> calendar_today </mat-icon>
+            Date & Time
           </th>
           <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
         </tr>
-        <tr *ngIf="job.executionTime as value">
+        <tr *ngIf="job.statusCode as value">
           <th>
-            <mat-icon> gavel </mat-icon>
-            Execution Time
+            <mat-icon> traffic </mat-icon>
+            Status Code
           </th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="job.statusMessage as value">
+          <th>
+            <mat-icon> sms </mat-icon>
+            Status Message
+          </th>
+          <td>{{ value }}</td>
         </tr>
         <tr *ngIf="job.jobParams as value">
           <th>
             <mat-icon> settings </mat-icon>
-            Job Params
+            Job Parameters
           </th>
           <td>{{ value | json }}</td>
         </tr>
-        <tr *ngIf="job.updatedAt as value">
+        <tr *ngIf="job.datasetsValidation as value">
           <th>
-            <mat-icon> markunread </mat-icon>
-            Date Of Last Message
+            <mat-icon> task </mat-icon>
+            Datasets Validation
           </th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+          <td>{{ value }}</td>
         </tr>
-        <tr *ngIf="job.datasetList as value">
+        <tr *ngIf="job.configVersion as value">
           <th>
-            <mat-icon> folder </mat-icon>
-            Dataset List
+            <mat-icon> tune </mat-icon>
+            Configuration Version
           </th>
-          <div *ngFor="let daSet of value">
-            {{ daSet.pid | json }}
-          </div>
+          <td>{{ value }}</td>
         </tr>
-        <tr *ngIf="job.createdAt as value">
+        <tr *ngIf="job.jobResultObject as value">
           <th>
-            <mat-icon> calendar_today </mat-icon>
-            Created At
+            <mat-icon> work_outline </mat-icon>
+            Job Result Object
           </th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+          <td>{{ value | json }}</td>
         </tr>
-        <tr *ngIf="job.updatedAt as value">
+        <tr *ngIf="job.ownerUser as value">
           <th>
-            <mat-icon> calendar_today </mat-icon>
-            Updated At
+            <mat-icon> assignment_ind </mat-icon>
+            Owner User
           </th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="job.ownerGroup as value">
+          <th>
+            <mat-icon> group </mat-icon>
+            Owner Group
+          </th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="job.accessGroups as value">
+          <th>
+            <mat-icon> groups </mat-icon>
+            Access Groups
+          </th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="job.updatedBy as value">
+          <th>
+            <mat-icon> edit </mat-icon>
+            Updated By
+          </th>
+          <td>{{ value }}</td>
         </tr>
       </table>
     </mat-card-content>

--- a/src/app/jobs/jobs-detail/jobs-detail.component.html
+++ b/src/app/jobs/jobs-detail/jobs-detail.component.html
@@ -23,10 +23,10 @@
           </th>
           <td>{{ value }}</td>
         </tr>
-        <tr *ngIf="job.DateTime as value">
+        <tr *ngIf="job.createdAt as value">
           <th>
             <mat-icon> calendar_today </mat-icon>
-            Date & Time
+            Created At
           </th>
           <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
         </tr>
@@ -97,6 +97,20 @@
           <th>
             <mat-icon> edit </mat-icon>
             Updated By
+          </th>
+          <td>{{ value }}</td>
+        </tr>
+        <tr *ngIf="job.updatedAt as value">
+          <th>
+            <mat-icon> edit_calendar </mat-icon>
+            Updated At
+          </th>
+          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+        </tr>
+        <tr *ngIf="job.isPublished as value">
+          <th>
+            <mat-icon> upload_file </mat-icon>
+            Updated At
           </th>
           <td>{{ value }}</td>
         </tr>

--- a/src/app/jobs/jobs-detail/jobs-detail.component.html
+++ b/src/app/jobs/jobs-detail/jobs-detail.component.html
@@ -1,120 +1,132 @@
-<div *ngIf="job$ | async as job" class="job-detail">
-  <mat-card>
-    <mat-card-content>
-      <table>
-        <tr>
-          <th>
+  <div fxLayout="row" fxLayout.xs="column" *ngIf="job$ | async as job">
+    <div fxFlex="100%">
+      <mat-card>
+        <mat-card-header class="general-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> description </mat-icon>
+          </div>
+          General Information
+        </mat-card-header>
+        <mat-card-content>
+          <table>
+            <tr *ngIf="job.id as value">
+              <th>ID</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.type as value">
+              <th>Type</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.createdAt as value">
+              <th>Created At</th>
+              <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
+            </tr>
+          </table>
+        </mat-card-content>
+      </mat-card>
+      <mat-card>
+        <mat-card-header class="creator-header">
+          <div mat-card-avatar class="section-icon">
             <mat-icon> person </mat-icon>
-            Created By
-          </th>
-          <td>{{ job.createdBy }}</td>
-        </tr>
-        <tr>
-          <th>
-            <mat-icon> mail </mat-icon>
-            Contact Email
-          </th>
-          <td>{{ job.contactEmail }}</td>
-        </tr>
-        <tr *ngIf="job.type as value">
-          <th>
-            <mat-icon> bubble_chart </mat-icon>
-            Type
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.createdAt as value">
-          <th>
-            <mat-icon> calendar_today </mat-icon>
-            Created At
-          </th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
-        </tr>
-        <tr *ngIf="job.statusCode as value">
-          <th>
-            <mat-icon> traffic </mat-icon>
-            Status Code
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.statusMessage as value">
-          <th>
-            <mat-icon> sms </mat-icon>
-            Status Message
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.jobParams as value">
-          <th>
-            <mat-icon> settings </mat-icon>
-            Job Parameters
-          </th>
-          <td>{{ value | json }}</td>
-        </tr>
-        <tr *ngIf="job.datasetsValidation as value">
-          <th>
-            <mat-icon> task </mat-icon>
-            Datasets Validation
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.configVersion as value">
-          <th>
-            <mat-icon> tune </mat-icon>
-            Configuration Version
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.jobResultObject as value">
-          <th>
-            <mat-icon> work_outline </mat-icon>
-            Job Result Object
-          </th>
-          <td>{{ value | json }}</td>
-        </tr>
-        <tr *ngIf="job.ownerUser as value">
-          <th>
-            <mat-icon> assignment_ind </mat-icon>
-            Owner User
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.ownerGroup as value">
-          <th>
-            <mat-icon> group </mat-icon>
-            Owner Group
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.accessGroups as value">
-          <th>
-            <mat-icon> groups </mat-icon>
-            Access Groups
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.updatedBy as value">
-          <th>
-            <mat-icon> edit </mat-icon>
-            Updated By
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-        <tr *ngIf="job.updatedAt as value">
-          <th>
-            <mat-icon> edit_calendar </mat-icon>
-            Updated At
-          </th>
-          <td>{{ value | date: "yyyy-MM-dd HH:mm" }}</td>
-        </tr>
-        <tr *ngIf="job.isPublished as value">
-          <th>
-            <mat-icon> upload_file </mat-icon>
-            Updated At
-          </th>
-          <td>{{ value }}</td>
-        </tr>
-      </table>
-    </mat-card-content>
-  </mat-card>
-</div>
+          </div>
+          Users and Ownership
+        </mat-card-header>
+        <mat-card-content>
+          <table>
+            <tr *ngIf="job.createdBy as value">
+              <th>Created By</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.contactEmail as value">
+              <th>Contact Email</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.ownerUser as value">
+              <th>Owner User</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.ownerGroup as value">
+              <th>Owner Group</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.accessGroups as value">
+              <th>Access Groups</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.updatedBy as value">
+              <th>Updated By</th>
+              <td>{{ value }}</td>
+            </tr>
+          </table>
+        </mat-card-content>
+      </mat-card>
+      <mat-card>
+        <mat-card-header class="derived-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> analytics </mat-icon>
+          </div>
+          Status
+        </mat-card-header>
+        <mat-card-content>
+          <table>
+            <tr *ngIf="job.statusCode as value">
+              <th>Status Code</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.statusMessage as value">
+              <th>Status Message</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.updatedAt as value">
+              <th>Updated At</th>
+              <td>{{ value }}</td>
+            </tr>
+          </table>
+        </mat-card-content>
+      </mat-card>
+      <mat-card>
+        <mat-card-header class="related-header">
+          <div mat-card-avatar class="section-icon">
+            <mat-icon> library_books </mat-icon>
+          </div>
+          Parameters and Configuration
+        </mat-card-header>
+        <mat-card-content>
+          <table>
+            <tr *ngIf="job.jobParams as value">
+              <th>Job Parameters</th>
+              <td>{{ value | json }}</td>
+            </tr>
+            <tr *ngIf="job.configVersion as value">
+              <th>Configuration Version</th>
+              <td>{{ value }}</td>
+            </tr>
+            <tr *ngIf="job.jobResultObject as value">
+              <th>Job Result Object</th>
+              <td>{{ value | json }}</td>
+            </tr>
+            <tr *ngIf="!job.datasetsValidation; elseBlockDatasetsValidation">
+              <th>Datasets Validation</th>
+              <td>No</td>
+            </tr>
+            <ng-template #elseBlockDatasetsValidation>
+              <tr>
+                <th>Datasets Validation</th>
+                <td>Yes</td>
+              </tr>
+            </ng-template>
+            <tr *ngIf="!job.isPublished; elseBlockIsPublished">
+              <th>Is Published</th>
+              <td>No</td>
+            </tr>
+            <ng-template #elseBlockIsPublished>
+              <tr>
+                <th>Is Published</th>
+                <td>Yes</td>
+              </tr>
+            </ng-template>
+          </table>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </div>

--- a/src/app/jobs/jobs-detail/jobs-detail.component.scss
+++ b/src/app/jobs/jobs-detail/jobs-detail.component.scss
@@ -1,20 +1,25 @@
-.job-detail {
-  mat-card {
-    margin: 1em;
+mat-card {
+  margin: 1em;
 
-    table {
-      td {
-        padding: 0.3em;
-      }
+  .section-icon {
+    height: auto !important;
+    width: auto !important;
 
-      th {
-        text-align: left;
-        padding-right: 0.5em;
+    mat-icon {
+      vertical-align: middle;
+    }
+  }
 
-        mat-icon {
-          vertical-align: middle;
-        }
-      }
+  table {
+    th {
+      min-width: 10rem;
+      padding-right: 0.5rem;
+      text-align: left;
+    }
+
+    td {
+      width: 100%;
+      padding: 0.5rem 0;
     }
   }
 }

--- a/src/app/shared/modules/shared-table/_shared-table-theme.scss
+++ b/src/app/shared/modules/shared-table/_shared-table-theme.scss
@@ -31,6 +31,7 @@
 
     mat-row:hover {
       background-color: mat.get-color-from-palette($hover, "lighter");
+      cursor: pointer;
     }
 
     .mat-form-field-appearance-outline {

--- a/src/app/shared/sdk/models/Job.ts
+++ b/src/app/shared/sdk/models/Job.ts
@@ -4,19 +4,21 @@ declare var Object: any;
 export interface JobInterface {
   id?: string;
   ownerUser?: string;
-  type: string;
+  type?: string;
   statusCode?: string;
   statusMessage?: string;
-  jobParams: any;
+  jobParams?: any;
   datasetsValidation?: boolean;
   contactEmail?: string;
   configVersion?: string;
   jobResultObject?: any;
-  createdBy: string;
+  createdBy?: string;
   updatedBy?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
   ownerGroup?: string;
   accessGroups?: any;
-  DateTime?: Date;
+  isPublished?: boolean;
 }
 
 export class Job implements JobInterface {
@@ -32,9 +34,11 @@ export class Job implements JobInterface {
   "jobResultObject": any;
   "createdBy": string;
   "updatedBy": string;
+  "createdAt": Date;
+  "updatedAt": Date;
   "ownerGroup": string;
   "accessGroups": any;
-  "DateTime": Date;
+  "isPublished": boolean;
 
   constructor(data?: JobInterface) {
     Object.assign(this, data);
@@ -118,6 +122,14 @@ export class Job implements JobInterface {
           name: "updatedBy",
           type: "string",
         },
+        createdAt: {
+          name: "createdAt",
+          type: "Date",
+        },
+        updatedAt: {
+          name: "updatedAt",
+          type: "Date",
+        },
         ownerGroup: {
           name: "ownerGroup",
           type: "string",
@@ -126,9 +138,9 @@ export class Job implements JobInterface {
           name: "accessGroups",
           type: "any",
         },
-        DateTime: {
-          name: "DateTime",
-          type: "Date",
+        isPublished: {
+          name: "isPublished",
+          type: "boolean",
         },
       },
       relations: {},

--- a/src/app/shared/sdk/models/Job.ts
+++ b/src/app/shared/sdk/models/Job.ts
@@ -3,34 +3,39 @@
 declare var Object: any;
 export interface JobInterface {
   id?: string;
-  emailJobInitiator: string;
+  ownerUser?: string;
   type: string;
-  creationTime?: Date;
-  executionTime?: Date;
-  jobParams?: any;
-  jobStatusMessage?: string;
-  datasetList?: any;
+  statusCode?: string;
+  statusMessage?: string;
+  jobParams: any;
+  datasetsValidation?: boolean;
+  contactEmail?: string;
+  configVersion?: string;
   jobResultObject?: any;
-  createdBy?: string;
+  createdBy: string;
   updatedBy?: string;
-  createdAt?: Date;
-  updatedAt?: Date;
+  ownerGroup?: string;
+  accessGroups?: any;
+  DateTime?: Date;
 }
 
 export class Job implements JobInterface {
   "id": string;
-  "emailJobInitiator": string;
+  "ownerUser": string;
   "type": string;
-  "creationTime": Date;
-  "executionTime": Date;
+  "statusCode": string;
+  "statusMessage": string;
   "jobParams": any;
-  "jobStatusMessage": string;
-  "datasetList": any;
+  "datasetsValidation": boolean;
+  "contactEmail": string;
+  "configVersion": string;
   "jobResultObject": any;
   "createdBy": string;
   "updatedBy": string;
-  "createdAt": Date;
-  "updatedAt": Date;
+  "ownerGroup": string;
+  "accessGroups": any;
+  "DateTime": Date;
+
   constructor(data?: JobInterface) {
     Object.assign(this, data);
   }
@@ -68,8 +73,8 @@ export class Job implements JobInterface {
           name: "id",
           type: "string",
         },
-        emailJobInitiator: {
-          name: "emailJobInitiator",
+        ownerUser: {
+          name: "ownerUser",
           type: "string",
         },
         type: {
@@ -77,25 +82,29 @@ export class Job implements JobInterface {
           type: "string",
           default: "retrieve",
         },
-        creationTime: {
-          name: "creationTime",
-          type: "Date",
+        statusCode: {
+          name: "statusCode",
+          type: "string",
         },
-        executionTime: {
-          name: "executionTime",
-          type: "Date",
+        statusMessage: {
+          name: "statusMessage",
+          type: "string",
         },
         jobParams: {
           name: "jobParams",
           type: "any",
         },
-        jobStatusMessage: {
-          name: "jobStatusMessage",
+        datasetsValidation: {
+          name: "datasetsValidation",
+          type: "boolean",
+        },
+        contactEmail: {
+          name: "contactEmail",
           type: "string",
         },
-        datasetList: {
-          name: "datasetList",
-          type: "any",
+        configVersion: {
+          name: "configVersion",
+          type: "string",
         },
         jobResultObject: {
           name: "jobResultObject",
@@ -109,12 +118,16 @@ export class Job implements JobInterface {
           name: "updatedBy",
           type: "string",
         },
-        createdAt: {
-          name: "createdAt",
-          type: "Date",
+        ownerGroup: {
+          name: "ownerGroup",
+          type: "string",
         },
-        updatedAt: {
-          name: "updatedAt",
+        accessGroups: {
+          name: "accessGroups",
+          type: "any",
+        },
+        DateTime: {
+          name: "DateTime",
           type: "Date",
         },
       },

--- a/src/app/state-management/effects/jobs.effects.spec.ts
+++ b/src/app/state-management/effects/jobs.effects.spec.ts
@@ -18,9 +18,11 @@ import { Type } from "@angular/core";
 
 const data: JobInterface = {
   id: "testId",
-  emailJobInitiator: "test@email.com",
+  createdBy: "testName",
   type: "archive",
-  datasetList: {},
+  jobParams: {
+    datasetIds: [],
+  },
 };
 const job = new Job(data);
 

--- a/src/app/state-management/reducers/jobs.reducer.spec.ts
+++ b/src/app/state-management/reducers/jobs.reducer.spec.ts
@@ -5,9 +5,11 @@ import { initialJobsState } from "state-management/state/jobs.store";
 
 const data: JobInterface = {
   id: "testId",
-  emailJobInitiator: "test@email.com",
+  createdBy: "testName",
   type: "archive",
-  datasetList: {},
+  jobParams: {
+    datasetIds: [],
+  },
 };
 const job = new Job(data);
 

--- a/src/app/state-management/selectors/jobs.selectors.spec.ts
+++ b/src/app/state-management/selectors/jobs.selectors.spec.ts
@@ -5,9 +5,11 @@ import { JobInterface, Job } from "shared/sdk";
 
 const data: JobInterface = {
   id: "testId",
-  emailJobInitiator: "test@email.com",
+  createdBy: "testName",
   type: "archive",
-  datasetList: {},
+  jobParams: {
+    datasetIds: [],
+  },
 };
 const job = new Job(data);
 


### PR DESCRIPTION
## Motivation

Make a first try to see whether the MVP `release-jobs` backend is compatible with the frontend.

## Description

To make the frontend compatible with the new Jobs schema from the `release-jobs` backend, we have to update the job list page, the job detail page, the schema in the frontend and all its references to it, as well as the `.spec` test files.

## Fixes:

- https://github.com/SciCatProject/frontend/issues/1138
- https://github.com/SciCatProject/frontend/issues/1139
- https://github.com/SciCatProject/frontend/issues/1140


## Changes:

- Provide new job schema in `src/app/shared/sdk/models/Job.ts` by updating the definition of `Job` class 
- Update the relevant fields whenever an instance of the `Job` class is created:
  - provide `datasetIds` inside `jobParams`
  - rename `emailJobInitiator` to `createdBy` and its value should be `username` instead of `email`
  - rename `creationTime` to `createdAt`
- Update `jobs-dashboard-new.component` and `jobs-detail.component`, so show in the job list and job details pages the new fields of the Job class
- `jobs-dashboard.component` had to be updated too to avoid getting errors, but it appears to no longer be used
- Update the relevant fields whenever an instance of the `Job` class is created in one of the test files

## Backend version

`release-jobs`