### PR TITLE
fix: fixed and improved some user interface issues. 

### DIFF
--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -54,6 +54,8 @@ const appConfig: AppConfig = {
   searchPublicDataEnabled: true,
   searchSamples: true,
   sftpHost: "login.esss.dk",
+  sourceFolder: "default",
+  maxFileSizeWarning: "Some files are above the max size",
   shareEnabled: true,
   shoppingCartEnabled: true,
   shoppingCartOnHeader: true,

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -82,7 +82,8 @@ export interface AppConfig {
   searchPublicDataEnabled: boolean;
   searchSamples: boolean;
   sftpHost: string | null;
-  largeDataFileAccessInstruction?: string;
+  sourceFolder?: string;
+  maxFileSizeWarning?: string;
   shareEnabled: boolean;
   shoppingCartEnabled: boolean;
   shoppingCartOnHeader: boolean;

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -82,6 +82,7 @@ export interface AppConfig {
   searchPublicDataEnabled: boolean;
   searchSamples: boolean;
   sftpHost: string | null;
+  largeDataFileAccessInstruction?: string;
   shareEnabled: boolean;
   shoppingCartEnabled: boolean;
   shoppingCartOnHeader: boolean;

--- a/src/app/datasets/dashboard/dashboard.component.ts
+++ b/src/app/datasets/dashboard/dashboard.component.ts
@@ -73,7 +73,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   subscriptions: Subscription[] = [];
 
   appConfig = this.appConfigService.getConfig();
-
   currentUser: User = new User();
   userGroups: string[] = [];
   clearColumnSearch = false;

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -2,7 +2,7 @@
   <ng-template [ngIf]="maxFileSize && tooLargeFile">
     <span>
       <mat-icon class="warning-icon"> warning </mat-icon>
-      <span [innerHTML]="hasTooLargeFilesMessage()"></span>
+      <span [innerHTML]="hasFileAboveMaxSizeWarning()"></span>
     </span>
   </ng-template>
 
@@ -45,7 +45,7 @@
       <input type="hidden" name="auth_token" [value]="auth_token" />
       <input type="hidden" name="jwt" [value]="jwt?.jwt" />
       <input type="hidden" name="dataset" [value]="datasetPid" />
-      <input type="hidden" name="directory" [value]="sourcefolder" />
+      <input type="hidden" name="directory" [value]="sourceFolder" />
       <input
         *ngFor="let file of getAllFiles(); index as i"
         type="hidden"
@@ -77,7 +77,7 @@
       <input type="hidden" name="jwt" [value]="jwt?.jwt" />
       <input type="hidden" name="auth_token" [value]="auth_token" />
       <input type="hidden" name="dataset" [value]="datasetPid" />
-      <input type="hidden" name="directory" [value]="sourcefolder" />
+      <input type="hidden" name="directory" [value]="sourceFolder" />
       <input
         *ngFor="let file of getSelectedFiles(); index as i"
         type="hidden"

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -2,16 +2,7 @@
   <ng-template [ngIf]="maxFileSize && tooLargeFile">
     <span>
       <mat-icon class="warning-icon"> warning </mat-icon>
-      One or more files are too large to be downloaded directly.
-      {{
-        sftpHost
-          ? "These files are available via sftp host " +
-            sftpHost +
-            " in directory " +
-            sourcefolder +
-            "."
-          : ""
-      }}
+      <span [innerHTML]="replace_dynamic_values()"></span>
     </span>
   </ng-template>
 

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -2,7 +2,7 @@
   <ng-template [ngIf]="maxFileSize && tooLargeFile">
     <span>
       <mat-icon class="warning-icon"> warning </mat-icon>
-      <span [innerHTML]="replace_dynamic_values()"></span>
+      <span [innerHTML]="hasTooLargeFilesMessage()"></span>
     </span>
   </ng-template>
 

--- a/src/app/datasets/datafiles/datafiles.component.spec.ts
+++ b/src/app/datasets/datafiles/datafiles.component.spec.ts
@@ -19,6 +19,7 @@ import { MatButtonModule } from "@angular/material/button";
 import { AppConfigService } from "app-config.service";
 import { MatDialogModule, MatDialogRef } from "@angular/material/dialog";
 import { DatafilesActionsComponent } from "datasets/datafiles-actions/datafiles-actions.component";
+import { FileSizePipe } from "shared/pipes/filesize.pipe";
 
 describe("DatafilesComponent", () => {
   let component: DatafilesComponent;
@@ -100,6 +101,7 @@ describe("DatafilesComponent", () => {
             provide: DatafilesActionsComponent,
             useClass: MockDatafilesActionsComponent,
           },
+          { provide: FileSizePipe },
         ],
       },
     });
@@ -140,7 +142,7 @@ describe("DatafilesComponent", () => {
       },
     ];
     component.tableData = component.files;
-    component.sourcefolder = "/test/";
+    component.sourceFolder = "/test/";
     fixture.detectChanges();
   });
 

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -207,10 +207,9 @@ export class DatafilesComponent
   }
 
   replace_dynamic_values() {
-    const fileTooLargeMessage = `Some files are too big, but they can be downloaded at our sftp server: <strong>${this.sftpHost}</strong> at the folder: 
-    <strong>${this.customSourcefolder || this.sourcefolder}</strong>`;
-
-    return fileTooLargeMessage;
+    return `Some files are too big, but they can be downloaded 
+    at our sftp server: <strong>${this.sftpHost}</strong> 
+    at the folder: <strong>${this.customSourcefolder || this.sourcefolder}</strong>`;
   }
 
   ngAfterViewInit() {

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -76,7 +76,9 @@ export class DatafilesComponent
     this.appConfig.fileserverButtonLabel || "Download";
   multipleDownloadAction: string | null = this.appConfig.multipleDownloadAction;
   maxFileSize: number | null = this.appConfig.maxDirectDownloadSize;
-  sftpHost: string | null = this.appConfig.sftpHost;
+  sftpHost: string = this.appConfig.sftpHost || "no sftp host provided";
+  customSourcefolder: string | null =
+    this.appConfig.largeDataFileAccessInstruction;
   jwt: any;
   auth_token: any;
 
@@ -202,6 +204,13 @@ export class DatafilesComponent
     } else {
       return false;
     }
