### PR TITLE
adapted sdk generation to unix environment

### DIFF
--- a/scripts/generate-nestjs-sdk.bash
+++ b/scripts/generate-nestjs-sdk.bash
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+#
+
+USER=`who am i | cut -d\  -f1`
+echo -e "\nUser running the script: ${USER}"
+
+echo -e "\nCleanup old files..."
+rm -rf node_modules/@scicatproject/scicat-sdk-ts
+rm -rf @scicatproject/scicat-sdk-ts
+
+echo -e "\nGenerating the new sdk..."
+docker run \
+	--rm \
+	--add-host host.docker.internal:host-gateway \
+	-v "`pwd`:/local" \
+	openapitools/openapi-generator-cli:v7.9.0 generate \
+	-i http://host.docker.internal:3000/explorer-json \
+	-g typescript-angular \
+	-o local/@scicatproject/scicat-sdk-ts \
+	--additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts,supportsES6=true,npmVersion=10.8.2,withInterfaces=true
+
+REMOVE_NPM_LINK=0
+if ! command -v npm 2>&1 1>/dev/null
+then
+	if [ "--`env | grep NVM_BIN`--" != "----" ]
+	then
+		echo -e "\nCreating links to npm and node versions"
+		ln -s "$NVM_BIN/npm" "/usr/local/bin/npm"
+		whereis npm
+		ln -s "$NVM_BIN/node" "/usr/local/bin/node"
+		whereis node
+		REMOVE_NPM_LINK=1
+	else
+		echo -e "\nNo npm found!!!"
+		exit 1
+	fi
+fi
+
+echo -e "\nInstalling dependencies and building the sdk..."
+cd @scicatproject/scicat-sdk-ts 
+npm install
+npm run build
+
+echo -e "\nCopying the build files in node_modules..."
+cd ../..
+cp -rv @scicatproject/scicat-sdk-ts/dist node_modules/@scicatproject/scicat-sdk-ts
+
+echo -e "\nAdjusting ownership to user ${USER}"
+chown -Rv ${USER} node_modules/@scicatproject/scicat-sdk-ts
+
+echo -e "\nFinal cleanup..."
+echo -e "Removing sdk folder"
+rm -rfv @scicatproject
+
+if [ $REMOVE_NPM_LINK -eq 1 ];
+then
+	echo -e "\nRemoving links to npm and node"
+	rm -fv "/usr/local/bin/npm"
+	rm -fv "/usr/local/bin/node"
+fi
+

--- a/scripts/generate-nestjs-sdk.js
+++ b/scripts/generate-nestjs-sdk.js
@@ -19,35 +19,50 @@ function getCurrentDirectory() {
   return "$(pwd)";
 }
 
-// NOTE: First do some cleanup before starting the generation
-console.log("Cleanup old files...");
-execSync(
-  "rm -rf node_modules/@scicatproject/scicat-sdk-ts && rm -rf @scicatproject/scicat-sdk-ts",
-  { encoding: "utf-8" },
-);
+if (isWindows()) {
 
-console.log("Generating the new sdk...");
-const generationOutput = execSync(
-  `docker run --rm --add-host host.docker.internal:host-gateway -v "${getCurrentDirectory()}:/local" openapitools/openapi-generator-cli:v7.9.0 generate -i http://host.docker.internal:3000/explorer-json -g typescript-angular -o local/@scicatproject/scicat-sdk-ts --additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts,supportsES6=true,npmVersion=10.8.2,withInterfaces=true`,
-  { encoding: "utf-8" },
-);
-console.log(generationOutput);
+  // NOTE: First do some cleanup before starting the generation
+  console.log("Cleanup old files...");
+  execSync(
+    "rm -rf node_modules/@scicatproject/scicat-sdk-ts && rm -rf @scicatproject/scicat-sdk-ts",
+    { encoding: "utf-8" },
+  );
 
-console.log("Installing dependencies and building the sdk...");
-const installBuildOutput = execSync(
-  "cd @scicatproject/scicat-sdk-ts && npm install && npm run build",
-  { encoding: "utf-8" },
-);
-console.log(installBuildOutput);
+  console.log("Generating the new sdk...");
+  const generationOutput = execSync(
+    `docker run --rm --add-host host.docker.internal:host-gateway -v "${getCurrentDirectory()}:/local" openapitools/openapi-generator-cli:v7.9.0 generate -i http://host.docker.internal:3000/explorer-json -g typescript-angular -o local/@scicatproject/scicat-sdk-ts --additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts,supportsES6=true,npmVersion=10.8.2,withInterfaces=true`,
+    { encoding: "utf-8" },
+  );
+  console.log(generationOutput);
 
-console.log("Copying the build files in node_modules...");
-const copyToNodeModulesOutput = execSync(
-  "cp -r @scicatproject/scicat-sdk-ts/dist node_modules/@scicatproject/scicat-sdk-ts",
-  { encoding: "utf-8" },
-);
-console.log(copyToNodeModulesOutput);
+  console.log("Installing dependencies and building the sdk...");
+  const installBuildOutput = execSync(
+    "cd @scicatproject/scicat-sdk-ts && npm install && npm run build",
+    { encoding: "utf-8" },
+  );  
+  console.log(installBuildOutput);
 
-console.log("Final cleanup...");
-execSync("rm -rf @scicatproject", {
-  encoding: "utf-8",
-});
+  console.log("Copying the build files in node_modules...");
+  const copyToNodeModulesOutput = execSync(
+    "cp -r @scicatproject/scicat-sdk-ts/dist node_modules/@scicatproject/scicat-sdk-ts",
+    { encoding: "utf-8" },
+  );
+  console.log(copyToNodeModulesOutput);
+
+  console.log("Final cleanup...");
+  execSync("rm -rf @scicatproject", {
+    encoding: "utf-8",
+  });
+
+  console.log("Local SDK generation completed");
+
+} else {
+  console.log("Your environment is a linux/unix");
+  console.log("Please run the following command on your terminal:");
+  console.log("> sudo -E ./scripts/generate-nestjs-sdk.bash");
+  console.log("");
+  console.log("IMPORTANT: the script runs under sudo. You will be asked your password.");
+  console.log("");
+
+}
+


### PR DESCRIPTION
## Description
This PR introduces bash script to generate locally the SDK on linux/unix environments.

## Motivation
The javascript script to generate locally the SDK was failing due to permission issues as the docker container generate the sdk as the root user, while the script is mostly run as non privileged user

## Fixes:
Please provide a list of the fixes implemented in this PR
* scripts/generate-nestjs-sdk.js

## Changes:
Please provide a list of the changes implemented by this PR
* scripts/generate-nestjs-sdk.bash

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

## Summary by Sourcery

Adapt SDK generation process to support Unix environments by adding a bash script and updating the existing JavaScript script to handle OS-specific execution.

New Features:
- Introduce a bash script for generating the SDK on Linux/Unix environments.

Enhancements:
- Modify the existing JavaScript SDK generation script to detect the operating system and guide users to use the appropriate script.