### PR TITLE
Revert to using datasetList in jobParams

### DIFF
--- a/src/app/datasets/admin-tab/admin-tab.component.ts
+++ b/src/app/datasets/admin-tab/admin-tab.component.ts
@@ -48,8 +48,19 @@ export class AdminTabComponent implements OnInit, OnDestroy {
             job.createdBy = user.username;
             job.createdAt = new Date();
             job.type = "reset";
-            job.jobParams = {};
-            job.jobParams["datasetIds"] = [this.dataset["pid"]];
+            const fileList: string[] = [];
+            if (this.dataset["datablocks"]) {
+              this.dataset["datablocks"].map((d) => {
+                fileList.push(d["archiveId"]);
+              });
+            }
+            const fileObj: FileObject = {
+              pid: this.dataset["pid"],
+              files: fileList,
+            };
+            job.jobParams = {
+              datasetList: [fileObj]
+            };
             console.log(job);
             this.store.dispatch(submitJobAction({ job }));
           }

--- a/src/app/datasets/archiving.service.spec.ts
+++ b/src/app/datasets/archiving.service.spec.ts
@@ -48,7 +48,10 @@ describe("ArchivingService", () => {
     it("should create a new object of type Job", () => {
       const user = new User({ username: "testName", email: "test@email.com" });
       const datasets = [new Dataset()];
-      const datasetList = datasets.map((dataset) => dataset.pid);
+      const datasetList = datasets.map((dataset) => ({
+        pid: dataset.pid,
+        files: [],
+      }));
       const archive = true;
       const destinationPath = { destinationPath: "/test/path/" };
 
@@ -61,7 +64,7 @@ describe("ArchivingService", () => {
 
       expect(job).toBeInstanceOf(Job);
       expect(job["createdBy"]).toEqual("testName");
-      expect(job["jobParams"]["datasetIds"]).toEqual(datasetList);
+      expect(job["jobParams"]["datasetList"]).toEqual(datasetList);
       expect(job["type"]).toEqual("archive");
     });
   });
@@ -81,10 +84,13 @@ describe("ArchivingService", () => {
 
       const user = new User({ username: "testName", email: "test@email.com" });
       const datasets = [new Dataset()];
-      const datasetList = datasets.map((dataset) => dataset.pid);
+      const datasetList = datasets.map((dataset) => ({
+        pid: dataset.pid,
+        files: [],
+      }));
       const archive = true;
       const job = new Job({
-        jobParams: { datasetIds: datasetList },
+        jobParams: { datasetList: datasetList },
         createdBy: user.username,
         createdAt: new Date(),
         type: "archive",

--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -27,7 +27,10 @@ export class ArchivingService {
   ): Job {
     const extra = archive ? {} : destinationPath;
     const jobParams = {
-      datasetIds: datasets.map((dataset) => dataset.pid),
+      datasetList: datasets.map((dataset) => ({
+        pid: dataset.pid,
+        files: [],
+      })),
       ...extra,
     };
 
@@ -37,8 +40,6 @@ export class ArchivingService {
 
     const data = {
       jobParams,
-      createdBy: user.username,
-      // Revise this, files == []...? See earlier version of this method in dataset-table component for context
       type: archive ? "archive" : "retrieve",
     };
 

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -266,13 +266,17 @@ export class DatafilesComponent
     });
     dialogRef.afterClosed().subscribe((email) => {
       if (email) {
-        this.getSelectedFiles();
         const data = {
           createdBy: email,
           createdAt: new Date(),
           type: "public",
           jobParams: {
-            datasetIds: [this.datasetPid],
+            datasetList: [
+              {
+                pid: this.datasetPid,
+                files: this.getSelectedFiles(),
+              },
+            ],
           },
         };
         const job = new Job(data);

--- a/src/app/state-management/effects/jobs.effects.spec.ts
+++ b/src/app/state-management/effects/jobs.effects.spec.ts
@@ -21,7 +21,7 @@ const data: JobInterface = {
   createdBy: "testName",
   type: "archive",
   jobParams: {
-    datasetIds: [],
+    datasetList: [],
   },
 };
 const job = new Job(data);

--- a/src/app/state-management/reducers/jobs.reducer.spec.ts
+++ b/src/app/state-management/reducers/jobs.reducer.spec.ts
@@ -8,7 +8,7 @@ const data: JobInterface = {
   createdBy: "testName",
   type: "archive",
   jobParams: {
-    datasetIds: [],
+    datasetList: [],
   },
 };
 const job = new Job(data);

--- a/src/app/state-management/selectors/jobs.selectors.spec.ts
+++ b/src/app/state-management/selectors/jobs.selectors.spec.ts
@@ -8,7 +8,7 @@ const data: JobInterface = {
   createdBy: "testName",
   type: "archive",
   jobParams: {
-    datasetIds: [],
+    datasetList: [],
   },
 };
 const job = new Job(data);


### PR DESCRIPTION
1. Revert to using the following inside `jobParams`:
```
datasetList: [
    {
        pid: 'someDatasetPid',
        files: [ 'file1', 'file2' ]
    }
]
```

2. Fix bug in `src/app/datasets/archiving.service.ts` that was not allowing job creation from the frontend.

## Summary by Sourcery

Revert to using 'datasetList' in job parameters and fix a bug in the archiving service to allow job creation from the frontend.

Bug Fixes:
- Fix a bug in the archiving service that prevented job creation from the frontend.

Enhancements:
- Refactor job parameter structure to use 'datasetList' instead of 'datasetIds' across multiple components and services.