### PR TITLE
feat: swap 4462 proposal metadata and label localization

### DIFF
--- a/CI/e2e/frontend.config.e2e.json
+++ b/CI/e2e/frontend.config.e2e.json
@@ -65,7 +65,7 @@
       "files": "all",
       "mat_icon": "download",
       "type": "form",
-      "url": "https://www.scicat.info/download/all",
+      "url": "http://localhost:4200/download/all",
       "target": "_blank",
       "enabled": "#SizeLimit",
       "authorization": ["#datasetAccess", "#datasetPublic"]
@@ -77,7 +77,7 @@
       "files": "selected",
       "mat_icon": "download",
       "type": "form",
-      "url": "https://www.scicat.info/download/selected",
+      "url": "http://localhost:4200/download/selected",
       "target": "_blank",
       "enabled": "#Selected && #SizeLimit",
       "authorization": ["#datasetAccess", "#datasetPublic"]
@@ -89,7 +89,7 @@
       "files": "all",
       "icon": "/assets/icons/jupyter_logo.png",
       "type": "form",
-      "url": "https://www.scicat.info/notebook/all",
+      "url": "http://localhost:4200/notebook/all",
       "target": "_blank",
       "authorization": ["#datasetAccess", "#datasetPublic"]
     },
@@ -100,7 +100,7 @@
       "files": "selected",
       "icon": "/assets/icons/jupyter_logo.png",
       "type": "form",
-      "url": "https://www.scicat.info/notebook/selected",
+      "url": "http://localhost:4200/notebook/selected",
       "target": "_blank",
       "enabled": "#Selected",
       "authorization": ["#datasetAccess", "#datasetPublic"]

