### PR TITLE
DNM: Debug pr 1657

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,7 @@ jobs:
       - name: docker logs
         if: ${{ failure() }}
         run: |
+          docker compose logs frontend
           docker compose logs es01
           docker compose logs backend
 

--- a/CI/e2e/docker-compose.e2e.yaml
+++ b/CI/e2e/docker-compose.e2e.yaml
@@ -48,7 +48,7 @@ services:
     build:
       context: .
     ports:
-      - 4200:80
+      - 4200:8080
     volumes:
       - "./CI/e2e/frontend.config.e2e.json:/usr/share/nginx/html/assets/config.json"
     depends_on:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN npx ng build
 
 FROM nginxinc/nginx-unprivileged
 COPY --from=builder /frontend/dist/ /usr/share/nginx/html/
-COPY scripts/site.conf /etc/nginx/conf.d/site.conf
+COPY scripts/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN npm ci
 COPY . /frontend/
 RUN npx ng build
 
-FROM nginx:1.25-alpine
-RUN rm -rf /usr/share/nginx/html/*
+FROM nginxinc/nginx-unprivileged
 COPY --from=builder /frontend/dist/ /usr/share/nginx/html/
-COPY scripts/nginx.conf /etc/nginx/nginx.conf
-EXPOSE 80
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN npx ng build
 
 FROM nginxinc/nginx-unprivileged
 COPY --from=builder /frontend/dist/ /usr/share/nginx/html/
+
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ RUN npx ng build
 
 FROM nginxinc/nginx-unprivileged
 COPY --from=builder /frontend/dist/ /usr/share/nginx/html/
+COPY scripts/site.conf /etc/nginx/conf.d/site.conf
 
 EXPOSE 8080

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -31,8 +31,8 @@ http {
     default_type        application/octet-stream;
 
     server {
-        listen       80 default_server;
-        listen       [::]:80 default_server;
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
         server_name  _;
         root         /usr/share/nginx/html;
 

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -2,10 +2,9 @@
 #   * Official English Documentation: http://nginx.org/en/docs/
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
 
-user nginx;
+pid        /tmp/nginx.pid;
+
 worker_processes auto;
-error_log /var/log/nginx/error.log;
-pid /run/nginx.pid;
 
 # Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;
@@ -15,6 +14,12 @@ events {
 }
 
 http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';

--- a/scripts/site.conf
+++ b/scripts/site.conf
@@ -1,0 +1,60 @@
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+
+        location / {
+    	   try_files $uri $uri/ /index.html;
+        }
+
+        # Enable gzip to compress large files
+        gzip on;
+        gzip_vary on;
+        gzip_types
+          text/plain
+          text/css
+          text/js
+          text/xml
+          text/javascript
+          application/javascript
+          application/json
+          application/xml
+          application/rss+xml
+          image/svg+xml
+          image/png;
+        gzip_min_length 1024;
+        gzip_proxied expired no-cache no-store private auth;
+    }
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2 default_server;
+#        listen       [::]:443 ssl http2 default_server;
+#        server_name  _;
+#        root         /usr/share/nginx/html;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers HIGH:!aNULL:!MD5;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /etc/nginx/default.d/*.conf;
+#
+#        location / {
+#        }
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+


### PR DESCRIPTION
Just trying to debug #1657 failures

## Summary by Sourcery

Update Docker configuration to use nginxinc/nginx-unprivileged and change the server port to 8080. Modify CI workflow to include frontend service logs on failure.

Build:
- Switch base image in Dockerfile to nginxinc/nginx-unprivileged and change exposed port to 8080.

CI:
- Add logging for the frontend service in GitHub Actions workflow on failure.