### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SciCatProject/reviewers


### PR DESCRIPTION
## Description

with the codeowners the list here will be added as automatic reviewers to PRs

## Summary by Sourcery

Chores:
- Introduce .github/CODEOWNERS to define automatic PR reviewers