### PR TITLE
fix: added default dateFormat value

### DIFF
--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -40,6 +40,7 @@ const appConfig: AppConfigInterface = {
   gettingStarted: null,
   ingestManual: null,
   jobsEnabled: true,
+  dateFormat: "yyyy-MM-dd HH:mm",
   jsonMetadataEnabled: true,
   jupyterHubUrl: "https://jupyterhub.esss.lu.se/",
   landingPage: "doi2.psi.ch/detail/",

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -179,6 +179,10 @@ export class AppConfigService {
       } as MainPageConfiguration;
     }
 
+    if (!config.dateFormat) {
+      config.dateFormat = "yyyy-MM-dd HH:mm";
+    }
+
     this.appConfig = config;
   }
 

--- a/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
@@ -205,10 +205,7 @@ export class MetadataEditComponent implements OnInit, OnChanges {
       const str = raw == null ? "" : String(raw);
 
       const iso = DateTime.fromISO(str);
-      const fmt = DateTime.fromFormat(
-        str,
-        this.appConfig.dateFormat || "yyyy-MM-dd HH:mm",
-      );
+      const fmt = DateTime.fromFormat(str, this.appConfig.dateFormat);
 
       return iso.isValid || fmt.isValid
         ? null

--- a/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-edit/metadata-edit.component.ts
@@ -205,7 +205,10 @@ export class MetadataEditComponent implements OnInit, OnChanges {
       const str = raw == null ? "" : String(raw);
 
       const iso = DateTime.fromISO(str);
-      const fmt = DateTime.fromFormat(str, this.appConfig.dateFormat);
+      const fmt = DateTime.fromFormat(
+        str,
+        this.appConfig.dateFormat || "yyyy-MM-dd HH:mm",
+      );
 
       return iso.isValid || fmt.isValid
         ? null


### PR DESCRIPTION
## Description
In this PR added default dateFormat.


## Motivation
metadata-edit component throws error when no dateFormat is provided.


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Enhancements:
- Provide default dateFormat 'yyyy-MM-dd HH:mm' in the application configuration if missing