+  }
+
+  replace_dynamic_values() {
+    const fileTooLargeMessage = `Some files are too big, but they can be downloaded at our sftp server: <strong>${this.sftpHost}</strong> at the folder: 
+    <strong>${this.customSourcefolder || this.sourcefolder}</strong>`;
+
+    return fileTooLargeMessage;
   }
 
   ngAfterViewInit() {

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -75,9 +75,9 @@ export class DatafilesComponent
     this.appConfig.fileserverButtonLabel || "Download";
   multipleDownloadAction: string | null = this.appConfig.multipleDownloadAction;
   maxFileSize: number | null = this.appConfig.maxDirectDownloadSize;
-  sourceFolder: string | null =
-    this.appConfig.sourceFolder || "no source folder provided";
-  sftpHost: string = this.appConfig.sftpHost || "no sftp host provided";
+  sourceFolder: string =
+    this.appConfig.sourceFolder || "No source folder provided";
+  sftpHost: string = this.appConfig.sftpHost || "No sftp host provided";
   maxFileSizeWarning: string | null =
     this.appConfig.maxFileSizeWarning ||
     `Some files are above the max size ${this.fileSizePipe.transform(this.maxFileSize)}`;

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -206,10 +206,12 @@ export class DatafilesComponent
     }
   }
 
