### PR TITLE
BREAKING CHANGE: release major version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN npm ci
 COPY . /frontend/
 RUN npx ng build
 
-# NOTE: As of Sept 22, frontend is served on port 8080 (previously 80).
-# Make sure deployments, ingress, and services reference 8080 instead of 80.
+# NOTE: As of Sept 22, frontend is served on port 8080 (previously 80)
+# Make sure deployments, ingress, and services reference 8080 instead of 80
 FROM docker.io/nginxinc/nginx-unprivileged:1.26.3
 USER root
 RUN rm -rf /usr/share/nginx/html/*


### PR DESCRIPTION
## Description
Release v5.5.0 includes a breaking change: the Docker image port has changed from 80 to 8080. Therefore, the release should have been a major bump instead of a minor bump.


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
