### PR TITLE
fix: small layout fix in datasets filters

### DIFF
--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -1,5 +1,5 @@
 <mat-card>
-  <mat-card-header class="section-container">
+  <mat-card-header class="section-container filters-header">
     <mat-card-title>Filters</mat-card-title>
     <div class="section-container" data-cy="more-filters-button">
       <button

--- a/src/app/datasets/datasets-filter/datasets-filter.component.scss
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.scss
@@ -66,7 +66,7 @@ mat-card {
     }
   }
 
-  .section-container:first-child {
+  .filters-header {
     padding-top: 0.1rem;
     margin-top: unset;
     display: flex;
@@ -78,6 +78,13 @@ mat-card {
       align-items: center;
       justify-content: end;
     }
+  }
+
+  .conditions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
     .condition-button {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Description
This PR fixes a layout issue in datasets filter component where conditions are displayed incorrectly when all filters are disabled.
Before:
<img width="361" height="208" alt="fix-filters-ui-before" src="https://github.com/user-attachments/assets/1bdb4a1e-a84c-4737-801a-beca4e7aa7ce" />

After:
<img width="364" height="245" alt="fix-filters-ui-after" src="https://github.com/user-attachments/assets/45c83152-4edd-4dd5-9651-12079d28eb29" />


## Motivation
Background on use case, changes needed


## Fixes:

* Items added


## Changes:

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Fix layout issues in the datasets filter component by renaming the header class and introducing a new conditions header for proper alignment

Bug Fixes:
- Fix misalignment of filter conditions when all filters are disabled

Enhancements:
- Rename the first section container to ‘filters-header’ for clear semantics
- Add a ‘conditions-header’ class with flex styling to properly align condition elements