### PR TITLE
fix: filters in dataset dashboard

### DIFF
--- a/src/app/shared/modules/filters/group-filter.component.html
+++ b/src/app/shared/modules/filters/group-filter.component.html
@@ -12,6 +12,8 @@
     #input
     (input)="onGroupInput($event)"
     [value]="groupInput$ | async"
+    (blur)="onGroupBlur()"
+    (keydown.enter)="onGroupKeyEnter()"
     matInput
     class="group-input"
     [matChipInputFor]="groupChipList"

--- a/src/app/shared/modules/filters/group-filter.component.ts
+++ b/src/app/shared/modules/filters/group-filter.component.ts
@@ -62,7 +62,7 @@ export class GroupFilterComponent
   onGroupInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.groupInput$.next(value);
-    this.typedGroup = value;
+    this.typedGroup = value.trim();
   }
   groupSelected(group: string) {
     this.store.dispatch(addGroupFilterAction({ group }));

--- a/src/app/shared/modules/filters/group-filter.component.ts
+++ b/src/app/shared/modules/filters/group-filter.component.ts
@@ -41,7 +41,7 @@ export class GroupFilterComponent
 
   groupFacetCounts$ = this.store.select(selectGroupFacetCounts);
   groupInput$ = new BehaviorSubject<string>("");
-  typedGroup: string = "";
+  typedGroup = "";
 
   groupSuggestions$ = createSuggestionObserver(
     this.groupFacetCounts$,

--- a/src/app/shared/modules/filters/group-filter.component.ts
+++ b/src/app/shared/modules/filters/group-filter.component.ts
@@ -41,6 +41,7 @@ export class GroupFilterComponent
 
   groupFacetCounts$ = this.store.select(selectGroupFacetCounts);
   groupInput$ = new BehaviorSubject<string>("");
+  typedGroup: string = "";
 
   groupSuggestions$ = createSuggestionObserver(
     this.groupFacetCounts$,
@@ -61,13 +62,27 @@ export class GroupFilterComponent
   onGroupInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.groupInput$.next(value);
+    this.typedGroup = value;
   }
   groupSelected(group: string) {
     this.store.dispatch(addGroupFilterAction({ group }));
     this.groupInput$.next("");
+    this.typedGroup = "";
   }
 
   groupRemoved(group: string) {
     this.store.dispatch(removeGroupFilterAction({ group }));
+  }
+
+  onGroupKeyEnter() {
+    if (this.typedGroup) {
+      this.groupSelected(this.typedGroup);
+    }
+  }
+
+  onGroupBlur() {
+    if (this.typedGroup) {
+      this.groupSelected(this.typedGroup);
+    }
   }
 }

--- a/src/app/shared/modules/filters/keyword-filter.component.html
+++ b/src/app/shared/modules/filters/keyword-filter.component.html
@@ -12,6 +12,8 @@
     #input
     (input)="onKeywordInput($event)"
     [value]="keywordsInput$ | async"
+    (blur)="onKeywordBlur()"
+    (keydown.enter)="onKeywordKeyEnter()"
     matInput
     class="keyword-input"
     [matChipInputFor]="keywordChipList"

--- a/src/app/shared/modules/filters/keyword-filter.component.ts
+++ b/src/app/shared/modules/filters/keyword-filter.component.ts
@@ -46,6 +46,7 @@ export class KeywordFilterComponent
   keywordFacetCounts$ = this.store.select(selectKeywordFacetCounts);
 
   subscription = undefined;
+  typedKeyword: string = "";
 
   keywordsSuggestions$ = createSuggestionObserver(
     this.keywordFacetCounts$,
@@ -75,15 +76,29 @@ export class KeywordFilterComponent
   onKeywordInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.keywordsInput$.next(value);
+    this.typedKeyword = value;
   }
 
   keywordSelected(keyword: string) {
     this.store.dispatch(addKeywordFilterAction({ keyword }));
     this.keywordsInput$.next("");
+    this.typedKeyword = "";
   }
 
   keywordRemoved(keyword: string) {
     this.store.dispatch(removeKeywordFilterAction({ keyword }));
+  }
+
+  onKeywordKeyEnter() {
+    if (this.typedKeyword) {
+      this.keywordSelected(this.typedKeyword);
+    }
+  }
+
+  onKeywordBlur() {
+    if (this.typedKeyword) {
+      this.keywordSelected(this.typedKeyword);
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/shared/modules/filters/keyword-filter.component.ts
+++ b/src/app/shared/modules/filters/keyword-filter.component.ts
@@ -46,7 +46,7 @@ export class KeywordFilterComponent
   keywordFacetCounts$ = this.store.select(selectKeywordFacetCounts);
 
   subscription = undefined;
-  typedKeyword: string = "";
+  typedKeyword = "";
 
   keywordsSuggestions$ = createSuggestionObserver(
     this.keywordFacetCounts$,

--- a/src/app/shared/modules/filters/keyword-filter.component.ts
+++ b/src/app/shared/modules/filters/keyword-filter.component.ts
@@ -76,7 +76,7 @@ export class KeywordFilterComponent
   onKeywordInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.keywordsInput$.next(value);
-    this.typedKeyword = value;
+    this.typedKeyword = value.trim();
   }
 
   keywordSelected(keyword: string) {

--- a/src/app/shared/modules/filters/location-filter.component.html
+++ b/src/app/shared/modules/filters/location-filter.component.html
@@ -13,6 +13,8 @@
     #input
     (input)="onLocationInput($event)"
     [value]="locationInput$ | async"
+    (blur)="onLocationBlur()"
+    (keydown.enter)="onLocationKeyEnter()"
     matInput
     class="location-input"
     [matChipInputFor]="locationChipList"

--- a/src/app/shared/modules/filters/location-filter.component.ts
+++ b/src/app/shared/modules/filters/location-filter.component.ts
@@ -42,6 +42,8 @@ export class LocationFilterComponent
 
   locationInput$ = new BehaviorSubject<string>("");
 
+  typedLocation: string = "";
+
   locationSuggestions$ = createSuggestionObserver(
     this.locationFacetCounts$,
     this.locationInput$,
@@ -62,6 +64,7 @@ export class LocationFilterComponent
     const loc = location || "";
     this.store.dispatch(addLocationFilterAction({ location: loc }));
     this.locationInput$.next("");
+    this.typedLocation = "";
   }
 
   locationRemoved(location: string) {
@@ -71,5 +74,18 @@ export class LocationFilterComponent
   onLocationInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.locationInput$.next(value);
+    this.typedLocation = value;
+  }
+
+  onLocationKeyEnter() {
+    if (this.typedLocation) {
+      this.locationSelected(this.typedLocation);
+    }
+  }
+
+  onLocationBlur() {
+    if (this.typedLocation) {
+      this.locationSelected(this.typedLocation);
+    }
   }
 }

--- a/src/app/shared/modules/filters/location-filter.component.ts
+++ b/src/app/shared/modules/filters/location-filter.component.ts
@@ -42,7 +42,7 @@ export class LocationFilterComponent
 
   locationInput$ = new BehaviorSubject<string>("");
 
-  typedLocation: string = "";
+  typedLocation = "";
 
   locationSuggestions$ = createSuggestionObserver(
     this.locationFacetCounts$,

--- a/src/app/shared/modules/filters/location-filter.component.ts
+++ b/src/app/shared/modules/filters/location-filter.component.ts
@@ -74,7 +74,7 @@ export class LocationFilterComponent
   onLocationInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.locationInput$.next(value);
-    this.typedLocation = value;
+    this.typedLocation = value.trim();
   }
 
   onLocationKeyEnter() {

--- a/src/app/shared/modules/filters/type-filter.component.html
+++ b/src/app/shared/modules/filters/type-filter.component.html
@@ -12,6 +12,8 @@
     #input
     (input)="onTypeInput($event)"
     [value]="typeInput$ | async"
+    (blur)="onTypeBlur()"
+    (keydown.enter)="onTypeKeyEnter()"
     matInput
     class="type-input"
     [matChipInputFor]="typeChipList"

--- a/src/app/shared/modules/filters/type-filter.component.ts
+++ b/src/app/shared/modules/filters/type-filter.component.ts
@@ -61,7 +61,7 @@ export class TypeFilterComponent
   onTypeInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.typeInput$.next(value);
-    this.typedType = value;
+    this.typedType = value.trim();
   }
 
   typeSelected(type: string) {

--- a/src/app/shared/modules/filters/type-filter.component.ts
+++ b/src/app/shared/modules/filters/type-filter.component.ts
@@ -41,7 +41,7 @@ export class TypeFilterComponent
 
   typeFilter$ = this.store.select(selectTypeFilter);
   typeInput$ = new BehaviorSubject<string>("");
-  typedType: string = "";
+  typedType = "";
 
   typeSuggestions$ = createSuggestionObserver(
     this.typeFacetCounts$,

--- a/src/app/shared/modules/filters/type-filter.component.ts
+++ b/src/app/shared/modules/filters/type-filter.component.ts
@@ -41,6 +41,7 @@ export class TypeFilterComponent
 
   typeFilter$ = this.store.select(selectTypeFilter);
   typeInput$ = new BehaviorSubject<string>("");
+  typedType: string = "";
 
   typeSuggestions$ = createSuggestionObserver(
     this.typeFacetCounts$,
@@ -60,14 +61,28 @@ export class TypeFilterComponent
   onTypeInput(event: any) {
     const value = (<HTMLInputElement>event.target).value;
     this.typeInput$.next(value);
+    this.typedType = value;
   }
 
   typeSelected(type: string) {
     this.store.dispatch(addTypeFilterAction({ datasetType: type }));
     this.typeInput$.next("");
+    this.typedType = "";
   }
 
   typeRemoved(type: string) {
     this.store.dispatch(removeTypeFilterAction({ datasetType: type }));
+  }
+
+  onTypeKeyEnter() {
+    if (this.typedType) {
+      this.typeSelected(this.typedType);
+    }
+  }
+
+  onTypeBlur() {
+    if (this.typedType) {
+      this.typeSelected(this.typedType);
+    }
   }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue with the filters in dataset dashboard where manually typing into Location, Group, Type and Keyword input fields did not apply the filters unless a suggestion was selected.

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Ensure manually typed filter values are applied by dispatching filter actions on input blur or Enter key across Location, Group, Type, and Keyword filters.

Bug Fixes:
- Apply manually entered filter values even when no suggestion is chosen

Enhancements:
- Add typed input state and onBlur/onKeyEnter handlers in filter components
- Update filter templates to trigger selection on blur and Enter key