### PR TITLE
fix: keyword tags in dataset detail page

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
@@ -110,6 +110,7 @@
                       [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
                       [matChipInputAddOnBlur]="true"
                       (matChipInputTokenEnd)="onAddKeyword($event)"
+                      class="keyword-input"
                     />
                   </mat-chip-grid>
                 </mat-form-field>

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
@@ -86,6 +86,7 @@
                   <mat-chip
                     role="listitem"
                     *ngFor="let keyword of dataset.keywords"
+                    (click)="onClickKeyword(keyword)"
                   >
                     {{ keyword }}
                   </mat-chip>

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.scss
@@ -86,3 +86,7 @@ mat-card {
   max-width: 80vw;
   overflow: auto;
 }
+
+.keyword-input {
+  padding-left: 10px;
+}

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
@@ -174,7 +174,7 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
     const value = event.value;
 
     if ((value || "").trim() && this.dataset) {
-      const keyword = value.trim().toLowerCase();
+      const keyword = value.trim();
       if (this.keywords.value.indexOf(keyword) === -1) {
         this.keywords.push(this.fb.control(keyword));
 


### PR DESCRIPTION
## Description
This PR fixes 3 issues with keywords in dataset detail page. First, clicking on a keyword tag in non editing mode now redirects user to dashboard with applied keyword filter. Second, when typing a new keyword, the first character is now visible in the input field. Third, when typing a new keyword, it no longer gets transformed to lower case.


## Motivation
Background on use case, changes needed


## Fixes:
* https://jira.ess.eu/browse/SWAP-4202
* https://jira.ess.eu/browse/SWAP-3288

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Fix keyword chips interactions and input display on the dataset detail page.

Bug Fixes:
- Enable clicking a keyword chip in view mode to redirect to the dashboard with the keyword filter applied
- Ensure the first character typed in the keyword input field is visible by adding left padding