### PR TITLE
fix: returnUrl from back end was being discarded

### DIFF
--- a/src/app/_layout/app-header/app-header.component.ts
+++ b/src/app/_layout/app-header/app-header.component.ts
@@ -46,9 +46,9 @@ export class AppHeaderComponent implements OnInit {
 
   login(): void {
     if (this.config.skipSciCatLoginPageEnabled) {
-      const returnURL = encodeURIComponent(this.router.url);
+      const returnUrl = encodeURIComponent(this.router.url);
       for (const endpoint of this.oAuth2Endpoints) {
-        this.document.location.href = `${this.config.lbBaseURL}/${endpoint.authURL}?returnURL=${returnURL}`;
+        this.document.location.href = `${this.config.lbBaseURL}/${endpoint.authURL}?returnUrl=${returnUrl}`;
       }
     } else {
       this.router.navigateByUrl("/login");

--- a/src/app/users/auth-callback/auth-callback.component.ts
+++ b/src/app/users/auth-callback/auth-callback.component.ts
@@ -38,11 +38,13 @@ export class AuthCallbackComponent implements OnInit {
       // External authentication will redirect to this component with a access-token and user-id query parameter
       const accessToken = params["access-token"];
       const userId = params["user-id"];
-      const parsedToken = this.parseJwt(params["access-token"]);
-      const ttl = parsedToken.exp - parsedToken.iat;
-      const created = new Date(parsedToken.iat * 1000);
+      const returnUrl: string = params["returnUrl"];
 
       if (accessToken && userId) {
+        const parsedToken = this.parseJwt(accessToken);
+        const ttl = parsedToken.exp - parsedToken.iat;
+        const created = new Date(parsedToken.iat * 1000);
+
         // If the user is authenticated, we will store the access token and user id in the store
         this.store.dispatch(
           loginOIDCAction({
@@ -64,7 +66,6 @@ export class AuthCallbackComponent implements OnInit {
 
         // After the user is authenticated, we will redirect to the home page
         // or the value of returnUrl query param
-        const returnUrl: string = params["returnUrl"];
         this.router.navigateByUrl(returnUrl || "/");
       }
     });

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -82,10 +82,10 @@ export class LoginComponent implements OnInit, OnDestroy {
   }
 
   redirectOIDC(authURL: string) {
-    const returnURL = this.returnUrl
+    const returnUrl = this.returnUrl
       ? encodeURIComponent(this.returnUrl)
       : "/datasets";
-    this.document.location.href = `${this.appConfig.lbBaseURL}/${authURL}?returnURL=${returnURL}`;
+    this.document.location.href = `${this.appConfig.lbBaseURL}/${authURL}?returnUrl=${returnUrl}`;
   }
 
   openPrivacyDialog() {

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -133,16 +133,22 @@ export class LoginComponent implements OnInit, OnDestroy {
     this.route.queryParams.subscribe((params) => {
       // OIDC logins eventually redirect to this componenet, adding information about user
       // which are parsed here.
-      if (params.returnUrl) {
+      if (params["returnUrl"]) {
         // dispatching to the loginOIDCAction passes information to eventually be added to Loopback AccessToken
         let accessToken = params["access-token"];
         let userId = params["user-id"];
+
         // Required for backend v3 compatibility (access-token and user-id are encoded in returnUrl)
         if (!accessToken && !userId) {
           const urlqp = new URLSearchParams(params.returnUrl.split("?")[1]);
           accessToken = urlqp.get("access-token");
           userId = urlqp.get("user-id");
+        } else {
+          // A returnUrl coming from v4 should be respected as the destination redirect
+          //  after login and user info fetching.
+          this.returnUrl = params["returnUrl"];
         }
+
         this.store.dispatch(
           loginOIDCAction({ oidcLoginResponse: { accessToken, userId } }),
         );


### PR DESCRIPTION
## Description

The "returnUrl" value passed to/from the back end was being ignored at the end of the journey.  These minor changes detect a "returnUrl" that's part of a successful OIDC login from the v4 back end, and use the value in subsequent navigation after the login page.

## Motivation

Together with the changes in https://github.com/SciCatProject/scicat-backend-next/pull/1815 , this makes "returnUrl" work as designed.

## Fixes / Changes:

Detecting and extracting "returnUrl" in a successful OIDC redirect.  Using "returnUrl" in place of "returnURL" for consistency.

## Tests included

Tests pass as before.

## Documentation

No documentation changes needed.

## Backend version

No specific back end is mandatory, but for "returnUrl" to fully work, the changes in https://github.com/SciCatProject/scicat-backend-next/pull/1815 should be integrated as well.