### PR TITLE
Fixing run number in dataset list

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
@@ -73,7 +73,7 @@ export class DatasetDetailDynamicComponent implements OnInit, OnDestroy {
     private router: Router,
     private snackBar: MatSnackBar,
   ) {
-    this.translateService.use("datasetCustom");
+    this.translateService.use("dataset");
   }
 
   ngOnInit() {

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
@@ -97,7 +97,7 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
     private router: Router,
     private fb: FormBuilder,
   ) {
-    this.translateService.use("datasetDefault");
+    this.translateService.use("dataset");
   }
 
   ngOnInit() {

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -213,7 +213,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
     this.columns = currentColumnSetting;
     const translated$ = forkJoin(
       currentColumnSetting.map((i) =>
-        this.translateService.get(i.name).pipe(
+        this.translateService.get(i.header || i.name).pipe(
           map((translated) => ({
             ...i,
             header: translated,

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -404,13 +404,13 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
           type: column.type as any,
         };
 
-        if (column.name === "runNumber" && column.type !== "custom") {
-          // NOTE: This is for the saved columns in the database or the old config.
-          convertedColumn.customRender = (c, row) =>
-            lodashGet(row, "scientificMetadata.runNumber.value");
-          convertedColumn.toExport = (row) =>
-            lodashGet(row, "scientificMetadata.runNumber.value");
-        }
+        // if (column.name === "runNumber" && column.type !== "custom") {
+        //   // NOTE: This is for the saved columns in the database or the old config.
+        //   convertedColumn.customRender = (c, row) =>
+        //     lodashGet(row, "scientificMetadata.runNumber.value");
+        //   convertedColumn.toExport = (row) =>
+        //     lodashGet(row, "scientificMetadata.runNumber.value");
+        // }
         // NOTE: This is how we render the custom columns if new config is used.
         if (column.type === "custom") {
           convertedColumn.customRender = (c, row) =>

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -9,7 +9,7 @@ import {
 } from "@angular/core";
 import { TableColumn } from "state-management/models";
 import { MatCheckboxChange } from "@angular/material/checkbox";
-import { BehaviorSubject, Subscription, lastValueFrom, take } from "rxjs";
+import { BehaviorSubject, Subscription, forkJoin, lastValueFrom, map, take } from "rxjs";
 import { Store } from "@ngrx/store";
 import {
   clearSelectionAction,
@@ -64,6 +64,7 @@ import { TitleCasePipe } from "shared/pipes/title-case.pipe";
 import { actionMenu } from "shared/modules/dynamic-material-table/utilizes/default-table-settings";
 import { TableConfigService } from "shared/services/table-config.service";
 import { selectInstruments } from "state-management/selectors/instruments.selectors";
+import { TranslateService } from "@ngx-translate/core";
 
 export interface SortChangeEvent {
   active: string;
@@ -155,7 +156,10 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
     private fileSize: FileSizePipe,
     private titleCase: TitleCasePipe,
     private tableConfigService: TableConfigService,
-  ) {}
+    private translateService: TranslateService,    
+  ) {
+    this.translateService.use("dataset");
+  }
 
   private getInstrumentName(row: OutputDatasetObsoleteDto): string {
     const instrument = this.instrumentMap.get(row.instrumentId);
@@ -207,6 +211,21 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
     }
 
     this.columns = currentColumnSetting;
+    const translated$ = forkJoin(
+      currentColumnSetting.map((i) =>
+        this.translateService.get(i.name).pipe(
+          map((translated) => ({
+            ...i,
+            header: translated,
+          })
+        ))
+      )
+    );
+
+    translated$.subscribe((result) => {
+      this.columns = result;
+    });
+
     this.setting = settingConfig;
     this.pagination = paginationConfig;
   }

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.ts
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.ts
@@ -512,10 +512,16 @@ export class DynamicMatTableComponent<T extends TableRow>
   }
 
   columnName(row: any, column: TableField<any>) {
+    console.log("------");
+    console.log(row);
+    console.log(column);
     if (column.customRender) {
+      console.log("Custom");
+      console.log(column.customRender(column, row));
       return column.customRender(column, row);
     }
-
+    console.log("standard");
+    console.log(row[column.name]);
     return row[column.name];
   }
 


### PR DESCRIPTION
## Description
This PR removes the custom function to extract the run number from the scientific metadata, but uses the high level field.

## Motivation
We need to show run number high level field by default. A soon to be created PR, will allow to include scientific metadata in the datasets list, so a different run number from scientific metadata will be addressed by the new PR.

## Changes:
Please provide a list of the changes implemented by this PR
* datasets table

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
