### PR TITLE
fix: fixing related proposals error related to count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@ngrx/router-store": "^16",
         "@ngrx/store": "^16",
         "@ngx-translate/core": "^16.0.4",
-        "@scicatproject/scicat-sdk-ts-angular": "^4.12.2",
+        "@scicatproject/scicat-sdk-ts-angular": "^4.13.0",
         "autolinker": "^4.0.0",
         "deep-equal": "^2.0.5",
         "exceljs": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@ngrx/router-store": "^16",
     "@ngrx/store": "^16",
     "@ngx-translate/core": "^16.0.4",
-    "@scicatproject/scicat-sdk-ts-angular": "^4.12.2",
+    "@scicatproject/scicat-sdk-ts-angular": "^4.13.0",
     "autolinker": "^4.0.0",
     "deep-equal": "^2.0.5",
     "exceljs": "^4.3.0",

--- a/src/app/state-management/effects/proposals.effects.ts
+++ b/src/app/state-management/effects/proposals.effects.ts
@@ -272,7 +272,10 @@ export class ProposalEffects {
         };
 
         return this.proposalsService
-          .proposalsControllerCount(JSON.stringify(queryFilter))
+          .proposalsControllerCount(
+            JSON.stringify({}),
+            JSON.stringify(queryFilter),
+          )
           .pipe(
             map(({ count }) =>
               fromActions.fetchRelatedProposalsCountCompleteAction({


### PR DESCRIPTION
## Description
There was an Internal server error in the related proposals count.


## Motivation
Fixing the error that was thrown in staging environment


## Fixes:
* https://jira.ess.eu/browse/SWAP-4554


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [x] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Fixes an internal server error related to the related proposals count by updating the proposalsControllerCount method to include query filters.

Bug Fixes:
- Fixes an internal server error in the related proposals count.

Enhancements:
- Updates the SciCat SDK to version 4.13.0.