### PR TITLE
chore: remove version update workflow

### DIFF
--- a/.github/workflows/release-push.yml
+++ b/.github/workflows/release-push.yml
@@ -40,17 +40,6 @@ jobs:
           WITHOUT_V=${TAG#v}
           echo "release_version=$WITHOUT_V" >> $GITHUB_OUTPUT
 
-      - name: Update release version
-        run: |
-          npm version --no-git-tag-version ${{ steps.release_version.output.release_version }}
-
-      - name: Commit package with new version
-        run: |
-          git config --global user.name 'SciCat FE Release Workflow'
-          git config --global user.email 'scicat.release.workflow@users.noreply.github.com'
-          git commit --amend -am "Set release"
-          git push
-
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Description
Revert previous changes that update the version in package.json. The approach was not working properly and was blocking our new release workflow.

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Remove version update steps from the release push workflow

CI:
- Simplified release workflow by removing version update and commit steps

Chores:
- Remove automatic version update and commit steps from the GitHub release workflow