### PR TITLE
Fix center logo in LoginDialog

### DIFF
--- a/src/app/users/login/login.component.html
+++ b/src/app/users/login/login.component.html
@@ -8,7 +8,7 @@
       <mat-card-content>
         <div fxLayout="row" class="facility-logo">
           <div fxFlex="auto"></div>
-          <div fxFlex="200px">
+          <div>
             <img src="assets/images/{{ siteLoginLogo }}" />
           </div>
           <div fxFlex="auto"></div>


### PR DESCRIPTION
auto size login logo div

## Description
horizontal align custom logos centered independent of their size.


## Motivation
logo <200px


## Fixes:
Please provide a list of the fixes implemented in this PR

* horizontal align center custom logos in login dialog


## Changes:
Please provide a list of the changes implemented by this PR

* removed flex from div to auto size and align centered

## Summary by Sourcery

Bug Fixes:
- Fix horizontal alignment of custom logos in the login dialog by removing fixed flex size.