### PR TITLE
fix(jobs): use updated SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ngrx/store": "^19.1.0",
         "@ngx-translate/core": "^16.0.4",
         "@ngxmc/datetime-picker": "^19.3.1",
-        "@scicatproject/scicat-sdk-ts-angular": "^4.17.0",
+        "@scicatproject/scicat-sdk-ts-angular": "^4.17.1",
         "autolinker": "^4.0.0",
         "deep-equal": "^2.0.5",
         "exceljs": "^4.3.0",
@@ -5826,9 +5826,10 @@
       }
     },
     "node_modules/@scicatproject/scicat-sdk-ts-angular": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-angular/-/scicat-sdk-ts-angular-4.17.0.tgz",
-      "integrity": "sha512-f9wgZab5kDCr76nCgKF7Eoq5rQd588xDAuxiPl7qs1oNsY3zh9Tgk5t3GYwGOcBT+da+9kV/I4Ws6f+lqK3tJw==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-angular/-/scicat-sdk-ts-angular-4.17.1.tgz",
+      "integrity": "sha512-9eeHsMF7ck9r5XHJGrC1Oqw6qSV8QDIZB9BnD/co7JIpnuqy1PtBnBmssukbp44gm0zH/skxtg3A+syd/rJmQw==",
+      "license": "Unlicense",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ngrx/store": "^19.1.0",
     "@ngx-translate/core": "^16.0.4",
     "@ngxmc/datetime-picker": "^19.3.1",
-    "@scicatproject/scicat-sdk-ts-angular": "^4.17.0",
+    "@scicatproject/scicat-sdk-ts-angular": "^4.17.1",
     "autolinker": "^4.0.0",
     "deep-equal": "^2.0.5",
     "exceljs": "^4.3.0",

--- a/src/app/state-management/effects/jobs.effects.spec.ts
+++ b/src/app/state-management/effects/jobs.effects.spec.ts
@@ -59,9 +59,9 @@ describe("JobEffects", () => {
         {
           provide: JobsService,
           useValue: jasmine.createSpyObj("jobApi", [
-            "jobsControllerFindAllV3V3",
-            "jobsControllerFindOneV3V3",
-            "jobsControllerCreateV3V3",
+            "jobsControllerFindAllV3",
+            "jobsControllerFindOneV3",
+            "jobsControllerCreateV3",
           ]),
         },
       ],
@@ -84,7 +84,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-a|", { a: jobs });
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--(bc)", { b: outcome1, c: outcome2 });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -96,7 +96,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-#", {});
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--b", { b: outcome });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -115,7 +115,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-a|", { a: jobs });
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--(bc)", { b: outcome1, c: outcome2 });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -127,7 +127,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-#", {});
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--b", { b: outcome });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -146,7 +146,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-a|", { a: jobs });
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--(bc)", { b: outcome1, c: outcome2 });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -158,7 +158,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-#", {});
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--b", { b: outcome });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -176,7 +176,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-a|", { a: jobs });
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--(bc)", { b: outcome1, c: outcome2 });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -188,7 +188,7 @@ describe("JobEffects", () => {
 
         actions = hot("-a", { a: action });
         const response = cold("-#", {});
-        jobApi.jobsControllerFindAllV3V3.and.returnValue(response);
+        jobApi.jobsControllerFindAllV3.and.returnValue(response);
 
         const expected = cold("--b", { b: outcome });
         expect(effects.fetchJobs$).toBeObservable(expected);
@@ -220,7 +220,7 @@ describe("JobEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-a|", { a: outputJob });
-      jobApi.jobsControllerFindOneV3V3.and.returnValue(response);
+      jobApi.jobsControllerFindOneV3.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchJob$).toBeObservable(expected);
@@ -232,7 +232,7 @@ describe("JobEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-#", {});
-      jobApi.jobsControllerFindOneV3V3.and.returnValue(response);
+      jobApi.jobsControllerFindOneV3.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchJob$).toBeObservable(expected);
@@ -246,7 +246,7 @@ describe("JobEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-a|", { a: outputJob });
-      jobApi.jobsControllerCreateV3V3.and.returnValue(response);
+      jobApi.jobsControllerCreateV3.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.submitJob$).toBeObservable(expected);

--- a/src/app/state-management/effects/jobs.effects.ts
+++ b/src/app/state-management/effects/jobs.effects.ts
@@ -30,7 +30,7 @@ export class JobEffects {
       concatLatestFrom(() => this.queryParams$),
       map(([action, params]) => params),
       switchMap((params) =>
-        this.jobsService.jobsControllerFindAllV3V3(JSON.stringify(params)).pipe(
+        this.jobsService.jobsControllerFindAllV3(JSON.stringify(params)).pipe(
           switchMap((jobs) => [
             fromActions.fetchJobsCompleteAction({ jobs }),
             fromActions.fetchCountAction(),
@@ -54,7 +54,7 @@ export class JobEffects {
     return this.actions$.pipe(
       ofType(fromActions.fetchJobAction),
       switchMap(({ jobId }) =>
-        this.jobsService.jobsControllerFindOneV3V3(jobId).pipe(
+        this.jobsService.jobsControllerFindOneV3(jobId).pipe(
           map((job) => fromActions.fetchJobCompleteAction({ job })),
           catchError(() => of(fromActions.fetchJobFailedAction())),
         ),
@@ -66,7 +66,7 @@ export class JobEffects {
     return this.actions$.pipe(
       ofType(fromActions.submitJobAction),
       switchMap(({ job }) =>
-        this.jobsService.jobsControllerCreateV3V3(job).pipe(
+        this.jobsService.jobsControllerCreateV3(job).pipe(
           map((res) => fromActions.submitJobCompleteAction({ job: res })),
           catchError((err) => of(fromActions.submitJobFailedAction({ err }))),
         ),


### PR DESCRIPTION
## Description
[Release v4.17.1](https://github.com/SciCatProject/scicat-backend-next/releases/tag/v4.17.1) updated the SDK to fix issue https://github.com/SciCatProject/scicat-backend-next/issues/1937

We now need to call the correct methods in the frontend.


## Motivation
https://github.com/SciCatProject/frontend/issues/1858


## Fixes:
Use `jobsControllerCreateV3()` instead of `jobsControllerCreateV3V3()`


## Changes:
- `src/app/state-management/effects/jobs.effects.ts`
- `src/app/state-management/effects/jobs.effects.spec.ts`

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Align job effects with updated SciCat SDK by replacing deprecated V3V3 methods with V3 variants and bumping the SDK dependency.

Bug Fixes:
- Replace calls to jobsControllerFindAllV3V3, jobsControllerFindOneV3V3, and jobsControllerCreateV3V3 with jobsControllerFindAllV3, jobsControllerFindOneV3, and jobsControllerCreateV3 to match the updated SDK.

Build:
- Bump @scicatproject/scicat-sdk-ts-angular dependency from v4.17.0 to v4.17.1.

Tests:
- Update jobs.effects.spec.ts to mock and expect the new V3 SDK method names.