-  replace_dynamic_values() {
+  hasTooLargeFilesMessage() {
     return `Some files are too big, but they can be downloaded 
     at our sftp server: <strong>${this.sftpHost}</strong> 
-    at the folder: <strong>${this.customSourcefolder || this.sourcefolder}</strong>`;
+    at the folder: <strong>${
+      this.customSourcefolder || this.sourcefolder
+    }</strong>`;
   }
 
   ngAfterViewInit() {

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -268,13 +268,17 @@
                 <a (click)="onClickSample(sample.sampleId)">
                   <span>{{ sample.description }}</span>
                 </a>
-                <span
+                <!-- NOTE: Sample editing is currently disabled.
+                    This feature not only contains bugs that need to be fixed,
+                    but we also want to have a centralized edit button in one location.
+                -->
+                <!-- <span
                   class="sample-edit"
                   (click)="openSampleEditDialog()"
                   *ngIf="appConfig.editDatasetSampleEnabled && editingAllowed"
                 >
                   <mat-icon>edit</mat-icon>
-                </span>
+                </span> -->
               </td>
             </tr>
             <tr *ngIf="dataset['instrumentId'] && instrument">

--- a/src/app/datasets/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.html
@@ -268,17 +268,6 @@
                 <a (click)="onClickSample(sample.sampleId)">
                   <span>{{ sample.description }}</span>
                 </a>
-                <!-- NOTE: Sample editing is currently disabled.
-                    This feature not only contains bugs that need to be fixed,
-                    but we also want to have a centralized edit button in one location.
-                -->
-                <!-- <span
-                  class="sample-edit"
-                  (click)="openSampleEditDialog()"
-                  *ngIf="appConfig.editDatasetSampleEnabled && editingAllowed"
-                >
-                  <mat-icon>edit</mat-icon>
-                </span> -->
               </td>
             </tr>
             <tr *ngIf="dataset['instrumentId'] && instrument">

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -341,38 +341,6 @@ describe("DatasetDetailComponent", () => {
     });
   });
 
-  // NOTE: Sample editing is currently disabled.
-  // This feature not only contains bugs that need to be fixed,
-  // but we also want to have a centralized edit button in one location.
-
-  // describe("#openSampleEditDialog()", () => {
-  //   it("should open the sample edit dialog and dispatch updatePropertyAction", () => {
-  //     const dispatchSpy = spyOn(store, "dispatch");
-  //     component.dataset = new Dataset();
-  //     component.dataset.ownerGroup = "test";
-  //     component.sample = new Sample();
-  //     const sampleId = "testId";
-  //     component.sample.sampleId = sampleId;
-  //     const pid = "testPid";
-  //     component.dataset.pid = pid;
-  //     const property = { sampleId };
-  //     const dialogOpenSpy = spyOn(component.dialog, "open").and.returnValue({
-  //       afterClosed: () => of({ sample: { sampleId: "testId" } }),
-  //     } as MatDialogRef<SampleEditComponent>);
-  //     component.openSampleEditDialog();
-
-  //     expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
-  //     expect(dialogOpenSpy).toHaveBeenCalledWith(SampleEditComponent, {
-  //       width: "1000px",
-  //       data: { ownerGroup: "test", sampleId: "testId" },
-  //     });
-  //     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-  //     expect(dispatchSpy).toHaveBeenCalledWith(
-  //       updatePropertyAction({ pid, property }),
-  //     );
-  //   });
-  // });
-
   describe("#onSaveMetadata()", () => {
     it("should dispatch an updatePropertyAction", () => {
       const dispatchSpy = spyOn(store, "dispatch");

--- a/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.spec.ts
@@ -341,33 +341,37 @@ describe("DatasetDetailComponent", () => {
     });
   });
 
-  describe("#openSampleEditDialog()", () => {
-    it("should open the sample edit dialog and dispatch updatePropertyAction", () => {
-      const dispatchSpy = spyOn(store, "dispatch");
-      component.dataset = new Dataset();
-      component.dataset.ownerGroup = "test";
-      component.sample = new Sample();
-      const sampleId = "testId";
-      component.sample.sampleId = sampleId;
-      const pid = "testPid";
-      component.dataset.pid = pid;
-      const property = { sampleId };
-      const dialogOpenSpy = spyOn(component.dialog, "open").and.returnValue({
-        afterClosed: () => of({ sample: { sampleId: "testId" } }),
-      } as MatDialogRef<SampleEditComponent>);
-      component.openSampleEditDialog();
+  // NOTE: Sample editing is currently disabled.
+  // This feature not only contains bugs that need to be fixed,
+  // but we also want to have a centralized edit button in one location.
 
-      expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
-      expect(dialogOpenSpy).toHaveBeenCalledWith(SampleEditComponent, {
-        width: "1000px",
-        data: { ownerGroup: "test", sampleId: "testId" },
-      });
-      expect(dispatchSpy).toHaveBeenCalledTimes(1);
-      expect(dispatchSpy).toHaveBeenCalledWith(
-        updatePropertyAction({ pid, property }),
-      );
-    });
-  });
+  // describe("#openSampleEditDialog()", () => {
+  //   it("should open the sample edit dialog and dispatch updatePropertyAction", () => {
+  //     const dispatchSpy = spyOn(store, "dispatch");
+  //     component.dataset = new Dataset();
+  //     component.dataset.ownerGroup = "test";
+  //     component.sample = new Sample();
+  //     const sampleId = "testId";
+  //     component.sample.sampleId = sampleId;
+  //     const pid = "testPid";
+  //     component.dataset.pid = pid;
+  //     const property = { sampleId };
+  //     const dialogOpenSpy = spyOn(component.dialog, "open").and.returnValue({
+  //       afterClosed: () => of({ sample: { sampleId: "testId" } }),
+  //     } as MatDialogRef<SampleEditComponent>);
+  //     component.openSampleEditDialog();
+
+  //     expect(dialogOpenSpy).toHaveBeenCalledTimes(1);
+  //     expect(dialogOpenSpy).toHaveBeenCalledWith(SampleEditComponent, {
+  //       width: "1000px",
+  //       data: { ownerGroup: "test", sampleId: "testId" },
+  //     });
+  //     expect(dispatchSpy).toHaveBeenCalledTimes(1);
+  //     expect(dispatchSpy).toHaveBeenCalledWith(
+  //       updatePropertyAction({ pid, property }),
+  //     );
+  //   });
+  // });
 
   describe("#onSaveMetadata()", () => {
     it("should dispatch an updatePropertyAction", () => {

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -4,7 +4,7 @@ import { ENTER, COMMA, SPACE } from "@angular/cdk/keycodes";
 import { MatChipInputEvent } from "@angular/material/chips";
 
 import { MatDialog } from "@angular/material/dialog";
-import { SampleEditComponent } from "datasets/sample-edit/sample-edit.component";
+// import { SampleEditComponent } from "datasets/sample-edit/sample-edit.component";
 import { DialogComponent } from "shared/modules/dialog/dialog.component";
 import { combineLatest, fromEvent, Observable, Subscription } from "rxjs";
 import { Store } from "@ngrx/store";
@@ -354,11 +354,7 @@ export class DatasetDetailComponent
   }
 
   getImageUrl(encoded: string) {
-    const mimeType = this.base64MimeType(encoded);
-    if (mimeType === "application/pdf") {
-      return "assets/images/pdf-icon.svg";
-    }
-    return encoded;
+    return this.attachmentService.getImageUrl(encoded);
   }
 
   openAttachment(encoded: string) {

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -277,32 +277,6 @@ export class DatasetDetailComponent
     this.router.navigateByUrl("/samples/" + id);
   }
 
-  // NOTE: Sample editing is currently disabled.
-  // This feature not only contains bugs that need to be fixed,
-  // but we also want to have a centralized edit button in one location.
-  // openSampleEditDialog() {
-  //   if (this.dataset) {
-  //     this.dialog
-  //       .open(SampleEditComponent, {
-  //         width: "1000px",
-  //         data: {
-  //           ownerGroup: this.dataset.ownerGroup,
-  //           sampleId: this.sample?.sampleId,
-  //         },
-  //       })
-  //       .afterClosed()
-  //       .subscribe((res) => {
-  //         if (res && this.dataset) {
-  //           const { sample } = res;
-  //           this.sample = sample;
-  //           const pid = this.dataset.pid;
-  //           const property = { sampleId: sample.sampleId };
-  //           this.store.dispatch(updatePropertyAction({ pid, property }));
-  //         }
-  //       });
-  //   }
-  // }
-
   onSlidePublic(event: MatSlideToggleChange) {
     if (this.dataset) {
       const pid = this.dataset.pid;

--- a/src/app/datasets/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail.component.ts
@@ -277,28 +277,31 @@ export class DatasetDetailComponent
     this.router.navigateByUrl("/samples/" + id);
   }
 
-  openSampleEditDialog() {
-    if (this.dataset) {
-      this.dialog
-        .open(SampleEditComponent, {
-          width: "1000px",
-          data: {
-            ownerGroup: this.dataset.ownerGroup,
-            sampleId: this.sample?.sampleId,
-          },
-        })
-        .afterClosed()
-        .subscribe((res) => {
-          if (res && this.dataset) {
-            const { sample } = res;
-            this.sample = sample;
-            const pid = this.dataset.pid;
-            const property = { sampleId: sample.sampleId };
-            this.store.dispatch(updatePropertyAction({ pid, property }));
-          }
-        });
-    }
-  }
+  // NOTE: Sample editing is currently disabled.
+  // This feature not only contains bugs that need to be fixed,
+  // but we also want to have a centralized edit button in one location.
+  // openSampleEditDialog() {
+  //   if (this.dataset) {
+  //     this.dialog
+  //       .open(SampleEditComponent, {
+  //         width: "1000px",
+  //         data: {
+  //           ownerGroup: this.dataset.ownerGroup,
+  //           sampleId: this.sample?.sampleId,
+  //         },
+  //       })
+  //       .afterClosed()
+  //       .subscribe((res) => {
+  //         if (res && this.dataset) {
+  //           const { sample } = res;
+  //           this.sample = sample;
+  //           const pid = this.dataset.pid;
+  //           const property = { sampleId: sample.sampleId };
+  //           this.store.dispatch(updatePropertyAction({ pid, property }));
+  //         }
+  //       });
+  //   }
+  // }
 
   onSlidePublic(event: MatSlideToggleChange) {
     if (this.dataset) {

--- a/src/app/datasets/dataset-table/dataset-table.component.html
+++ b/src/app/datasets/dataset-table/dataset-table.component.html
@@ -208,7 +208,7 @@
       <mat-cell *matCellDef="let dataset">
         <img
           src="{{ dataset.pid | thumbnail | async }}"
-          height="60px"
+          height="42px"
           loading="lazy"
         />
       </mat-cell>

--- a/src/app/datasets/datasets.module.ts
+++ b/src/app/datasets/datasets.module.ts
@@ -89,7 +89,6 @@ import { DatasetsFilterSettingsComponent } from "./datasets-filter/settings/data
 import { CdkDrag, CdkDragHandle, CdkDropList } from "@angular/cdk/drag-drop";
 import { FiltersModule } from "shared/modules/filters/filters.module";
 import { userReducer } from "state-management/reducers/user.reducer";
-import { AttachmentService } from "shared/services/attachment.service";
 
 @NgModule({
   imports: [

--- a/src/app/shared/modules/file-uploader/file-uploader.component.ts
+++ b/src/app/shared/modules/file-uploader/file-uploader.component.ts
@@ -109,11 +109,7 @@ export class FileUploaderComponent {
   }
 
   getImageUrl(encoded: string) {
-    const mimeType = this.base64MimeType(encoded);
-    if (mimeType === "application/pdf") {
-      return "assets/images/pdf-icon.svg";
-    }
-    return encoded;
+    return this.attachmentService.getImageUrl(encoded);
   }
 
   openAttachment(encoded: string) {

--- a/src/app/shared/services/attachment.service.spec.ts
+++ b/src/app/shared/services/attachment.service.spec.ts
@@ -29,8 +29,22 @@ describe("AttachmentService", () => {
     });
 
     it("should return null for non-string input", () => {
-      const mimeType = service.base64MimeType(null as any);
+      const mimeType = service.base64MimeType(null);
       expect(mimeType).toBeNull();
+    });
+  });
+
+  describe("getImageUrl", () => {
+    it("should return the pdf icon if the file is pdf", () => {
+      const encoded = "data:application/pdf;base64,SGVsbG8sIFdvcmxkIQ==";
+      const imageUrl = service.getImageUrl(encoded);
+      expect(imageUrl).toBe("assets/images/pdf-icon.svg");
+    });
+
+    it("should return the encoded string if the file is not pdf", () => {
+      const encoded = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA";
+      const imageUrl = service.getImageUrl(encoded);
+      expect(imageUrl).toBe(encoded);
     });
   });
 

--- a/src/app/shared/services/attachment.service.ts
+++ b/src/app/shared/services/attachment.service.ts
@@ -3,6 +3,8 @@ import { Injectable } from "@angular/core";
 @Injectable()
 export class AttachmentService {
   base64MimeType(encoded: string): string {
+    if (!encoded) return null;
+
     let result = null;
 
     if (typeof encoded !== "string") {
@@ -17,7 +19,20 @@ export class AttachmentService {
 
     return result;
   }
+
+  getImageUrl(encoded: string) {
+    if (!encoded) return null;
+
+    const mimeType = this.base64MimeType(encoded);
+    if (mimeType === "application/pdf") {
+      return "assets/images/pdf-icon.svg";
+    }
+    return encoded;
+  }
+
   openAttachment(encoded: string) {
+    if (!encoded) return null;
+
     const mimeType = this.base64MimeType(encoded);
     const strippedData = encoded.replace(
       new RegExp(`^data:${mimeType};base64,`),

--- a/src/app/shared/services/attachment.service.ts
+++ b/src/app/shared/services/attachment.service.ts
@@ -3,7 +3,9 @@ import { Injectable } from "@angular/core";
 @Injectable()
 export class AttachmentService {
   base64MimeType(encoded: string): string {
-    if (!encoded) return null;
+    if (!encoded) {
+      return null;
+    }
 
     let result = null;
 
@@ -21,7 +23,9 @@ export class AttachmentService {
   }
 
   getImageUrl(encoded: string) {
-    if (!encoded) return null;
+    if (!encoded) {
+      return null;
+    }
 
     const mimeType = this.base64MimeType(encoded);
     if (mimeType === "application/pdf") {
@@ -31,7 +35,9 @@ export class AttachmentService {
   }
 
   openAttachment(encoded: string) {
-    if (!encoded) return null;
+    if (!encoded) {
+      return null;
+    }
 
     const mimeType = this.base64MimeType(encoded);
     const strippedData = encoded.replace(

--- a/src/app/shared/services/thumbnail.service.spec.ts
+++ b/src/app/shared/services/thumbnail.service.spec.ts
@@ -5,6 +5,7 @@ import { ThumbnailService } from "./thumbnail.service";
 import { selectDatasetsPerPage } from "state-management/selectors/datasets.selectors";
 import { MockStore, provideMockStore } from "@ngrx/store/testing";
 import { of, throwError } from "rxjs";
+import { AttachmentService } from "./attachment.service";
 
 describe("ThumbnailService", () => {
   let service: ThumbnailService;
@@ -26,6 +27,9 @@ describe("ThumbnailService", () => {
         {
           provide: AppConfigService,
           useValue: { getConfig },
+        },
+        {
+          provide: AttachmentService,
         },
         provideMockStore({
           selectors: [

--- a/src/app/shared/services/thumbnail.service.ts
+++ b/src/app/shared/services/thumbnail.service.ts
@@ -4,6 +4,7 @@ import { distinctUntilChanged, firstValueFrom } from "rxjs";
 import { DatasetApi } from "shared/sdk";
 import { selectDatasetsPerPage } from "state-management/selectors/datasets.selectors";
 import { AppConfigService } from "app-config.service";
+import { AttachmentService } from "./attachment.service";
 
 interface ThumbnailCache {
   [pid: string]: {
@@ -25,6 +26,7 @@ export class ThumbnailService {
   constructor(
     private datasetApi: DatasetApi,
     private store: Store,
+    private attachmentService: AttachmentService,
     private appConfigService: AppConfigService,
   ) {
     this.store
@@ -60,7 +62,7 @@ export class ThumbnailService {
     try {
       const encodedPid = encodeURIComponent(pid);
       const res = await firstValueFrom(this.datasetApi.thumbnail(encodedPid));
-      const thumbnail = res?.thumbnail || null;
+      const thumbnail = this.attachmentService.getImageUrl(res?.thumbnail);
 
       this.thumbnailCache[pid] = {
         value: thumbnail,


### PR DESCRIPTION
## Description
This PR contains a couple of small UI improvements and changes:
- made large data files download instruction text configurable on the `dataset/datafiles` page
- commented out sample editing feature temporarily, as the sample editing feature is broken and there's no strong need for the feature.
- resized thumbnail image to prevent it from being cut off partially.
- replaced red cross pdf file thumbnail with default pdf icon on dataset table
- added tests for the changes.

<img width="1541" alt="image" src="https://github.com/user-attachments/assets/10881728-6f19-47ea-8b6a-f5fde5ebfb58">

## Motivation


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Disable the sample editing feature due to bugs and the need for a centralized edit button. Refactor image URL retrieval logic to use the AttachmentService for consistency and maintainability. Update the datafiles component to dynamically replace file size warning messages with configurable values.

Bug Fixes:
- Disable the sample editing feature due to existing bugs and the need for a centralized edit button.

Enhancements:
- Refactor the method for retrieving image URLs by moving logic to the AttachmentService.