### PR TITLE
test(proposals): add e2e test to test proposal logbook fetch

### DIFF
--- a/cypress/e2e/proposals/proposals-general.cy.js
+++ b/cypress/e2e/proposals/proposals-general.cy.js
@@ -11,20 +11,21 @@ describe("Proposals general", () => {
     beforeEach(() => {
       // Clear logs before each test
       logbookLogs = [];
-    });
 
-    it("should trigger 'Fetch Logbook Complete' action only once after navigation", () => {
       // Capture console logs matching logBookAction
-      Cypress.on("window:before:load", (win) => {
-        const originalConsoleLog = win.console.log;
-        win.console.log = (...args) => {
+      cy.window().then((win) => {
+        cy.stub(win.console, "log").callsFake((...args) => {
+          // Check if the first argument matches logBookAction
           if (args[0] === logBookAction) {
             logbookLogs.push(args[0]);
           }
-          originalConsoleLog.apply(win.console, args); // Preserve default behavior
-        };
+          // Preserve the original console.log behavior
+          return win.console.log.apply(win.console, args);
+        });
       });
+    });
 
+    it("should trigger 'Fetch Logbook Complete' action only once after navigation", () => {
       const proposalId = Math.floor(100000 + Math.random() * 900000).toString();
       cy.createProposal(proposalId);
       cy.visit("/proposals");
@@ -33,7 +34,6 @@ describe("Proposals general", () => {
       cy.finishedLoading();
       cy.visit("/datasets");
 
-      cy.wait(50000); // Test
       cy.wrap(null).should(() => {
         expect(logbookLogs).to.have.length(1);
       });

--- a/cypress/e2e/proposals/proposals-general.cy.js
+++ b/cypress/e2e/proposals/proposals-general.cy.js
@@ -1,0 +1,48 @@
+describe("Proposals general", () => {
+  beforeEach(() => {
+    cy.login(Cypress.env("username"), Cypress.env("password"));
+  });
+
+  describe("Proposals Page Component", () => {
+    let logbookLogs = [];
+    const logBookAction =
+      "Logbook reducer Action came in! [Logbook] Fetch Logbook Complete";
+
+    beforeEach(() => {
+      // Clear logs before each test
+      logbookLogs = [];
+    });
+
+    it("should trigger 'Fetch Logbook Complete' action only once after navigation", () => {
+      // Capture console logs matching logBookAction
+      Cypress.on("window:before:load", (win) => {
+        const originalConsoleLog = win.console.log;
+        win.console.log = (...args) => {
+          if (args[0] === logBookAction) {
+            logbookLogs.push(args[0]);
+          }
+          originalConsoleLog.apply(win.console, args); // Preserve default behavior
+        };
+      });
+
+      const proposalId = Math.floor(100000 + Math.random() * 900000).toString();
+      cy.createProposal(proposalId);
+      cy.visit("/proposals");
+
+      cy.contains("A minimal test proposal").click();
+      cy.finishedLoading();
+      cy.visit("/datasets");
+
+      cy.wait(50000); // Test
+      cy.wrap(null).should(() => {
+        expect(logbookLogs).to.have.length(1);
+      });
+
+      cy.login(
+        Cypress.env("secondaryUsername"),
+        Cypress.env("secondaryPassword"),
+      );
+      cy.deleteProposal(proposalId);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Short description of the pull request


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Tests:
- Add an end-to-end test for the proposal logbook fetch functionality, ensuring the 'Fetch Logbook Complete' action is triggered only once after navigation.