### PR TITLE
chore: added skip validate spec and reasoning for generate nestjs sdk script

### DIFF
--- a/scripts/generate-nestjs-sdk.bash
+++ b/scripts/generate-nestjs-sdk.bash
@@ -10,6 +10,11 @@ rm -rf node_modules/@scicatproject/scicat-sdk-ts-angular
 rm -rf @scicatproject/scicat-sdk-ts-angular
 
 echo -e "\nGenerating the new sdk..."
+
+##
+# NOTE: parameter --skip-validate-spec is passed to avoid some errors like not supporting the "content" in the @ApiQuery() parameter that we use in the dataset v4 controller.
+# This should not be a risk as after the generation we can get a feedback immediately if something is broken here when we run and test the frontend.
+##
 docker run \
 	--rm \
 	--add-host host.docker.internal:host-gateway \
@@ -18,7 +23,7 @@ docker run \
 	-i http://host.docker.internal:3000/explorer-json \
 	-g typescript-angular \
 	-o local/@scicatproject/scicat-sdk-ts-angular \
-	--additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts-angular,supportsES6=true,npmVersion=10.8.2,withInterfaces=true
+	--additional-properties=ngVersion=16.2.12,npmName=@scicatproject/scicat-sdk-ts-angular,supportsES6=true,npmVersion=10.8.2,withInterfaces=true  --skip-validate-spec
 
 REMOVE_NPM_LINK=0
 if ! command -v npm 2>&1 1>/dev/null


### PR DESCRIPTION
## Description
added --skip-validate-spec and reasoning for .bash file


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Build:
- Skip OpenAPI spec validation during NestJS SDK generation.