### PR TITLE
fix: enable editDataset option for dataset editing

### DIFF
--- a/CI/e2e/frontend.config.e2e.json
+++ b/CI/e2e/frontend.config.e2e.json
@@ -4,6 +4,7 @@
   "archiveWorkflowEnabled": false,
   "datasetReduceEnabled": true,
   "datasetJsonScientificMetadata": true,
+  "editDatasetEnabled": true,
   "editDatasetSampleEnabled": true,
   "editMetadataEnabled": true,
   "editPublishedData": false,

--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -19,6 +19,7 @@ const appConfig: AppConfigInterface = {
   archiveWorkflowEnabled: true,
   datasetReduceEnabled: true,
   datasetJsonScientificMetadata: true,
+  editDatasetEnabled: true,
   editDatasetSampleEnabled: true,
   editMetadataEnabled: true,
   editPublishedData: true,

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -57,6 +57,7 @@ export interface AppConfigInterface {
   datasetDetailsShowMissingProposalId: boolean;
   datafilesActionsEnabled: boolean;
   datafilesActions: any[];
+  editDatasetEnabled: boolean;
   editDatasetSampleEnabled: boolean;
   editMetadataEnabled: boolean;
   editPublishedData: boolean;

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
@@ -114,7 +114,9 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
           combineLatest([this.accessGroups$, this.isAdmin$]).subscribe(
             ([groups, isAdmin]) => {
               this.editingAllowed =
-                groups.indexOf(this.dataset.ownerGroup) !== -1 || isAdmin;
+                (this.appConfig.editDatasetEnabled &&
+                  groups.indexOf(this.dataset.ownerGroup) !== -1) ||
+                isAdmin;
             },
           );
         }

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -4,6 +4,7 @@
   "archiveWorkflowEnabled": false,
   "datasetReduceEnabled": true,
   "datasetJsonScientificMetadata": true,
+  "editDatasetEnabled": true,
   "editDatasetSampleEnabled": true,
   "editMetadataEnabled": true,
   "editPublishedData": false,
@@ -224,7 +225,7 @@
     "labelSets": {
       "ess": {
         "dataset-default": {},
-        "dataset-custom" : {
+        "dataset-custom": {
           "pid": "PID",
           "description": "Description",
           "principalInvestigator": "Principal Investigator",
@@ -233,17 +234,17 @@
           "scientificMetadata": "Scientific Metadata",
           "metadataJsonView": "Metadata JsonView"
         },
-        "proposal" : {
+        "proposal": {
           "General Information": "Proposal Information",
-          "Abstract" : "Abstract",
-          "Proposal Id" : "Proposal Id",
-          "Proposal Type" : "Proposal Type",
-          "Parent Proposal" : "Parent Proposal",
-          "Start Time" : "Start Time",
-          "End Time" : "End Time",
-          "Creator Information" : "People",
+          "Abstract": "Abstract",
+          "Proposal Id": "Proposal Id",
+          "Proposal Type": "Proposal Type",
+          "Parent Proposal": "Parent Proposal",
+          "Start Time": "Start Time",
+          "End Time": "End Time",
+          "Creator Information": "People",
           "Main Proposer": "Proposal Submitted By",
-          "Principal Investigator" : "Principal Investigator",
+          "Principal Investigator": "Principal Investigator",
           "Metadata": "Additional Information"
         }
       }
@@ -252,5 +253,5 @@
   "defaultMainPage": {
     "nonAuthenticatedUser": "DATASETS",
     "authenticatedUser": "DATASETS"
-  },
+  }
 }


### PR DESCRIPTION
## Description
Wrapped dataset editing permission check with the new this.appConfig.editDatasetEnabled feature flag. This allows enabling or disabling dataset editing globally via configuration.


## Motivation
To provide better control over dataset edit functionality and prevent unintended edits in production environments.

## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Add editDatasetEnabled feature flag to control dataset editing UI based on configuration and user permissions

New Features:
- Introduce editDatasetEnabled flag in the application configuration
- Gate dataset editing in DatasetDetailComponent behind the editDatasetEnabled flag and user/group permissions

CI:
- Add editDatasetEnabled to the frontend end-to-end test configuration