### PR TITLE
Feature/backend auth

### DIFF
--- a/src/app/ingestor/ingestor/dialog/ingestor.new-transfer-dialog.component.ts
+++ b/src/app/ingestor/ingestor/dialog/ingestor.new-transfer-dialog.component.ts
@@ -67,7 +67,7 @@ export class IngestorNewTransferDialogComponent implements OnInit {
 
   apiGetExtractionMethods(): void {
     this.http
-      .get(this.backendURL + INGESTOR_API_ENDPOINTS_V1.EXTRACTOR)
+      .get(this.backendURL + INGESTOR_API_ENDPOINTS_V1.EXTRACTOR, {withCredentials: true})
       .subscribe(
         (response: any) => {
           if (response.methods && response.methods.length > 0) {
@@ -85,7 +85,7 @@ export class IngestorNewTransferDialogComponent implements OnInit {
 
   apiGetAvailableFilePaths(): void {
     this.http
-      .get(this.backendURL + INGESTOR_API_ENDPOINTS_V1.DATASET)
+      .get(this.backendURL + INGESTOR_API_ENDPOINTS_V1.DATASET, {withCredentials: true})
       .subscribe(
         (response: any) => {
           if (response.datasets && response.datasets.length > 0) {

--- a/src/app/ingestor/ingestor/ingestor.component.ts
+++ b/src/app/ingestor/ingestor/ingestor.component.ts
@@ -81,7 +81,7 @@ export class IngestorComponent implements OnInit {
 
     // Try to connect to the facility backend/version to check if it is available
     console.log("Connecting to facility backend: " + facilityBackendUrlVersion);
-    this.http.get(facilityBackendUrlVersion).subscribe(
+    this.http.get(facilityBackendUrlVersion, {withCredentials: true}).subscribe(
       (response) => {
         console.log("Connected to facility backend", response);
         // If the connection is successful, store the connected facility backend URL
@@ -115,7 +115,7 @@ export class IngestorComponent implements OnInit {
     }
     this.http
       .get(this.connectedFacilityBackend + INGESTOR_API_ENDPOINTS_V1.TRANSFER, {
-        params,
+        params, withCredentials: true
       })
       .subscribe(
         (response) => {
@@ -139,7 +139,7 @@ export class IngestorComponent implements OnInit {
     this.http
       .post(
         this.connectedFacilityBackend + INGESTOR_API_ENDPOINTS_V1.DATASET,
-        payload,
+        {payload, withCredentials: true},
       )
       .subscribe(
         (response) => {
@@ -178,7 +178,7 @@ export class IngestorComponent implements OnInit {
       this.http
         .post(
           this.connectedFacilityBackend + INGESTOR_API_ENDPOINTS_V1.EXTRACTOR,
-          payload,
+          {payload, withCredentials: true},
         )
         .subscribe(
           (response) => {
@@ -334,7 +334,8 @@ export class IngestorComponent implements OnInit {
         this.connectedFacilityBackend +
           INGESTOR_API_ENDPOINTS_V1.TRANSFER +
           "/" +
-          transferId,
+          transferId, 
+          {withCredentials: true}
       )
       .subscribe(
         (response) => {


### PR DESCRIPTION
## Description
Adds proper forwarding of the backend auth cookie (HttpOnly cookie) by adding the "withCredentials" header to requests

## Motivation
It's needed to support the ingestor with auth enabled

## Fixes:
* fixes communication with ingestor when auth is enabled on the latter

## Changes:
* Adds "withCredentials" header

## Summary by Sourcery

Bug Fixes:
- Fix communication with the ingestor when authentication is enabled on the ingestor.