### PR TITLE
fix(datasets): make fullquery request on view mode change

### DIFF
--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -51,6 +51,7 @@ export class DatasetEffects {
         fromActions.fetchDatasetsAction,
         fromActions.setPublicViewModeAction,
         fromActions.sortByColumnAction,
+        fromActions.setArchiveViewModeAction,
       ),
       concatLatestFrom(() => this.fullqueryParams$),
       map(([, params]) => params),


### PR DESCRIPTION
## Description
Fixes #1990

## Motivation
Probably no other facilities enabled the config for this and it got removed somewhere in the commits

## Fixes:
Please provide a list of the fixes implemented in this PR

* when "archivable/retrievable" is toggled an effect is triggered that does a fullquery request.

## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Include archive view mode toggling in the dataset effects to trigger a full dataset query when archivable/retrievable view is toggled.

Bug Fixes:
- Ensure toggling the archivable/retrievable view mode triggers a fullquery request

Enhancements:
- Add setArchiveViewModeAction to the list of actions that trigger the fullqueryParams effect