### PR TITLE
feat: configurable main page

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -109,7 +109,7 @@ export interface AppConfigInterface {
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: "root",
 })
 export class AppConfigService {
   private appConfig: object = {};

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -35,7 +35,7 @@ export class HelpMessages {
   }
 }
 
-export interface AppConfig {
+export interface AppConfigInterface {
   skipSciCatLoginPageEnabled?: boolean;
   accessTokenPrefix: string;
   addDatasetEnabled: boolean;
@@ -108,7 +108,9 @@ export interface AppConfig {
   dateFormat?: string;
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class AppConfigService {
   private appConfig: object = {};
 
@@ -132,11 +134,11 @@ export class AppConfigService {
     }
   }
 
-  getConfig(): AppConfig {
+  getConfig(): AppConfigInterface {
     if (!this.appConfig) {
       console.error("AppConfigService: Configuration not loaded!");
     }
 
-    return this.appConfig as AppConfig;
+    return this.appConfig as AppConfigInterface;
   }
 }

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -35,6 +35,13 @@ export class HelpMessages {
   }
 }
 
+export enum MainPageOptions {
+  DATASETS = "/datasets",
+  PROPOSALS = "/proposals",
+  INSTRUMENTS = "/instruments",
+  SAMPLES = "/samples"
+}
+
 export interface AppConfigInterface {
   skipSciCatLoginPageEnabled?: boolean;
   accessTokenPrefix: string;
@@ -106,6 +113,7 @@ export interface AppConfigInterface {
   datasetDetailComponent?: DatasetDetailComponentConfig;
   labelsLocalization?: LabelsLocalization;
   dateFormat?: string;
+  defaultMainPage?: string;
 }
 
 @Injectable({
@@ -132,6 +140,15 @@ export class AppConfigService {
         console.error("No config provided.");
       }
     }
+
+    const config: AppConfigInterface = (this.appConfig as AppConfigInterface);
+    if ("defaultMainPage" in config && Object.keys(MainPageOptions).includes(config.defaultMainPage)) {
+      config.defaultMainPage = MainPageOptions[config.defaultMainPage];
+    } else {
+      config.defaultMainPage = MainPageOptions.DATASETS;
+    }
+
+    this.appConfig = config;
   }
 
   getConfig(): AppConfigInterface {

--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -5,6 +5,8 @@ import { ErrorPageComponent } from "shared/modules/error-page/error-page.compone
 import { AppLayoutComponent } from "_layout/app-layout/app-layout.component";
 import { AppMainLayoutComponent } from "_layout/app-main-layout/app-main-layout.component";
 import { ServiceGuard } from "./service.guard";
+import { MainPageGuard } from "./main-page";
+import { DummyComponent } from "./dummy.component";
 
 export const routes: Routes = [
   {
@@ -13,7 +15,8 @@ export const routes: Routes = [
     children: [
       {
         path: "",
-        redirectTo: "/datasets",
+        canActivate: [MainPageGuard],
+        component: DummyComponent,
         pathMatch: "full",
       },
       {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ import {
   selectUserMessage,
 } from "state-management/selectors/user.selectors";
 import { MessageType } from "state-management/models";
-import { AppConfigService, AppConfig as Config } from "app-config.service";
+import { AppConfigService, AppConfigInterface } from "app-config.service";
 import { Configuration } from "@scicatproject/scicat-sdk-ts-angular";
 
 @Component({
@@ -36,7 +36,7 @@ import { Configuration } from "@scicatproject/scicat-sdk-ts-angular";
 export class AppComponent implements OnDestroy, OnInit, AfterViewChecked {
   loading$ = this.store.select(selectIsLoading);
 
-  config: Config;
+  config: AppConfigInterface;
 
   title: string;
   facility: string;

--- a/src/app/shared/services/scicat.datasource.ts
+++ b/src/app/shared/services/scicat.datasource.ts
@@ -4,7 +4,7 @@ import { ScicatDataService } from "./scicat-data-service";
 import { catchError, finalize } from "rxjs/operators";
 import { ExportExcelService } from "./export-excel.service";
 import { Column } from "shared/modules/shared-table/shared-table.module";
-import { AppConfig, AppConfigService } from "app-config.service";
+import { AppConfigInterface, AppConfigService } from "app-config.service";
 
 // For each different table type one instance of this class should be created
 
@@ -12,7 +12,7 @@ const resolvePath = (object: any, path: string, defaultValue: unknown) =>
   path.split(".").reduce((o, p) => (o ? o[p] : defaultValue), object);
 
 export class SciCatDataSource implements DataSource<any> {
-  private appConfig: AppConfig;
+  private appConfig: AppConfigInterface;
   private exportSubscription: Subscription;
   private dataForExcel: unknown[] = [];
   private columnsdef: Column[] = [];

--- a/src/app/state-management/actions/user.actions.ts
+++ b/src/app/state-management/actions/user.actions.ts
@@ -10,7 +10,7 @@ import {
   ConditionConfig,
   FilterConfig,
 } from "../../shared/modules/filters/filters.module";
-import { AppConfig } from "app-config.service";
+import { AppConfigInterface } from "app-config.service";
 import { AccessTokenInterface } from "shared/services/auth/auth.service";
 
 export const setDatasetTableColumnsAction = createAction(
@@ -193,5 +193,5 @@ export const updateConditionsConfigs = createAction(
 
 export const loadDefaultSettings = createAction(
   "[User] Load Default Settings",
-  props<{ config: AppConfig }>(),
+  props<{ config: AppConfigInterface }>(),
 );

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -17,7 +17,7 @@ import { selectLoginPageViewModel } from "state-management/selectors/user.select
 import { MatDialog } from "@angular/material/dialog";
 import { PrivacyDialogComponent } from "users/privacy-dialog/privacy-dialog.component";
 import {
-  AppConfig,
+  AppConfigInterface,
   AppConfigService,
   OAuth2Endpoint,
 } from "app-config.service";
@@ -46,7 +46,7 @@ export class LoginComponent implements OnInit, OnDestroy {
   private proceedSubscription = new Subscription();
   vm$ = this.store.select(selectLoginPageViewModel);
 
-  appConfig: AppConfig = this.appConfigService.getConfig();
+  appConfig: AppConfigInterface = this.appConfigService.getConfig();
   facility: string | null = null;
   loginFormEnabled = false;
   loginFacilityEnabled = false;


### PR DESCRIPTION
## Description
This PR adds the functionality to set in configuration which is the main page that users will be redirected to when typing the main URL of the instance.

## Motivation
We have received multiple request to be able start the user journey from an arbitrary page different than the datasets list.

## Changes:
Please provide a list of the changes implemented by this PR
* config file adding the entry `defaultMainPage`
* config app service adding enum with the options and chaniking them upon loading configuration

## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: the changes are backward compatible. This PR is linked to the BE PR with the same name
