### PR TITLE
feat(dataset-detail-dynamic): add of source field possibility for scientificMetadata sub object display using type scientificMetadata

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
@@ -160,22 +160,27 @@
             </mat-card-header>
             <mat-card-content>
               <ng-container *ngIf="appConfig.tableSciDataEnabled">
-                <div [ngSwitch]="section.viewMode">
-                  <tree-view
-                    *ngSwitchCase="'tree'"
-                    [metadata]="dataset['scientificMetadata']"
-                  ></tree-view>
-                  <metadata-view
-                    *ngSwitchDefault
-                    [metadata]="dataset['scientificMetadata']"
-                  ></metadata-view>
-                  <div class="json-view" *ngSwitchCase="'json'">
-                    <ngx-json-viewer
-                      [json]="dataset['scientificMetadata']"
-                      [expanded]="false"
-                    ></ngx-json-viewer>
+                <ng-container *ngIf="getScientificMetadata(dataset, section.source) as metadata">
+                  <div [ngSwitch]="section.viewMode">
+                    <tree-view
+                      *ngSwitchCase="'tree'"
+                      [metadata]="metadata"
+                    ></tree-view>
+                    <metadata-view
+                      *ngSwitchDefault
+                      [metadata]="metadata"
+                    ></metadata-view>
+                    <div class="json-view" *ngSwitchCase="'json'">
+                      <ngx-json-viewer
+                        [json]="metadata"
+                        [expanded]="false"
+                      ></ngx-json-viewer>
+                    </div>
                   </div>
