### PR TITLE
fix: improved dataset detail layout and scientific metadata display

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
@@ -27,10 +27,8 @@
     <div [fxFlex]="(attachments$ | async)?.length > 0 ? '90%' : '100%'">
       <mat-card [formGroup]="form" data-cy="general-info">
         <mat-card-header class="general-header">
-          <div mat-card-avatar class="section-icon">
-            <mat-icon> description </mat-icon>
-          </div>
-          {{ "General Information" | translate }}
+          <mat-icon class="section-icon"> description </mat-icon>
+          <mat-card-title class="section-title">{{ "General Information" | translate }}</mat-card-title>
         </mat-card-header>
         <mat-card-content>
           <table>
@@ -168,10 +166,8 @@
 
       <mat-card>
         <mat-card-header class="creator-header">
-          <div mat-card-avatar class="section-icon">
-            <mat-icon> person </mat-icon>
-          </div>
-          {{ "Creator Information" | translate }}
+          <mat-icon class="section-icon"> person </mat-icon>
+          <mat-card-title class="section-title">{{ "Creator Information" | translate }}</mat-card-title>
         </mat-card-header>
 
         <mat-card-content>
@@ -210,10 +206,8 @@
 
       <mat-card>
         <mat-card-header class="file-header">
-          <div mat-card-avatar class="section-icon">
-            <mat-icon> folder </mat-icon>
-          </div>
-          {{ "File Information" | translate }}
+            <mat-icon class="section-icon"> folder </mat-icon>
+          <mat-card-title class="section-title">{{ "File Information" | translate }}</mat-card-title>
         </mat-card-header>
 
         <mat-card-content>
@@ -236,10 +230,8 @@
 
       <mat-card>
         <mat-card-header class="related-header">
-          <div mat-card-avatar class="section-icon">
-            <mat-icon> library_books </mat-icon>
-          </div>
-          {{ "Related Documents" | translate }}
+          <mat-icon class="section-icon"> library_books </mat-icon>
+          <mat-card-title class="section-title">{{ "Related Documents" | translate }}</mat-card-title>
         </mat-card-header>
 
         <mat-card-content>
@@ -353,11 +345,10 @@
       </mat-card>
 
       <mat-card>
-        <mat-card-header class="scientific-header">
-          <div mat-card-avatar class="section-icon">
-            <mat-icon> science </mat-icon>
-          </div>
-          {{ "Scientific Metadata" | translate }}
+        <mat-card-header   
+        class="scientific-header">
+         <mat-icon class="section-icon"> science </mat-icon>
+         <mat-card-title class="section-title">{{ "Scientific Metadata" | translate }}</mat-card-title>
         </mat-card-header>
         <mat-card-content>
           <ng-template

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.scss
@@ -1,14 +1,30 @@
 mat-card {
   margin: 1em;
 
+  .scientific-header, .related-header, .creator-header, .file-header, .general-header {
+    display: flex;
+    align-items: center;
+    padding: 1em;
+  }
+
   .section-icon {
     height: auto !important;
     width: auto !important;
+    margin-right: 4px;
+    order: -1;
+    display: flex;
+    align-self: center;
 
     mat-icon {
       vertical-align: middle;
     }
   }
+  .section-title {
+    font-size: small;
+    font-weight: bold;
+    line-height: 1;
+  }
+
   .caption-text {
     word-break: break-all;
   }

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
@@ -107,8 +107,9 @@ mat-header-cell {
 @include header-sort;
 
 cdk-virtual-scroll-viewport {
-  min-height: 100px;
-  height: inherit;
+  min-height: 0;
+  height: 100%;
+  flex: auto;
   overflow: auto;
 }
 

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
@@ -1,6 +1,7 @@
 .metadataTable {
   height: 100%;
-
+  margin-left: -16px;
+  margin-right: -16px;
   .mat-column-name {
     flex: 1 0 7em;
   }


### PR DESCRIPTION
## Description

Before:
![before-part1](https://github.com/user-attachments/assets/937d8cb3-a2dc-4ea7-9f4e-d5ff7b355a75)
![before-part2](https://github.com/user-attachments/assets/ad18be6d-60ae-4e08-b125-87295f876ea9)


After:
![after-part1](https://github.com/user-attachments/assets/d061d688-3160-4fe0-a4fb-ddd967f62244)
![after-part2](https://github.com/user-attachments/assets/1c43bbef-4fe2-4944-8560-b798d6d52067)

## Motivation
Sections headers had misaligned icons and titles. The metadata table only showed row at a time with wasted space below it.

## Fixes:
* Fixed vertical alignment of icons and titles in section headers
* Ensured consistent spacing between icons and titles
* Modified scientific metadata table to display multiple rows instead of just one

## Summary by Sourcery

Fix header layout alignment and spacing and adjust table container styling to enable multi-row scientific metadata display

Bug Fixes:
- Align section header icons and titles using flex layout and consistent spacing
- Adjust dynamic table and metadata view styles to utilize full height and display multiple rows