### PR TITLE
feat: improve the visibility of the active column sort and filter

### DIFF
--- a/cypress/e2e/proposals/proposals-general.cy.js
+++ b/cypress/e2e/proposals/proposals-general.cy.js
@@ -334,11 +334,62 @@ describe("Proposals general", () => {
 
       cy.get(".mat-sort-header-container").contains("Proposal ID").click();
 
+      cy.get(".mat-sort-header-container")
+        .contains("Proposal ID")
+        .closest("mat-header-cell")
+        .should("have.class", "active-sort");
+
+      cy.get("mat-header-cell.active-sort .mat-sort-header-arrow svg").should(
+        ($el) => {
+          expect($el).to.have.css("color", "rgb(200, 25, 25)"); // warn color
+        },
+      );
+
       cy.get("mat-table mat-row")
         .first()
         .should("contain", newProposal.proposalId);
 
       cy.reload();
+
+      cy.get("mat-table mat-row")
+        .first()
+        .should("contain", newProposal.proposalId);
+    });
+
+    it("should be able to filter by column", () => {
+      const newProposal = {
+        ...testData.proposal,
+        proposalId: "100100",
+      };
+
+      cy.createProposal(newProposal);
+
+      cy.visit("/proposals");
+
+      cy.get(".mat-sort-header-container").contains("Proposal ID").click();
+
+      cy.get(".mat-sort-header-container")
+        .contains("Proposal ID")
+        .closest("header-filter")
+        .find(".mat-mdc-menu-trigger")
+        .click();
+
+      cy.get(
+        ".cdk-overlay-container .mat-mdc-menu-panel .filter-panel mat-form-field.input-field input",
+      )
+        .clear()
+        .type(newProposal.proposalId);
+      cy.get(
+        ".cdk-overlay-container .mat-mdc-menu-panel .menu-action button[color='primary']",
+      ).click();
+
+      cy.get(".mat-sort-header-container")
+        .contains("Proposal ID")
+        .closest("header-filter")
+        .find(".mat-mdc-menu-trigger mat-icon")
+        .should(($el) => {
+          expect($el).to.have.css("color", "rgb(200, 25, 25)"); // warn color
+        });
 
       cy.get("mat-table mat-row")
         .first()

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
@@ -71,6 +71,7 @@
         [cdkDragData]="{ name: column.name, columnIndex: i }"
         [ngStyle]="column.style"
         [class.active-resize]="resizeColumn.columnIndex === i"
+        [class.active-sort]="sort.direction && sort.active === column.name"
         cdkDragBoundary="mat-header-row"
       >
         <!-- class="left-resize-handler" -->

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
@@ -312,3 +312,7 @@ cdk-virtual-scroll-viewport {
   cursor: pointer;
   padding-right: 0.5em;
 }
+
+::ng-deep .active-sort .mat-sort-header-arrow svg {
+  color: var(--theme-warn-default) !important;
+}

--- a/src/app/shared/modules/dynamic-material-table/table/extensions/filter/header-filter.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/extensions/filter/header-filter.component.html
@@ -89,5 +89,5 @@
   [matMenuTriggerFor]="filterMenu"
   *ngIf="field.filter !== 'none'"
 >
-  <mat-icon>filter_list</mat-icon>
+  <mat-icon [color]="hasValue ? 'warn' : ''">filter_list</mat-icon>
 </span>


### PR DESCRIPTION
## Description
Improve the visibility of active sort and filter states in the dynamic material table by introducing an "active-sort" class, styling changes, and corresponding end-to-end tests

Enhancements:
- Highlight the active sorted column by adding an "active-sort" class and styling its sort arrow with the warn theme color
- Color the filter icon in the header when a column filter is applied

Tests:
- Add Cypress end-to-end tests to verify the active sort class, colored sort arrow, and colored filter icon behavior

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
<img width="1416" height="909" alt="active_filter" src="https://github.com/user-attachments/assets/3e2ae418-8eb7-4b59-8604-daeb4c420c89" />
<img width="1412" height="914" alt="active_sort" src="https://github.com/user-attachments/assets/5da8ab68-bc95-4f12-9a12-24b6ffcf564b" />
