### PR TITLE
Make release version consistent

### DIFF
--- a/.github/workflows/release-push.yml
+++ b/.github/workflows/release-push.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       ## Commit message examples for Release type (patch|minor|major) can be found:
       ## https://github.com/mathieudutour/github-tag-action
       - name: Bump version and push tag
@@ -27,6 +32,24 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: ${{ env.RELEASE_BRANCH }}
+
+      - name: Strip 'v' from the tag
+        id: release_version
+        run: |
+          TAG=${{ steps.tag_version.outputs.new_tag }}
+          WITHOUT_V=${TAG#v}
+          echo "release_version=$WITHOUT_V" >> $GITHUB_OUTPUT
+
+      - name: Update release version
+        run: |
+          npm version --no-git-tag-version ${{ steps.release_version.release_version }}
+
+      - name: Commit package with new version
+        run: |
+          git config --global user.name 'SciCat FE Release Workflow'
+          git config --global user.email 'nitrosx@users.noreply.github.com'
+          git commit -am "Set release"
+          git push
 
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
@@ -49,11 +72,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Node.js dependencies
         run: npm ci


### PR DESCRIPTION
## Description
This PR adds the necessary steps to the release workflow to update package.json with the matching version of the release.

## Motivation
The FE uses the version entry in package.json to show its version to the user. 
At the moment version in package.json must be updated manually, which it is a source of confusion because it is easy to forget and it is hard to know before hand the new version, given that we use semantic versioning in the release workflow.


## Changes:
Please provide a list of the changes implemented by this PR
* change the github workflow for release

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
