### PR TITLE
Datafiles action type json

### DIFF
--- a/src/app/datasets/datafiles-actions/datafiles-action.component.ts
+++ b/src/app/datasets/datafiles-actions/datafiles-action.component.ts
@@ -111,6 +111,8 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
   perform_action() {
     const action_type = this.actionConfig.type || "form";
     switch (action_type) {
+      case "json":
+        return this.type_json();
       case "form":
       default:
         return this.type_form();
@@ -159,21 +161,27 @@ export class DatafilesActionComponent implements OnInit, OnChanges {
     return true;
   }
 
-  /*
-   * future development
-   *
-  type_fetch() {
-    const data = new URLSearchParams();
-    for (const pair of new FormData(formElement)) {
-      data.append(pair[0], pair[1]);
-    }
+  type_json() {
+    const data = {
+      auth_token: `Bearer ${this.authService.getToken().id}`,
+      jwt: this.jwt,
+      dataset: this.actionDataset.pid,
+      directory: this.actionDataset.sourceFolder,
+      files: this.files
+        .filter(
+          (item) =>
+            this.actionConfig.files === "all" ||
+            (this.actionConfig.files === "selected" && item.selected),
+        )
+        .map((item) => item.path),
+    };
 
-    fetch(url, {
-      method: 'post',
-      body: data,
-    })
-    .then(…);
-    }
+    fetch(this.actionConfig.url, {
+      method: this.actionConfig.method || "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+
+    return true;
   }
-   */
 }


### PR DESCRIPTION
## Description
This PR add the option to create a datafile action in json format.
It will submit a request to the specified URL with the payload in json format in the body

## Motivation
sciwyrm (Jupiter notebook generator) accepts only requests formatted as json.
ESS is currently deploying it in their infrastructure.

## Changes:
Please provide a list of the changes implemented by this PR
* datafiles actions controller

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
