### PR TITLE
fixed sdk local generation for linux

### DIFF
--- a/scripts/generate-nestjs-sdk.js
+++ b/scripts/generate-nestjs-sdk.js
@@ -15,7 +15,8 @@ execSync(
 
 console.log("Generating the new sdk...");
 const generationOutput = execSync(
-  'docker run --rm -v "%cd%:/local" openapitools/openapi-generator-cli:v7.9.0 generate -i http://host.docker.internal:3000/explorer-json -g typescript-angular -o local/@scicatproject/scicat-sdk-ts --additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts,supportsES6=true,npmVersion=10.8.2,withInterfaces=true',
+  // 'docker run --rm -v "%cd%:/local" openapitools/openapi-generator-cli:v7.9.0 generate -i http://host.docker.internal:3000/explorer-json -g typescript-angular -o local/@scicatproject/scicat-sdk-ts --additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts,supportsES6=true,npmVersion=10.8.2,withInterfaces=true',
+  'docker run --rm --add-host host.docker.internal:host-gateway -v "./node_modules:/local" openapitools/openapi-generator-cli:v7.9.0 generate -i http://host.docker.internal:3000/explorer-json -g typescript-angular -o local/@scicatproject/scicat-sdk-ts --additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts,supportsES6=true,npmVersion=10.8.2,withInterfaces=true',
   { encoding: "utf-8" },
 );
 console.log(generationOutput);


### PR DESCRIPTION
## Description
Fix sdk generation in local development environment

## Motivation
While testing the feature, the autogeneration did not worked in a linux environment.
This PR ensures that the local sdk autogeneration works on Linux.
We will need to test it in a window environment.

## Fixes:
- scripts/generate-nestjs-sdk.js

## Tests included
- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) Tested manually

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]
