### PR TITLE
fix: optimize condition editing logic in DatasetsFilterSettingsComponent

### DIFF
--- a/cypress/e2e/datasets/datasets-general.cy.js
+++ b/cypress/e2e/datasets/datasets-general.cy.js
@@ -93,4 +93,55 @@ describe("Datasets general", () => {
       cy.deleteProposal(proposalId);
     });
   });
+
+  describe.only("Dataset page filter and scientific condition UI test", () => {
+    it("should not be able to add duplicated conditions ", () => {
+      cy.visit("/datasets");
+
+      cy.get(".user-button").click();
+
+      cy.get("[data-cy=logout-button]").click();
+
+      cy.finishedLoading();
+
+      cy.visit("/datasets");
+
+      cy.get('[data-cy="more-filters-button"]').click();
+
+      cy.get('[data-cy="add-scientific-condition-button"]').click();
+
+      cy.get('input[name="lhs"]').type("test");
+      cy.get('input[name="rhs"]').type("1");
+
+      cy.get('button[type="submit"]').click();
+
+      cy.get('[data-cy="add-scientific-condition-button"]').click();
+
+      cy.get('input[name="lhs"]').type("test");
+      cy.get('input[name="rhs"]').type("1");
+
+      cy.get('button[type="submit"]').click();
+
+      cy.get(".snackbar-warning")
+        .should("contain", "Condition already exists")
+        .contains("Close")
+        .click();
+
+      cy.get('[data-cy="scientific-condition-filter-list"').should(
+        "have.length",
+        1,
+      );
+
+      cy.get('[data-cy="add-scientific-condition-button"]').click();
+
+      cy.get('input[name="lhs"]').type("test");
+      cy.get('input[name="rhs"]').type("2");
+
+      cy.get('button[type="submit"]').click();
+
+      cy.get('[data-cy="scientific-condition-filter-list"]')
+        .find("input")
+        .should("have.length", 2);
+    });
+  });
 });

--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -17,7 +17,11 @@
       </ng-container>
     </ng-container>
 
-    <div class="section-container" *ngIf="appConfig.scienceSearchEnabled">
+    <div
+      class="section-container"
+      *ngIf="appConfig.scienceSearchEnabled"
+      data-cy="scientific-condition-filter-list"
+    >
       <ng-container *ngFor="let condition of scientificConditions$ | async">
         <ng-container
           *ngComponentOutlet="ConditionFilterComponent; inputs: { condition }"
@@ -25,7 +29,7 @@
       </ng-container>
     </div>
 
-    <div class="section-container">
+    <div class="section-container" data-cy="more-filters-button">
       <button
         mat-button
         class="full-width-button"

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.html
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.html
@@ -102,6 +102,7 @@
       color="primary"
       *ngIf="appConfig.scienceSearchEnabled"
       (click)="addCondition()"
+      data-cy="add-scientific-condition-button"
     >
       <mat-icon>add</mat-icon>
       Add Conditions

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.spec.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.spec.ts
@@ -36,6 +36,7 @@ import { MatIconModule } from "@angular/material/icon";
 import { AppConfigService } from "app-config.service";
 import { DatasetsFilterSettingsComponent } from "./datasets-filter-settings.component";
 import { ConditionConfig } from "../../../shared/modules/filters/filters.module";
