### PR TITLE
feat(dataset-table): add instrument name column

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -18,6 +18,7 @@ import {
   selectAllDatasetsAction,
   sortByColumnAction,
 } from "state-management/actions/datasets.actions";
+import { fetchInstrumentsAction } from "state-management/actions/instruments.actions";
 
 import {
   selectDatasets,
@@ -35,6 +36,7 @@ import {
 import {
   DatasetClass,
   OutputDatasetObsoleteDto,
+  Instrument,
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { TableField } from "shared/modules/dynamic-material-table/models/table-field.model";
 import {
@@ -60,6 +62,8 @@ import { DatePipe } from "@angular/common";
 import { FileSizePipe } from "shared/pipes/filesize.pipe";
 import { actionMenu } from "shared/modules/dynamic-material-table/utilizes/default-table-settings";
 import { TableConfigService } from "shared/services/table-config.service";
+import { selectInstruments } from "state-management/selectors/instruments.selectors";
+
 export interface SortChangeEvent {
   active: string;
   direction: "asc" | "desc" | "";
@@ -86,6 +90,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
   selectColumnsWithFetchedSettings$ = this.store.select(
     selectColumnsWithHasFetchedSettings,
   );
+  instruments$ = this.store.select(selectInstruments);
 
   @Input() selectedSets: OutputDatasetObsoleteDto[] | null = null;
   @Output() pageChange = new EventEmitter<{
@@ -94,6 +99,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
   }>();
 
   datasets: OutputDatasetObsoleteDto[] = [];
+  instruments: Instrument[] = [];
 
   @Output() rowClick = new EventEmitter<OutputDatasetObsoleteDto>();
 
@@ -461,17 +467,38 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
           convertedColumn.renderImage = true;
         }
 
+        if (column.name === "instrumentName") {
+          const getInstrumentName = (row: OutputDatasetObsoleteDto) => {
+            const instrument = this.instruments.find(
+              (inst) => inst.pid === row.instrumentId,
+            );
+            return instrument?.name || row.instrumentId || "-";
+          };
+
+          convertedColumn.customRender = (column, row) =>
+            getInstrumentName(row);
+          convertedColumn.toExport = (row) => getInstrumentName(row);
+        }
+
         return convertedColumn;
       });
   }
 
   ngOnInit() {
+    this.store.dispatch(fetchInstrumentsAction({ limit: 1000, skip: 0 }));
+
     this.subscriptions.push(
       this.selectedDatasets$.subscribe((datasets) => {
         // NOTE: In the selectionIds we are storing either _id or pid. Dynamic material table works only with these two.
         this.selectionIds = datasets.map((dataset) => {
           return dataset.pid;
         });
+      }),
+    );
+
+    this.subscriptions.push(
+      this.instruments$.subscribe((instruments) => {
+        this.instruments = instruments;
       }),
     );
 


### PR DESCRIPTION
## Description
Implementation of Instrument Name column in the datasets table page as one of the available column by default.

## Motivation
At ILL, the instrument is a really important information, therefore we think that it should be one of the available column by default.

## Changes:

Introduction of default Instrument Name column

## Tests included
Included and Passing

## Documentation
Nothing done, i do not think it is worth it to be documented such a small change ?

## Summary by Sourcery

Add Instrument Name as a default column in the datasets table and implement store integration, rendering, and export logic for instrument details

New Features:
- Introduce default "Instrument Name" column in the datasets table with custom rendering and export logic

Enhancements:
- Dispatch fetchInstrumentsAction on initialization and subscribe to instruments$ selector to populate instrument data

Tests:
- Add unit tests for instrumentName column rendering and export behavior across various scenarios
- Add tests to verify instruments subscription updates the component’s instruments array