### PR TITLE
fix(metadataView table): better management of height for metadataView table if more than one row is available

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
@@ -158,7 +158,7 @@
               </div>
               {{ section.label | translate }}
             </mat-card-header>
-            <mat-card-content>
+            <mat-card-content class="scientific-metadata-content">
               <ng-container *ngIf="appConfig.tableSciDataEnabled">
                 <div [ngSwitch]="section.viewMode">
                   <tree-view

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.scss
@@ -127,3 +127,11 @@ mat-card {
   pointer-events: none;
   cursor: default;
 }
+
+.scientific-metadata-content {
+  height: 100%;
+  
+  > div {
+    height: 100%;
+  }
+}

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
@@ -10,12 +10,13 @@
     [sticky]="stickyHeader"
     [dataSource]="dataSource"
     [pagination]="pagination"
+    [pagingMode]="pagingMode"
     [showNoData]="showNoData"
     [rowSelectionMode]="rowSelectionMode"
     [printConfig]="printConfig"
     [showProgress]="showProgress"
     [showGlobalTextSearch]="showGlobalTextSearch"
-    style="height: 60vh"
+    style="height: 100%"
   >
   </dynamic-mat-table>
 </div>

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
@@ -1,4 +1,6 @@
 .metadataTable {
+  height: 100%;
+
   .mat-column-name {
     flex: 1 0 7em;
   }

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
@@ -23,6 +23,7 @@ import { PrettyUnitPipe } from "shared/pipes/pretty-unit.pipe";
 import { DateTime } from "luxon";
 import { MetadataTypes } from "../metadata-edit/metadata-edit.component";
 import { actionMenu } from "shared/modules/dynamic-material-table/utilizes/default-table-settings";
+import { TablePaginationMode } from "shared/modules/dynamic-material-table/models/table-pagination.model";
 
 @Component({
   selector: "metadata-view",
@@ -57,6 +58,8 @@ export class MetadataViewComponent implements OnInit, OnChanges {
   stickyHeader = true;
 
   pagination = null;
+
+  pagingMode: TablePaginationMode = "none";
 
   printConfig: PrintConfig = {};
 


### PR DESCRIPTION
Better management of height for metadataView table if more than one row is available

## Description
Before:
![image](https://github.com/user-attachments/assets/ba6566de-91ff-442a-b1cf-ff1d0a3ecea0)

After:
![image](https://github.com/user-attachments/assets/0b5eb0ad-c179-4281-ae60-40e406d9beba)


## Motivation
Before there was useless space under the metadataView table, I think it is a phenomenon that occurs when we let it have more than one row

## Fixes:
- height 100% for mat-card-content of dataset-detail-dynamic-content of scientificMetadata
- add of _pagingMode_ set in metadata-view in the objective of not using _viewport-with-pagination_ but _viewport_ in the **table.core.directive.js**

## Summary by Sourcery

Adjust height properties and introduce a paging mode option to ensure the metadataView table fully utilizes vertical space and avoid empty gaps.

Bug Fixes:
- Expand component container and table height definitions to 100%, removing wasted space under the metadataView table.

Enhancements:
- Add pagingMode input (defaulting to “none”) to the metadata-view component to control pagination behavior and replace the fixed 60vh inline height style.