+import { MatSnackBar, MatSnackBarModule } from "@angular/material/snack-bar";
 
 export class MockMatDialog {
   open() {
@@ -82,6 +83,7 @@ describe("DatasetsFilterSettingsComponent", () => {
         MatSelectModule,
         MatNativeDateModule,
         ReactiveFormsModule,
+        MatSnackBarModule,
         SharedScicatFrontendModule,
         StoreModule.forRoot({}),
       ],
@@ -96,6 +98,7 @@ describe("DatasetsFilterSettingsComponent", () => {
         providers: [
           { provide: AppConfigService, useValue: { getConfig } },
           { provide: MatDialog, useClass: MockMatDialog },
+          { provide: MatSnackBar },
           { provide: MatDialogRef, useClass: MockMatDialogRef },
           {
             provide: MAT_DIALOG_DATA,

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -66,6 +66,7 @@ export class DatasetsFilterSettingsComponent {
           if (existingConditionIndex !== -1) {
             this.snackBar.open("Condition already exists", "Close", {
               duration: 2000,
+              panelClass: ["snackbar-warning"],
             });
             return;
           }

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -23,6 +23,7 @@ import {
   FilterConfig,
 } from "../../../shared/modules/filters/filters.module";
 import { isEqual } from "lodash-es";
+import { MatSnackBar } from "@angular/material/snack-bar";
 
 @Component({
   selector: "app-type-datasets-filter-settings",
@@ -39,6 +40,7 @@ export class DatasetsFilterSettingsComponent {
   constructor(
     public dialogRef: MatDialogRef<DatasetsFilterSettingsComponent>,
     public dialog: MatDialog,
+    private snackBar: MatSnackBar,
     private store: Store,
     private asyncPipe: AsyncPipe,
     private appConfigService: AppConfigService,
@@ -62,7 +64,10 @@ export class DatasetsFilterSettingsComponent {
             (config) => isEqual(config.condition, data),
           );
           if (existingConditionIndex !== -1) {
-            console.log("Condition already exists");
+            this.snackBar.open("Condition already exists", "Close", {
+              duration: 2000,
+              panelClass: ["snackbar-error"],
+            });
             return;
           }
           const condition = this.toggleCondition({

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -22,6 +22,7 @@ import {
   ConditionConfig,
   FilterConfig,
 } from "../../../shared/modules/filters/filters.module";
+import { isEqual } from "lodash-es";
 
 @Component({
   selector: "app-type-datasets-filter-settings",
@@ -55,6 +56,15 @@ export class DatasetsFilterSettingsComponent {
       .subscribe((res) => {
         if (res) {
           const { data } = res;
+
+          // If the condition already exists, do nothing
+          const existingConditionIndex = this.data.conditionConfigs.findIndex(
+            (config) => isEqual(config.condition, data),
+          );
+          if (existingConditionIndex !== -1) {
+            console.log("Condition already exists");
+            return;
+          }
           const condition = this.toggleCondition({
             condition: data,
             enabled: false,
@@ -77,30 +87,33 @@ export class DatasetsFilterSettingsComponent {
         if (res) {
           const { data } = res;
 
-          if (data !== condition.condition) {
-            this.store.dispatch(
-              removeScientificConditionAction({
-                condition: condition.condition,
-              }),
-            );
-            this.store.dispatch(
-              deselectColumnAction({
-                name: condition.condition.lhs,
-                columnType: "custom",
-              }),
-            );
-
-            this.data.conditionConfigs[i] = {
-              ...condition,
-              condition: data,
-            };
-            this.store.dispatch(
-              addScientificConditionAction({ condition: data }),
-            );
-            this.store.dispatch(
-              selectColumnAction({ name: data.lhs, columnType: "custom" }),
-            );
+          // If the condition is unchanged, do nothing
+          if (isEqual(condition.condition, data)) {
+            return;
           }
+
+          this.store.dispatch(
+            removeScientificConditionAction({
+              condition: condition.condition,
+            }),
+          );
+          this.store.dispatch(
+            deselectColumnAction({
+              name: condition.condition.lhs,
+              columnType: "custom",
+            }),
+          );
+
+          this.data.conditionConfigs[i] = {
+            ...condition,
+            condition: data,
+          };
+          this.store.dispatch(
+            addScientificConditionAction({ condition: data }),
+          );
+          this.store.dispatch(
+            selectColumnAction({ name: data.lhs, columnType: "custom" }),
+          );
         }
       });
   }

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -27,7 +27,6 @@ import {
   selector: "app-type-datasets-filter-settings",
   templateUrl: `./datasets-filter-settings.component.html`,
   styleUrls: [`./datasets-filter-settings.component.scss`],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DatasetsFilterSettingsComponent {
   metadataKeys$ = this.store.select(selectMetadataKeys);
@@ -66,15 +65,6 @@ export class DatasetsFilterSettingsComponent {
   }
 
   editCondition(condition: ConditionConfig, i: number) {
-    this.store.dispatch(
-      removeScientificConditionAction({ condition: condition.condition }),
-    );
-    this.store.dispatch(
-      deselectColumnAction({
-        name: condition.condition.lhs,
-        columnType: "custom",
-      }),
-    );
     this.dialog
       .open(SearchParametersDialogComponent, {
         data: {
@@ -86,16 +76,31 @@ export class DatasetsFilterSettingsComponent {
       .subscribe((res) => {
         if (res) {
           const { data } = res;
-          this.data.conditionConfigs[i] = {
-            ...condition,
-            condition: data,
-          };
-          this.store.dispatch(
-            addScientificConditionAction({ condition: data }),
-          );
-          this.store.dispatch(
-            selectColumnAction({ name: data.lhs, columnType: "custom" }),
-          );
+
+          if (data !== condition.condition) {
+            this.store.dispatch(
+              removeScientificConditionAction({
+                condition: condition.condition,
+              }),
+            );
+            this.store.dispatch(
+              deselectColumnAction({
+                name: condition.condition.lhs,
+                columnType: "custom",
+              }),
+            );
+
+            this.data.conditionConfigs[i] = {
+              ...condition,
+              condition: data,
+            };
+            this.store.dispatch(
+              addScientificConditionAction({ condition: data }),
+            );
+            this.store.dispatch(
+              selectColumnAction({ name: data.lhs, columnType: "custom" }),
+            );
+          }
         }
       });
   }

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -66,7 +66,6 @@ export class DatasetsFilterSettingsComponent {
           if (existingConditionIndex !== -1) {
             this.snackBar.open("Condition already exists", "Close", {
               duration: 2000,
-              panelClass: ["snackbar-error"],
             });
             return;
           }

--- a/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
+++ b/src/app/datasets/datasets-filter/settings/datasets-filter-settings.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject } from "@angular/core";
+import { Component, Inject } from "@angular/core";
 import {
   MAT_DIALOG_DATA,
   MatDialog,

--- a/src/app/datasets/datasets.module.ts
+++ b/src/app/datasets/datasets.module.ts
@@ -89,6 +89,7 @@ import { DatasetsFilterSettingsComponent } from "./datasets-filter/settings/data
 import { CdkDrag, CdkDragHandle, CdkDropList } from "@angular/cdk/drag-drop";
 import { FiltersModule } from "shared/modules/filters/filters.module";
 import { userReducer } from "state-management/reducers/user.reducer";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
 
 @NgModule({
   imports: [
@@ -121,6 +122,7 @@ import { userReducer } from "state-management/reducers/user.reducer";
     MatStepperModule,
     MatTableModule,
     MatTabsModule,
+    MatSnackBarModule,
     MatTooltipModule,
     NgxJsonViewerModule,
     ReactiveFormsModule,


### PR DESCRIPTION
## Description
This PR addresses the following issues:
1. Fixes a UI issue in the filter where editing a scientific metadata condition caused the previous condition to disappear.
2. Fixes duplicate creation of scientific metadata conditions
3. Resolves an issue where the input value changes only when the input field is focused again.


<img width="1270" alt="image" src="https://github.com/user-attachments/assets/2877909a-a94c-4d0d-a26d-d6a3f29cc011">
<img width="532" alt="image" src="https://github.com/user-attachments/assets/bdd5ad35-9c80-4e01-b142-ca1eddf076d2">
<img width="911" alt="image" src="https://github.com/user-attachments/assets/bc7789ea-2f42-4eac-88df-bd3a12e9ecd6">


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Optimize the condition editing logic in the DatasetsFilterSettingsComponent to fix UI issues related to scientific metadata conditions and input value changes.

Bug Fixes:
- Fix a UI issue where editing a scientific metadata condition caused the previous condition to disappear.
- Resolve an issue where the input value changes only when the input field is focused again.