--- a/cypress/e2e/datasets/datasets-datafiles.cy.js
+++ b/cypress/e2e/datasets/datasets-datafiles.cy.js
@@ -1,8 +1,14 @@
 describe("Dataset datafiles", () => {
   beforeEach(() => {
+    cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
+      cy.intercept("GET", "**/admin/config", baseConfig).as(
+        "getFrontendConfig",
+      );
+    });
     cy.login(Cypress.env("username"), Cypress.env("password"));
     cy.intercept("PATCH", "/api/v3/datasets/**/*").as("change");
     cy.intercept("GET", "*").as("fetch");
+    cy.visit("/");
   });
 
   after(() => {
@@ -11,10 +17,10 @@ describe("Dataset datafiles", () => {
 
   describe("Datafiles action test", () => {
     const actionUrl = {
-      downloadSelected: "https://www.scicat.info/download/selected",
-      downloadAll: "https://www.scicat.info/download/all",
-      notebookSelected: "https://www.scicat.info/notebook/selected",
-      notebookAll: "https://www.scicat.info/notebook/all",
+      downloadSelected: "http://localhost:4200/download/selected",
+      downloadAll: "http://localhost:4200/download/all",
+      notebookSelected: "http://localhost:4200/notebook/selected",
+      notebookAll: "http://localhost:4200/notebook/all",
     };
     it("Should be able to download/notebook with selected/all", () => {
       cy.createDataset("raw", undefined, "small");

--- a/cypress/e2e/datasets/datasets-detail-dynamic.cy.js
+++ b/cypress/e2e/datasets/datasets-detail-dynamic.cy.js
@@ -4,7 +4,7 @@ import { mergeConfig } from "../../support/utils";
 describe("Datasets Detail View Dynamic", () => {
   const dynamicComponentConfig = testConfig.dynamicDetialViewComponent;
   const customizedLabelSets =
-    dynamicComponentConfig.datasetDetailViewLabelOption.labelSets.test;
+    dynamicComponentConfig.labelsLocalization.datasetCustom;
   const customizedComponents =
     dynamicComponentConfig.datasetDetailComponent.customization;
 

--- a/cypress/e2e/datasets/datasets-general.cy.js
+++ b/cypress/e2e/datasets/datasets-general.cy.js
@@ -94,7 +94,7 @@ describe("Datasets general", () => {
     });
   });
 
-  describe.only("Dataset page filter and scientific condition UI test", () => {
+  describe("Dataset page filter and scientific condition UI test", () => {
     it("should not be able to add duplicated conditions ", () => {
       cy.visit("/datasets");
 

--- a/cypress/e2e/proposals/proposals-general.cy.js
+++ b/cypress/e2e/proposals/proposals-general.cy.js
@@ -84,7 +84,7 @@ describe("Proposals general", () => {
       cy.get("mat-card").should("not.contain", newProposal.title);
     });
 
-    it.only("proposal should have type", () => {
+    it("proposal should have type", () => {
       const defaultProposalType = "Default Proposal";
       const newProposal = {
         ...testData.proposal,

--- a/cypress/e2e/proposals/proposals-general.cy.js
+++ b/cypress/e2e/proposals/proposals-general.cy.js
@@ -4,7 +4,14 @@ import { mergeConfig } from "../../support/utils";
 
 describe("Proposals general", () => {
   let proposal;
+  const proposalLabelsConfig = testConfig.proposalViewCustomLabels;
   beforeEach(() => {
+    cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
+      const mergedConfig = mergeConfig(baseConfig, proposalLabelsConfig);
+      cy.intercept("GET", "**/admin/config", mergedConfig).as(
+        "getFrontendConfig",
+      );
+    });
     cy.login(Cypress.env("username"), Cypress.env("password"));
   });
 
@@ -77,7 +84,7 @@ describe("Proposals general", () => {
       cy.get("mat-card").should("not.contain", newProposal.title);
     });
 
-    it("proposal should have type", () => {
+    it.only("proposal should have type", () => {
       const defaultProposalType = "Default Proposal";
       const newProposal = {
         ...testData.proposal,
@@ -214,15 +221,6 @@ describe("Proposals general", () => {
   });
 
   describe("Proposal view details labelization", () => {
-    const proposalLabelsConfig = testConfig.proposalViewCustomLabels;
-    before(() => {
-      cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
-        const mergedConfig = mergeConfig(baseConfig, proposalLabelsConfig);
-        cy.intercept("GET", "**/admin/config", mergedConfig).as(
-          "getFrontendConfig",
-        );
-      });
-    });
     it("should load proposal with fallback labels when no custom labels are available", () => {
       const fallbackLabelsToCheck = ["Main proposer", "Proposal Type"];
       const customizedLabelsToCheck = [

--- a/cypress/fixtures/testData.js
+++ b/cypress/fixtures/testData.js
@@ -248,4 +248,14 @@ export const testConfig = {
       customization: [],
     },
   },
+  proposalViewCustomLabels: {
+    labelsLocalization: {
+      proposalDefault: {
+        "General Information": "Test Proposal Information",
+        Title: "Test Proposal Title",
+        Abstract: "Test Abstract",
+        "Proposal Id": "Test Proposal Id",
+      },
+    },
+  },
 };

--- a/cypress/fixtures/testData.js
+++ b/cypress/fixtures/testData.js
@@ -152,21 +152,18 @@ export const testData = {
 
 export const testConfig = {
   dynamicDetialViewComponent: {
-    datasetDetailViewLabelOption: {
-      currentLabelSet: "test",
-      labelSets: {
-        test: {
-          datasetName: "Test String",
-          description: "Test Copy",
-          ownerEmail: "Test Linky",
-          keywords: "Test Tag",
-          "Section Label Regular": "Test Section Regular",
-          "Section Label Attachments": "Test Section Attachments",
-          "Section Label Metadata JSON": "Test Section Metadata JSON",
-          "Section Label Metadata TABLE": "Test Section Metadata TABLE",
-          "Section Label Metadata TREE": "Test Section Metadata TREE",
-          "Section Label Dataset JsonView": "Test Section Dataset JsonView",
-        },
+    labelsLocalization: {
+      datasetCustom: {
+        datasetName: "Test String",
+        description: "Test Copy",
+        ownerEmail: "Test Linky",
+        keywords: "Test Tag",
+        "Section Label Regular": "Test Section Regular",
+        "Section Label Attachments": "Test Section Attachments",
+        "Section Label Metadata JSON": "Test Section Metadata JSON",
+        "Section Label Metadata TABLE": "Test Section Metadata TABLE",
+        "Section Label Metadata TREE": "Test Section Metadata TREE",
+        "Section Label Dataset JsonView": "Test Section Dataset JsonView",
       },
     },
     datasetDetailComponent: {
@@ -235,18 +232,15 @@ export const testConfig = {
     },
   },
   defaultDetailViewComponent: {
-    datasetDetailViewLabelOption: {
-      currentLabelSet: "test",
-      labelSets: {
-        test: {
-          "Dataset Name": "Test Dataset name",
-          Description: "Test Description",
-          "Creation time": "Test Creation time",
-          Pid: "Test Pid",
-          Type: "Test Type",
-          "General Information": "Test General Information",
-          "Creator Information": "Creator Information",
-        },
+    labelsLocalization: {
+      datasetDefault: {
+        "Dataset Name": "Test Dataset name",
+        Description: "Test Description",
+        "Creation time": "Test Creation time",
+        Pid: "Test Pid",
+        Type: "Test Type",
+        "General Information": "Test General Information",
+        "Creator Information": "Creator Information",
       },
     },
     datasetDetailComponent: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scicat-frontend",
-  "version": "4.5.0",
+  "version": "local.dev",
   "license": "BSD-3-Clause",
   "scripts": {
     "ng": "ng",

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -3,9 +3,9 @@ import { Injectable } from "@angular/core";
 import { timeout } from "rxjs/operators";
 import {
   DatasetDetailComponentConfig,
-  DatasetDetailViewLabelOption,
   DatasetsListSettings,
   LabelMaps,
+  LabelsLocalization,
   TableColumn,
 } from "state-management/models";
 
@@ -103,8 +103,8 @@ export interface AppConfig {
   labelMaps: LabelMaps;
   thumbnailFetchLimitPerPage: number;
   maxFileUploadSizeInMb?: string;
-  datasetDetailViewLabelOption?: DatasetDetailViewLabelOption;
   datasetDetailComponent?: DatasetDetailComponentConfig;
+  labelsLocalization?: LabelsLocalization;
 }
 
 @Injectable()

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.spec.ts
@@ -30,11 +30,7 @@ describe("DatasetDetailDynamicComponent", () => {
     navigateByUrl: jasmine.createSpy("navigateByUrl"),
   };
 
-  const getConfig = () => ({
-    datasetDetailViewLabelOption: {
-      currentLabel: "test",
-    },
-  });
+  const getConfig = () => ({});
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
@@ -58,9 +58,7 @@ export class DatasetDetailDynamicComponent implements OnInit {
     private store: Store,
     private fb: FormBuilder,
   ) {
-    this.translateService.use(
-      this.appConfig.datasetDetailViewLabelOption?.currentLabelSet,
-    );
+    this.translateService.use("datasetCustom");
   }
 
   ngOnInit() {

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.spec.ts
@@ -57,11 +57,7 @@ describe("DatasetDetailComponent", () => {
     navigateByUrl: jasmine.createSpy("navigateByUrl"),
   };
 
-  const getConfig = () => ({
-    datasetDetailViewLabelOption: {
-      currentLabel: "test",
-    },
-  });
+  const getConfig = () => ({});
 
   let store: MockStore;
 

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
@@ -98,7 +98,7 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
     private fb: FormBuilder,
   ) {
     this.translateService.use(
-      this.appConfig.datasetDetailViewLabelOption?.currentLabelSet,
+      this.appConfig.labelsLocalization?.currentLabelSet["dataset-default"],
     );
   }
 

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
@@ -97,9 +97,7 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
     private router: Router,
     private fb: FormBuilder,
   ) {
-    this.translateService.use(
-      this.appConfig.labelsLocalization?.currentLabelSet["dataset-default"],
-    );
+    this.translateService.use("datasetDefault");
   }
 
   ngOnInit() {

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -87,7 +87,7 @@
     <mat-card-content>
       <table>
         <tr>
-          <th>{{ "Main proposer" |  translate }}</th>
+          <th>{{ "Main proposer" | translate }}</th>
           <td *ngIf="proposal.firstname && proposal.lastname; else noName">
             <a href="mailto:{{ proposal.email }}"
               >{{ proposal.firstname }} {{ proposal.lastname }}</a

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -4,22 +4,40 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> description </mat-icon>
       </div>
-      General Information
+      {{ "General Information" | translate }}
     </mat-card-header>
 
     <mat-card-content>
       <table>
         <tr>
-          <th>Title</th>
+          <th>{{ "Title" | translate }}</th>
           <td>{{ proposal.title }}</td>
         </tr>
         <tr>
-          <th>Abstract</th>
+          <th>{{ "Abstract" | translate }}</th>
           <td>{{ proposal.abstract }}</td>
         </tr>
         <tr>
-          <th>Identifier</th>
+          <th>{{ "Proposal Id" | translate }}</th>
           <td>{{ proposal.proposalId }}</td>
+        </tr>
+        <tr data-cy="proposal-type">
+          <th>{{ "Proposal Type" | translate }}</th>
+          <!-- TODO: Change this to just proposal.type when new sdk is merged -->
+          <td>{{ proposal["type"] }}</td>
+        </tr>
+        <tr
+          *ngIf="
+            proposal['parentProposalId'] && parentProposal$
+              | async as parentProposal
+          "
+        >
+          <th>{{ "Parent proposal" | translate }}</th>
+          <td>
+            <a (click)="onClickProposal(parentProposal.proposalId)">{{
+              parentProposal.title
+            }}</a>
+          </td>
         </tr>
         <ng-template
           [ngIf]="
@@ -35,7 +53,7 @@
             let-first="first"
           >
             <tr *ngIf="first">
-              <th>Start Time</th>
+              <th>{{ "Start Time" | translate }}</th>
               <td>
                 {{ period.start | date }}
               </td>
@@ -49,29 +67,11 @@
             let-last="last"
           >
             <tr *ngIf="last">
-              <th>End Time</th>
+              <th>{{ "End Time" | translate }}</th>
               <td>{{ period.end | date }}</td>
             </tr>
           </ng-template>
         </ng-template>
-        <tr data-cy="proposal-type">
-          <th>Type</th>
-          <!-- TODO: Change this to just proposal.type when new sdk is merged -->
-          <td>{{ proposal["type"] }}</td>
-        </tr>
-        <tr
-          *ngIf="
-            proposal['parentProposalId'] && parentProposal$
-              | async as parentProposal
-          "
-        >
-          <th>Parent proposal</th>
-          <td>
-            <a (click)="onClickProposal(parentProposal.proposalId)">{{
-              parentProposal.title
-            }}</a>
-          </td>
-        </tr>
       </table>
     </mat-card-content>
   </mat-card>
@@ -81,13 +81,13 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> person </mat-icon>
       </div>
-      Creator Information
+      {{ "Creator Information" | translate }}
     </mat-card-header>
 
     <mat-card-content>
       <table>
         <tr>
-          <th>Main proposer</th>
+          <th>{{ "Main proposer" |  translate }}</th>
           <td *ngIf="proposal.firstname && proposal.lastname; else noName">
             <a href="mailto:{{ proposal.email }}"
               >{{ proposal.firstname }} {{ proposal.lastname }}</a
@@ -100,7 +100,7 @@
           </ng-template>
         </tr>
         <tr *ngIf="proposal.pi_firstname && proposal.pi_lastname">
-          <th>Principal investigator</th>
+          <th>{{ "Principal Investigator" | translate }}</th>
           <td *ngIf="proposal.pi_email; else withoutEmail">
             <a href="mailto:{{ proposal.pi_email }}"
               >{{ proposal.pi_firstname }} {{ proposal.pi_lastname }}</a
@@ -122,7 +122,7 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> science </mat-icon>
       </div>
-      Metadata
+      {{ "Metadata" | translate }}
     </mat-card-header>
     <mat-card-content>
       <ng-template [ngIf]="appConfig.tableSciDataEnabled" [ngIfElse]="jsonView">

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -4,25 +4,25 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> description </mat-icon>
       </div>
-      {{ "General Information" | componentTranslate:"proposal" }}
+      {{ "General Information" | translate }}
     </mat-card-header>
 
     <mat-card-content>
       <table>
         <tr>
-          <th>{{ "Title" | componentTranslate:"proposal" }}</th>
+          <th>{{ "Title" | translate }}</th>
           <td>{{ proposal.title }}</td>
         </tr>
         <tr>
-          <th>{{ "Abstract" | componentTranslate:"proposal" }}</th>
+          <th>{{ "Abstract" | translate }}</th>
           <td>{{ proposal.abstract }}</td>
         </tr>
         <tr>
-          <th>{{ "Proposal Id" | componentTranslate:"proposal" }}</th>
+          <th>{{ "Proposal Id" | translate }}</th>
           <td>{{ proposal.proposalId }}</td>
         </tr>
         <tr data-cy="proposal-type">
-          <th>{{ "Proposal Type" | componentTranslate:"proposal" }}</th>
+          <th>{{ "Proposal Type" | translate }}</th>
           <!-- TODO: Change this to just proposal.type when new sdk is merged -->
           <td>{{ proposal["type"] }}</td>
         </tr>
@@ -32,7 +32,7 @@
               | async as parentProposal
           "
         >
-          <th>{{ "Parent proposal" | componentTranslate:"proposal" }}</th>
+          <th>{{ "Parent proposal" | translate }}</th>
           <td>
             <a (click)="onClickProposal(parentProposal.proposalId)">{{
               parentProposal.title
@@ -53,7 +53,7 @@
             let-first="first"
           >
             <tr *ngIf="first">
-              <th>{{ "Start Time" | componentTranslate:"proposal" }}</th>
+              <th>{{ "Start Time" | translate }}</th>
               <td>
                 {{ period.start | date }}
               </td>
@@ -67,7 +67,7 @@
             let-last="last"
           >
             <tr *ngIf="last">
-              <th>{{ "End Time" | componentTranslate:"proposal" }}</th>
+              <th>{{ "End Time" | translate }}</th>
               <td>{{ period.end | date }}</td>
             </tr>
           </ng-template>
@@ -81,13 +81,13 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> person </mat-icon>
       </div>
-      {{ "Creator Information" | componentTranslate:"proposal" }}
+      {{ "Creator Information" | translate }}
     </mat-card-header>
 
     <mat-card-content>
       <table>
         <tr>
-          <th>{{ "Main proposer" |  componentTranslate:"proposal" }}</th>
+          <th>{{ "Main proposer" |  translate }}</th>
           <td *ngIf="proposal.firstname && proposal.lastname; else noName">
             <a href="mailto:{{ proposal.email }}"
               >{{ proposal.firstname }} {{ proposal.lastname }}</a
@@ -100,7 +100,7 @@
           </ng-template>
         </tr>
         <tr *ngIf="proposal.pi_firstname && proposal.pi_lastname">
-          <th>{{ "Principal Investigator" | componentTranslate:"proposal" }}</th>
+          <th>{{ "Principal Investigator" | translate }}</th>
           <td *ngIf="proposal.pi_email; else withoutEmail">
             <a href="mailto:{{ proposal.pi_email }}"
               >{{ proposal.pi_firstname }} {{ proposal.pi_lastname }}</a
@@ -122,7 +122,7 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> science </mat-icon>
       </div>
-      {{ "Metadata" | componentTranslate:"proposal" }}
+      {{ "Metadata" | translate }}
     </mat-card-header>
     <mat-card-content>
       <ng-template [ngIf]="appConfig.tableSciDataEnabled" [ngIfElse]="jsonView">

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -146,30 +146,6 @@
             </ng-template>
             <ng-container *ngTemplateOutlet="metadataView"> </ng-container>
           </mat-tab>
-          <mat-tab
-            class="editTab"
-            *ngIf="editingAllowed"
-            [hidden]="!appConfig.editMetadataEnabled"
-          >
-            <ng-template mat-tab-label>
-              <mat-icon> edit </mat-icon> Edit
-            </ng-template>
-            <div [ngSwitch]="appConfig.metadataStructure">
-              <tree-edit
-                *ngSwitchCase="'tree'"
-                [metadata]="proposal['metadata']"
-                (save)="onSaveMetadata($event)"
-                (hasUnsavedChanges)="onHasUnsavedChanges($event)"
-              >
-              </tree-edit>
-              <metadata-edit
-                *ngSwitchDefault
-                [metadata]="proposal['metadata']"
-                (save)="onSaveMetadata($event)"
-              >
-              </metadata-edit>
-            </div>
-          </mat-tab>
         </mat-tab-group>
       </ng-template>
 

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -146,6 +146,30 @@
             </ng-template>
             <ng-container *ngTemplateOutlet="metadataView"> </ng-container>
           </mat-tab>
+          <mat-tab
+            class="editTab"
+            *ngIf="editingAllowed"
+            [hidden]="!appConfig.editMetadataEnabled"
+          >
+            <ng-template mat-tab-label>
+              <mat-icon> edit </mat-icon> Edit
+            </ng-template>
+            <div [ngSwitch]="appConfig.metadataStructure">
+              <tree-edit
+                *ngSwitchCase="'tree'"
+                [metadata]="proposal['metadata']"
+                (save)="onSaveMetadata($event)"
+                (hasUnsavedChanges)="onHasUnsavedChanges($event)"
+              >
+              </tree-edit>
+              <metadata-edit
+                *ngSwitchDefault
+                [metadata]="proposal['metadata']"
+                (save)="onSaveMetadata($event)"
+              >
+              </metadata-edit>
+            </div>
+          </mat-tab>
         </mat-tab-group>
       </ng-template>
 

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -4,25 +4,25 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> description </mat-icon>
       </div>
-      {{ "General Information" | translate }}
+      {{ "General Information" | componentTranslate:"proposal" }}
     </mat-card-header>
 
     <mat-card-content>
       <table>
         <tr>
-          <th>{{ "Title" | translate }}</th>
+          <th>{{ "Title" | componentTranslate:"proposal" }}</th>
           <td>{{ proposal.title }}</td>
         </tr>
         <tr>
-          <th>{{ "Abstract" | translate }}</th>
+          <th>{{ "Abstract" | componentTranslate:"proposal" }}</th>
           <td>{{ proposal.abstract }}</td>
         </tr>
         <tr>
-          <th>{{ "Proposal Id" | translate }}</th>
+          <th>{{ "Proposal Id" | componentTranslate:"proposal" }}</th>
           <td>{{ proposal.proposalId }}</td>
         </tr>
         <tr data-cy="proposal-type">
-          <th>{{ "Proposal Type" | translate }}</th>
+          <th>{{ "Proposal Type" | componentTranslate:"proposal" }}</th>
           <!-- TODO: Change this to just proposal.type when new sdk is merged -->
           <td>{{ proposal["type"] }}</td>
         </tr>
@@ -32,7 +32,7 @@
               | async as parentProposal
           "
         >
-          <th>{{ "Parent proposal" | translate }}</th>
+          <th>{{ "Parent proposal" | componentTranslate:"proposal" }}</th>
           <td>
             <a (click)="onClickProposal(parentProposal.proposalId)">{{
               parentProposal.title
@@ -53,7 +53,7 @@
             let-first="first"
           >
             <tr *ngIf="first">
-              <th>{{ "Start Time" | translate }}</th>
+              <th>{{ "Start Time" | componentTranslate:"proposal" }}</th>
               <td>
                 {{ period.start | date }}
               </td>
@@ -67,7 +67,7 @@
             let-last="last"
           >
             <tr *ngIf="last">
-              <th>{{ "End Time" | translate }}</th>
+              <th>{{ "End Time" | componentTranslate:"proposal" }}</th>
               <td>{{ period.end | date }}</td>
             </tr>
           </ng-template>
@@ -81,13 +81,13 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> person </mat-icon>
       </div>
-      {{ "Creator Information" | translate }}
+      {{ "Creator Information" | componentTranslate:"proposal" }}
     </mat-card-header>
 
     <mat-card-content>
       <table>
         <tr>
-          <th>{{ "Main proposer" |  translate }}</th>
+          <th>{{ "Main proposer" |  componentTranslate:"proposal" }}</th>
           <td *ngIf="proposal.firstname && proposal.lastname; else noName">
             <a href="mailto:{{ proposal.email }}"
               >{{ proposal.firstname }} {{ proposal.lastname }}</a
@@ -100,7 +100,7 @@
           </ng-template>
         </tr>
         <tr *ngIf="proposal.pi_firstname && proposal.pi_lastname">
-          <th>{{ "Principal Investigator" | translate }}</th>
+          <th>{{ "Principal Investigator" | componentTranslate:"proposal" }}</th>
           <td *ngIf="proposal.pi_email; else withoutEmail">
             <a href="mailto:{{ proposal.pi_email }}"
               >{{ proposal.pi_firstname }} {{ proposal.pi_lastname }}</a
@@ -122,7 +122,7 @@
       <div mat-card-avatar class="section-icon">
         <mat-icon> science </mat-icon>
       </div>
-      {{ "Metadata" | translate }}
+      {{ "Metadata" | componentTranslate:"proposal" }}
     </mat-card-header>
     <mat-card-content>
       <ng-template [ngIf]="appConfig.tableSciDataEnabled" [ngIfElse]="jsonView">

--- a/src/app/proposals/proposal-detail/proposal-detail.component.spec.ts
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.spec.ts
@@ -7,6 +7,17 @@ import { MatButtonModule } from "@angular/material/button";
 import { NgxJsonViewerModule } from "ngx-json-viewer";
 import { AppConfigService } from "app-config.service";
 import { StoreModule } from "@ngrx/store";
+import {
+  TranslateLoader,
+  TranslateModule,
+  TranslationObject,
+} from "@ngx-translate/core";
+import { Observable, of } from "rxjs";
+class MockTranslateLoader implements TranslateLoader {
+  getTranslation(): Observable<TranslationObject> {
+    return of({});
+  }
+}
 
 const getConfig = () => ({
   jsonMetadataEnabled: true,
@@ -25,12 +36,23 @@ describe("ProposalsDetailComponent", () => {
         MatIconModule,
         NgxJsonViewerModule,
         StoreModule.forRoot({}),
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: MockTranslateLoader,
+          },
+        }),
       ],
       declarations: [ProposalDetailComponent],
     });
     TestBed.overrideComponent(ProposalDetailComponent, {
       set: {
-        providers: [{ provide: AppConfigService, useValue: { getConfig } }],
+        providers: [
+          {
+            provide: AppConfigService,
+            useValue: { getConfig },
+          },
+        ],
       },
     });
     TestBed.compileComponents();

--- a/src/app/proposals/proposal-detail/proposal-detail.component.ts
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.ts
@@ -51,7 +51,7 @@ export class ProposalDetailComponent implements OnInit, OnDestroy {
     private store: Store,
     private router: Router,
   ) {
-    this.translateService.use(this.appConfig.labelsLocalization?.proposal);
+    this.translateService.use("proposalDefault");
   }
 
   ngOnInit(): void {

--- a/src/app/proposals/proposal-detail/proposal-detail.component.ts
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.ts
@@ -21,6 +21,7 @@ import {
   selectProfile,
 } from "state-management/selectors/user.selectors";
 import { clearProposalsStateAction } from "state-management/actions/proposals.actions";
+import { TranslateService } from "@ngx-translate/core";
 
 @Component({
   selector: "proposal-detail",
@@ -46,9 +47,14 @@ export class ProposalDetailComponent implements OnInit, OnDestroy {
 
   constructor(
     public appConfigService: AppConfigService,
+    private translateService: TranslateService,
     private store: Store,
     private router: Router,
-  ) {}
+  ) {
+    this.translateService.use(
+      this.appConfig.labelsLocalization?.currentLabelSet["proposal"],
+    );
+  }
 
   ngOnInit(): void {
     // Prevent user from reloading page if there are unsave changes

--- a/src/app/proposals/proposal-detail/proposal-detail.component.ts
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.ts
@@ -51,9 +51,7 @@ export class ProposalDetailComponent implements OnInit, OnDestroy {
     private store: Store,
     private router: Router,
   ) {
-    this.translateService.use(
-      this.appConfig.labelsLocalization?.currentLabelSet["proposal"],
-    );
+    this.translateService.use(this.appConfig.labelsLocalization?.proposal);
   }
 
   ngOnInit(): void {

--- a/src/app/proposals/proposals.module.ts
+++ b/src/app/proposals/proposals.module.ts
@@ -37,6 +37,7 @@ import { logbooksReducer } from "state-management/reducers/logbooks.reducer";
 import { ProposalLogbookComponent } from "./proposal-logbook/proposal-logbook.component";
 import { RelatedProposalsComponent } from "./related-proposals/related-proposals.component";
 import { ProposalDatasetsComponent } from "./proposal-datasets/proposal-datasets.component";
+import { TranslateModule } from "@ngx-translate/core";
 
 @NgModule({
   imports: [
@@ -62,6 +63,7 @@ import { ProposalDatasetsComponent } from "./proposal-datasets/proposal-datasets
     SharedScicatFrontendModule,
     StoreModule.forFeature("proposals", proposalsReducer),
     StoreModule.forFeature("logbooks", logbooksReducer),
+    TranslateModule,
   ],
   declarations: [
     ViewProposalPageComponent,

--- a/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
+++ b/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
@@ -31,7 +31,7 @@ export class ViewProposalPageComponent implements OnInit, OnDestroy {
     private translateService: TranslateService,
   ) {
     this.translateService.use(
-      this.appConfig.labelsLocalization?.currentLabelSet["proposal"],
+      this.appConfig.labelsLocalization?.currentLabelSet,
     );
   }
 

--- a/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
+++ b/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
@@ -30,9 +30,7 @@ export class ViewProposalPageComponent implements OnInit, OnDestroy {
     private store: Store,
     private translateService: TranslateService,
   ) {
-    this.translateService.use(
-      this.appConfig.labelsLocalization?.currentLabelSet,
-    );
+    this.translateService.use("proposalDefault");
   }
 
   ngOnInit() {

--- a/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
+++ b/src/app/proposals/view-proposal-page/view-proposal-page.component.ts
@@ -31,7 +31,7 @@ export class ViewProposalPageComponent implements OnInit, OnDestroy {
     private translateService: TranslateService,
   ) {
     this.translateService.use(
-      this.appConfig.datasetDetailViewLabelOption?.currentLabelSet,
+      this.appConfig.labelsLocalization?.currentLabelSet["proposal"],
     );
   }
 

--- a/src/app/shared/loaders/custom-translate.loader.ts
+++ b/src/app/shared/loaders/custom-translate.loader.ts
@@ -9,7 +9,7 @@ export class CustomTranslateLoader implements TranslateLoader {
 
   getTranslation(): Observable<TranslationObject> {
     const { currentLabelSet = "", labelSets = {} } =
-      this.appConfig.datasetDetailViewLabelOption || {};
+      this.appConfig?.labelsLocalization || {};
 
     if (currentLabelSet in labelSets) {
       return of(labelSets[currentLabelSet]);

--- a/src/app/shared/loaders/custom-translate.loader.ts
+++ b/src/app/shared/loaders/custom-translate.loader.ts
@@ -8,12 +8,13 @@ export class CustomTranslateLoader implements TranslateLoader {
   constructor(private appConfigService: AppConfigService) {}
 
   getTranslation(): Observable<TranslationObject> {
-    const { currentLabelSet = "", labelSets = {} } =
-      this.appConfig?.labelsLocalization || {};
+    // const { currentLabelSet = "", labelSets = {} } =
+    //   this.appConfig?.labelsLocalization || {};
 
-    if (currentLabelSet in labelSets) {
-      return of(labelSets[currentLabelSet]);
-    }
-    return of({});
+    // if (currentLabelSet in labelSets) {
+    //   return of(labelSets[currentLabelSet]);
+    // }
+    //return of({});
+    return of(this.appConfig.labelsLocalization || {});
   }
 }

--- a/src/app/shared/loaders/custom-translate.loader.ts
+++ b/src/app/shared/loaders/custom-translate.loader.ts
@@ -7,14 +7,15 @@ export class CustomTranslateLoader implements TranslateLoader {
 
   constructor(private appConfigService: AppConfigService) {}
 
-  getTranslation(): Observable<TranslationObject> {
-    // const { currentLabelSet = "", labelSets = {} } =
-    //   this.appConfig?.labelsLocalization || {};
+  getTranslation(lang: string): Observable<TranslationObject> {
+    if (
+      this.appConfig.labelsLocalization &&
+      this.appConfig.labelsLocalization[lang]
+    ) {
+      return of(this.appConfig.labelsLocalization[lang]);
+    }
 
-    // if (currentLabelSet in labelSets) {
-    //   return of(labelSets[currentLabelSet]);
-    // }
-    //return of({});
-    return of(this.appConfig.labelsLocalization || {});
+    console.warn(`Translation for "${lang}" not found.`);
+    return of({});
   }
 }

--- a/src/app/shared/pipes/component-translate.pipe.ts
+++ b/src/app/shared/pipes/component-translate.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { TranslateService } from "@ngx-translate/core";
+
+@Pipe({
+  name: "componentTranslate",
+})
+export class ComponentTranslatePipe implements PipeTransform {
+  constructor(private translateService: TranslateService) {}
+
+  transform(value: any, component = "", ...args: any[]): string {
+    const valueToBeTranslated = component ? component + "." + value : value;
+    const translatedValue = this.translateService.instant(valueToBeTranslated);
+    return translatedValue !== valueToBeTranslated ? translatedValue : value;
+  }
+}

--- a/src/app/shared/pipes/pipes.module.ts
+++ b/src/app/shared/pipes/pipes.module.ts
@@ -13,6 +13,7 @@ import { DynamicPipe } from "./dynamicPipe.pipe";
 import { NewDynamicPipe } from "./newDynamicPipe.pipe";
 import { DescriptionTitlePipe } from "./description-title.pipe";
 import { FormatNumberPipe } from "./format-number.pipe";
+import { ComponentTranslatePipe } from "./component-translate.pipe";
 @NgModule({
   declarations: [
     FileSizePipe,
@@ -28,6 +29,7 @@ import { FormatNumberPipe } from "./format-number.pipe";
     DynamicPipe,
     NewDynamicPipe,
     DescriptionTitlePipe,
+    ComponentTranslatePipe,
   ],
   imports: [CommonModule],
   exports: [
@@ -44,6 +46,7 @@ import { FormatNumberPipe } from "./format-number.pipe";
     DynamicPipe,
     NewDynamicPipe,
     DescriptionTitlePipe,
+    ComponentTranslatePipe,
   ],
 })
 export class PipesModule {}

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -21,10 +21,12 @@ export interface LabelMaps {
   [key: string]: Record<string, string>;
 }
 
-export interface DatasetDetailViewLabelOption {
+export interface LabelsLocalization {
   currentLabelSet: string;
   labelSets: {
-    [key: string]: Record<string, string>;
+    [key: string]: {
+      [key: string]: Record<string, string>;
+    };
   };
 }
 

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -22,12 +22,9 @@ export interface LabelMaps {
 }
 
 export interface LabelsLocalization {
-  currentLabelSet: string;
-  labelSets: {
-    [key: string]: {
-      [key: string]: Record<string, string>;
-    };
-  };
+  datasetDefault: Record<string, string>;
+  datasetCustom: Record<string, string>;
+  proposalDefault: Record<string, string>;
 }
 
 export interface DatasetDetailComponentConfig {

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -224,10 +224,14 @@
           "General Information": "Proposal Information",
           "Title" : "Proposal Title",
           "Abstract" : "Abstract",
-          "Identifier" : "Proposal Id",
-          "Type" : "Proposal Type",
+          "Proposal Id" : "Proposal Id",
+          "Proposal Type" : "Proposal Type",
+          "Parent Proposal" : "Parent Proposal",
+          "Start Time" : "Start Time",
+          "End Time" : "End Time",
           "Creator Information" : "People",
           "Main Proposer": "Proposal Submitted By",
+          "Principal Investigator" : "Principal Investigator",
           "Metadata": "Additional Information"
         }
       }

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -222,7 +222,7 @@
         },
         "proposal" : {
           "General Information": "Proposal Information",
-          "Title" : "Proposal Title",
+          //"Title" : "Proposal Title",
           "Abstract" : "Abstract",
           "Proposal Id" : "Proposal Id",
           "Proposal Type" : "Proposal Type",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -205,5 +205,32 @@
       { "TextFilter": true }
     ],
     "conditions": []
+  },
+  "labelsLocalization": {
+    "currentLabelSet": "ess",
+    "labelSets": {
+      "ess": {
+        "dataset-default": {},
+        "dataset-custom" : {
+          "pid": "PID",
+          "description": "Description",
+          "principalInvestigator": "Principal Investigator",
+          "keywords": "Keywords",
+          "creationTime": "Creation Time",
+          "scientificMetadata": "Scientific Metadata",
+          "metadataJsonView": "Metadata JsonView"
+        },
+        "proposal" : {
+          "General Information": "Proposal Information",
+          "Title" : "Proposal Title",
+          "Abstract" : "Abstract",
+          "Identifier" : "Proposal Id",
+          "Type" : "Proposal Type",
+          "Creator Information" : "People",
+          "Main Proposer": "Proposal Submitted By",
+          "Metadata": "Additional Information"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description
This PR streamline showing the metadata for proposals and add localization to the proposals

## Motivation
Showing metadata on proposals involves multiple configurations settings and a simplification was needed.
Following up the dataset labels localization, it was easy to extend to proposals

## Changes:
* Proposal module
* Proposal details html page

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [x] Does it require a specific version of the backend
- which version of the backend is required:  BE PR still needs to be created

## Summary by Sourcery

Add localization to proposal metadata and simplify metadata display configuration.

New Features:
- Added localization support for proposal metadata.

Tests:
- No tests were included in this pull request.