### PR TITLE
fix: ensure scientific metadata table display correctly when unit is missing

### DIFF
--- a/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
@@ -133,7 +133,7 @@ export class MetadataEditComponent implements OnInit, OnChanges {
           typeof this.metadata[key] === "object" &&
           "value" in (this.metadata[key] as ScientificMetadata)
         ) {
-          if (this.metadata[key]["unit"].length > 0) {
+          if (this.metadata[key].unit?.length > 0) {
             field = this.formBuilder.group({
               fieldType: this.formControlFields["fieldType"]("quantity"),
               fieldName: this.formControlFields["fieldName"](key),

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
@@ -26,7 +26,10 @@
         Unit
       </mat-header-cell>
       <mat-cell *matCellDef="let metadata">
-        <ng-template [ngIf]="metadata.unit.length > 0" [ngIfElse]="noUnit">
+        <ng-template
+          [ngIf]="metadata.unit && metadata.unit.length > 0"
+          [ngIfElse]="noUnit"
+        >
           <span class="unit-input">
             {{ metadata.unit | prettyUnit }}
             <mat-icon

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
@@ -26,10 +26,7 @@
         Unit
       </mat-header-cell>
       <mat-cell *matCellDef="let metadata">
-        <ng-template
-          [ngIf]="metadata.unit && metadata.unit.length > 0"
-          [ngIfElse]="noUnit"
-        >
+        <ng-template [ngIf]="metadata.unit?.length > 0" [ngIfElse]="noUnit">
           <span class="unit-input">
             {{ metadata.unit | prettyUnit }}
             <mat-icon


### PR DESCRIPTION
## Description
This PR fixes metadata table crash when no unit is provided in the scientific metadata table
![image](https://github.com/user-attachments/assets/b4f96d2b-f047-4c86-bec3-5bbc7caccb37)


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
