### PR TITLE
feat: add ability to merge config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ Thumbs.db
 
 # karma
 karma-junit.xml
+
+# config files overrides
+config.override.json
+config.override.*.json

--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -5,7 +5,7 @@ import {
   AppConfigService,
   HelpMessages,
 } from "app-config.service";
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
 import { MockHttp } from "shared/MockStubs";
 
 const appConfig: AppConfigInterface = {
@@ -280,6 +280,47 @@ describe("AppConfigService", () => {
   });
 
   describe("#getConfig()", () => {
+    const mockConfigResponses: Record<string, object> = {
+      "/assets/config.json": {
+        accessTokenPrefix: "",
+        lbBaseURL: "http://127.0.0.1:3000",
+        gettingStarted: null,
+        mainMenu: { nonAuthenticatedUser: { datasets: true } },
+      },
+      "/assets/config.0.json": { accessTokenPrefix: "Bearer " },
+      "/assets/config.override.json": {
+        gettingStarted: "aGettingStarted",
+        addDatasetEnabled: true,
+        mainMenu: { nonAuthenticatedUser: { files: true } },
+      },
+      "/assets/config.override.0.json": { siteTitle: "Test title" },
+    };
+
+    const mergedConfig = {
+      accessTokenPrefix: "Bearer ",
+      lbBaseURL: "http://127.0.0.1:3000",
+      gettingStarted: "aGettingStarted",
+      addDatasetEnabled: true,
+      siteTitle: "Test title",
+      mainMenu: { nonAuthenticatedUser: { datasets: true, files: true } },
+    };
+
+    const mockHttpGet = (backendError = false) => {
+      spyOn(service["http"], "get").and.callFake(
+        (url: string): Observable<any> => {
+          if (url === "/api/v3/admin/config") {
+            if (backendError) {
+              return new Observable((sub) =>
+                sub.error(new Error("No config in backend")),
+              );
+            }
+            return of(mergedConfig);
+          }
+          return of(mockConfigResponses[url] || {});
+        },
+      );
+    };
+
     it("should return the AppConfig object", async () => {
       spyOn(service["http"], "get").and.returnValue(of(appConfig));
       await service.loadAppConfig();
@@ -287,6 +328,30 @@ describe("AppConfigService", () => {
       const config = service.getConfig();
 
       expect(config).toEqual(appConfig);
+    });
+
+    it("should merge multiple config JSONs", async () => {
+      mockHttpGet();
+      const config = await service["mergeConfig"]();
+      expect(config).toEqual(mergedConfig);
+    });
+
+    it("should return the merged appConfig", async () => {
+      mockHttpGet(true);
+      await service.loadAppConfig();
+
+      expect(service["appConfig"]).toEqual(
+        jasmine.objectContaining(mergedConfig),
+      );
+      expect(service["http"].get).toHaveBeenCalledWith("/api/v3/admin/config");
+      expect(service["http"].get).toHaveBeenCalledWith("/assets/config.json");
+      expect(service["http"].get).toHaveBeenCalledWith("/assets/config.0.json");
+      expect(service["http"].get).toHaveBeenCalledWith(
+        "/assets/config.override.json",
+      );
+      expect(service["http"].get).toHaveBeenCalledWith(
+        "/assets/config.override.0.json",
+      );
     });
   });
 });

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -1,6 +1,8 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { timeout } from "rxjs/operators";
+import { merge } from "lodash-es";
+import { firstValueFrom, forkJoin, of } from "rxjs";
+import { catchError, timeout } from "rxjs/operators";
 import {
   DatasetDetailComponentConfig,
   DatasetsListSettings,
@@ -156,8 +158,34 @@ function isMainPageConfiguration(obj: any): obj is MainPageConfiguration {
 })
 export class AppConfigService {
   private appConfig: object = {};
+  private configsSize = 4;
 
   constructor(private http: HttpClient) {}
+
+  private async loadAndMerge(files: string[]): Promise<object> {
+    const requests = files.map((f) =>
+      this.http.get(`/assets/${f}`).pipe(catchError(() => of({}))),
+    );
+    const configs = await firstValueFrom(forkJoin(requests));
+    return configs.reduce((acc, cfg) => merge(acc, cfg), {});
+  }
+
+  private async mergeConfig(): Promise<object> {
+    const normalConfigFiles = Array.from(
+      { length: this.configsSize },
+      (_, i) => `config.${i}.json`,
+    );
+    const overrideConfigFiles = Array.from(
+      { length: this.configsSize },
+      (_, i) => `config.override.${i}.json`,
+    );
+    return await this.loadAndMerge([
+      "config.json",
+      ...normalConfigFiles,
+      "config.override.json",
+      ...overrideConfigFiles,
+    ]);
+  }
 
   async loadAppConfig(): Promise<void> {
     try {
@@ -169,7 +197,7 @@ export class AppConfigService {
     } catch (err) {
       console.log("No config available in backend, trying with local config.");
       try {
-        const config = await this.http.get("/assets/config.json").toPromise();
+        const config = await this.mergeConfig();
         this.appConfig = Object.assign({}, this.appConfig, config);
       } catch (err) {
         console.error("No config provided.");


### PR DESCRIPTION
## Description
This is handy when different envs require shared bits from the same config but need overriding some other parts, e.g. the backendUrl. 

## Changes:
Please provide a list of the changes implemented by this PR

* enables merging sequentially up to 10 files, config.json -> ... -> config.3.json -> config.override.json -> ... -> config.override.3.json
* adds config.override* to gitignore to allow scicatlive not to mess with git

## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Enable AppConfigService to merge multiple local configuration files and fallback to them when backend config is unavailable, update .gitignore, and add tests for the new merging logic.

New Features:
- Support merging of up to 10 sequential config files (normal and override) in AppConfigService

Enhancements:
- Implement loadAndMerge and mergeConfig methods to sequentially combine multiple local config JSON files
- Refactor loadAppConfig to use the merged local config on backend failure

Tests:
- Add unit tests for mergeConfig to verify multi-file merging behavior
- Add tests to validate loadAppConfig fallback to merged local config and correct HTTP requests

Chores:
- Ignore config.override* files in .gitignore