### PR TITLE
fix(dynamic-mat-table): small css fix for cursor pointer on row label in dynamic mat table

### DIFF
--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
@@ -31,6 +31,7 @@
 
 .label-cell {
   width: 100%;
+  cursor: inherit;
 }
 
 mat-cell .label-cell {


### PR DESCRIPTION
## Description
super tiny css fix for cursor pointer on row label in dynamic mat table

Before:
![image](https://github.com/user-attachments/assets/8935c9f2-fc93-44d2-aa9b-699be7cf61a0)


After:
![image](https://github.com/user-attachments/assets/f5c09c2c-3f9e-47d5-b8b2-df744abcfd11)


## Fixes:

added inherit on css property of label of dynamic mat table