### PR TITLE
fix: remove duplicate argument in related proposals

### DIFF
--- a/src/app/state-management/effects/proposals.effects.ts
+++ b/src/app/state-management/effects/proposals.effects.ts
@@ -280,10 +280,7 @@ export class ProposalEffects {
         };
 
         return this.proposalsService
-          .proposalsControllerCount(
-            JSON.stringify({}),
-            JSON.stringify(queryFilter),
-          )
+          .proposalsControllerCount(JSON.stringify(queryFilter))
           .pipe(
             map(({ count }) =>
               fromActions.fetchRelatedProposalsCountCompleteAction({


### PR DESCRIPTION
## Description
Removes a duplicate argument in src/app/state-management/effects/proposals.effects.ts line 283-285 which caused a compilation error on startup. Reverted back to code as in Release v5.1.0.
Compilation tested in local env, error is resolved.

## Fixes:

* Removed extra argument in proposalsControllerCount

## Summary by Sourcery

Bug Fixes:
- Removes a duplicate argument in proposalsControllerCount, resolving a compilation error.