-                </div>
+                </ng-container>
+                <ng-container *ngIf="!getScientificMetadata(dataset, section.source)">
+                  <p class="no-metadata-message">No scientific metadata found for this section</p>
+                </ng-container>
               </ng-container>
             </mat-card-content>
           </mat-card>

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.spec.ts
@@ -74,4 +74,184 @@ describe("DatasetDetailDynamicComponent", () => {
   it("should create", () => {
     expect(component).toBeTruthy();
   });
+
+  describe("getScientificMetadata", () => {
+    it("should return null when dataset is null or undefined", () => {
+      expect(component.getScientificMetadata(null, "any.path")).toBeNull();
+      expect(component.getScientificMetadata(undefined, "any.path")).toBeNull();
+    });
+
+    it("should return null when dataset has no scientificMetadata", () => {
+      const dataset = { pid: "test" } as any;
+      expect(component.getScientificMetadata(dataset, "any.path")).toBeNull();
+    });
+
+    it("should return entire scientificMetadata when no source is provided", () => {
+      const dataset = {
+        scientificMetadata: { key1: "value1", key2: "value2" }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset);
+      expect(result).toEqual({ key1: "value1", key2: "value2" });
+    });
+
+    it("should return entire scientificMetadata when empty source is provided", () => {
+      const dataset = {
+        scientificMetadata: { key1: "value1", key2: "value2" }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "");
+      expect(result).toEqual({ key1: "value1", key2: "value2" });
+    });
+
+    it("should return entire scientificMetadata when source is 'scientificMetadata'", () => {
+      const dataset = {
+        scientificMetadata: { key1: "value1", key2: "value2" }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "scientificMetadata");
+      expect(result).toEqual({ key1: "value1", key2: "value2" });
+    });
+
+    it("should return nested metadata when valid path is provided", () => {
+      const dataset = {
+        scientificMetadata: {
+          sampleProperties: {
+            temperature: "25°C",
+            pressure: "1 atm"
+          },
+          otherData: "test"
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "scientificMetadata.sampleProperties");
+      expect(result).toEqual({
+        temperature: "25°C",
+        pressure: "1 atm"
+      });
+    });
+
+    it("should return nested metadata when path without 'scientificMetadata' prefix is provided", () => {
+      const dataset = {
+        scientificMetadata: {
+          sampleProperties: {
+            temperature: "25°C",
+            pressure: "1 atm"
+          }
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "sampleProperties");
+      expect(result).toEqual({
+        temperature: "25°C",
+        pressure: "1 atm"
+      });
+    });
+
+    it("should return deeply nested metadata", () => {
+      const dataset = {
+        scientificMetadata: {
+          experiment: {
+            conditions: {
+              environmental: {
+                humidity: "60%"
+              }
+            }
+          }
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "experiment.conditions.environmental");
+      expect(result).toEqual({ humidity: "60%" });
+    });
+
+    it("should return null when path does not exist", () => {
+      const dataset = {
+        scientificMetadata: {
+          sampleProperties: {
+            temperature: "25°C"
+          }
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "nonExistentPath");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when partial path exists but final key does not", () => {
+      const dataset = {
+        scientificMetadata: {
+          sampleProperties: {
+            temperature: "25°C"
+          }
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "sampleProperties.nonExistentKey");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when path leads to non-object value", () => {
+      const dataset = {
+        scientificMetadata: {
+          sampleProperties: {
+            temperature: "25°C"
+          }
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "sampleProperties.temperature");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when path leads to null value", () => {
+      const dataset = {
+        scientificMetadata: {
+          sampleProperties: null
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "sampleProperties");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when path leads to undefined value", () => {
+      const dataset = {
+        scientificMetadata: {
+          sampleProperties: undefined
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "sampleProperties");
+      expect(result).toBeNull();
+    });
+
+    it("should handle array values correctly", () => {
+      const dataset = {
+        scientificMetadata: {
+          measurements: [
+            { value: 1, unit: "cm" },
+            { value: 2, unit: "cm" }
+          ]
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "measurements");
+      expect(result).toEqual([
+        { value: 1, unit: "cm" },
+        { value: 2, unit: "cm" }
+      ]);
+    });
+
+    it("should handle empty object values", () => {
+      const dataset = {
+        scientificMetadata: {
+          emptySection: {}
+        }
+      } as any;
+      
+      const result = component.getScientificMetadata(dataset, "emptySection");
+      expect(result).toEqual({});
+    });
+  });
 });

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
@@ -203,4 +203,41 @@ export class DatasetDetailDynamicComponent implements OnInit {
         break;
     }
   }
+
+  getScientificMetadata(dataset: OutputDatasetObsoleteDto, source?: string): any {
+    if (!dataset || !dataset.scientificMetadata) {
+      return null;
+    }
+
+    // If no source is specified, return the entire scientificMetadata
+    if (!source) {
+      return dataset.scientificMetadata;
+    }
+
+    // Handle nested path like "scientificMetadata.sampleProperties"
+    const pathParts = source.split('.');
+    
+    // Remove 'scientificMetadata' from the beginning if present
+    if (pathParts[0] === 'scientificMetadata') {
+      pathParts.shift();
+    }
+
+    // If no remaining path, return entire scientificMetadata
+    if (pathParts.length === 0) {
+      return dataset.scientificMetadata;
+    }
+
+    // Navigate through the nested path
+    let result = dataset.scientificMetadata;
+    for (const part of pathParts) {
+      if (result && typeof result === 'object' && part in result) {
+        result = result[part];
+      } else {
+        return null;
+      }
+    }
+
+    // Ensure the result is a valid object for metadata display
+    return result && typeof result === 'object' ? result : null;
+  }
 }

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -60,6 +60,7 @@ export interface CustomizationItem {
   row: number;
   col: number;
   fields?: Field[];
+  source?: string;
   options?: AttachmentOptions;
   viewMode?: viewModeOptions;
 }


### PR DESCRIPTION
## Description
I've modified the dataset-detail-dynamic so it can manage source field in scientifcMetadata, for example:

{
        "type": "scientificMetadata",
        "label": "Instrument Properties",
        "source": "scientificMetadata.instrumentProperties.value",
        "viewMode": "table",
        "order": 4,
        "col": 2,
        "row": 1
      },

This way we can use the nice display that offer the type scientificMetadata on objects nested in it.


## Motivation

Display nicely the objects _instrumentProperties_ and _sampleProperties_, that I store in _scientificMetadata_ object, by leveraging views that are currently available only for _scienticMetadata_ object.


## Changes:
Please provide a list of the changes implemented by this PR

* Add of source field management in dataset-detail-dynamic
* Add of optional source field in CustomizationItem


## Tests included
- Especially testing _getScientificMetadata_, the new method added by this PR

## Documentation
- If this PR is validated, I'll add documentation here in the Component Configuration Table: [https://github.com/SciCatProject/scicat-backend-next/blob/master/docs/frontend-config-guide/dynamic-dataset-detail-component.md](https://github.com/SciCatProject/scicat-backend-next/blob/master/docs/frontend-config-guide/dynamic-dataset-detail-component.md)
