### PR TITLE
fix: proposal datasets table pagination not working

### DIFF
--- a/src/app/proposals/proposal-datasets/proposal-datasets.component.ts
+++ b/src/app/proposals/proposal-datasets/proposal-datasets.component.ts
@@ -124,6 +124,8 @@ export class ProposalDatasetsComponent implements OnInit, OnDestroy {
 
   defaultPageSize = 10;
 
+  defaultPageSizeOptions = [5, 10, 25, 100];
+
   tablesSettings: object;
 
   showGlobalTextSearch = false;
@@ -140,31 +142,40 @@ export class ProposalDatasetsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.store.dispatch(
-      fetchProposalDatasetsAction({ proposalId: this.proposalId }),
+      fetchProposalDatasetsAction({
+        proposalId: this.proposalId,
+        limit: this.defaultPageSize,
+        skip: 0,
+      }),
     );
 
     this.subscription = this.proposalDatasets$.subscribe((data) => {
       this.dataSource.next(this.formatTableData(data.datasets));
       this.pending = false;
 
+      const paginationConfig = this.getTablePaginationConfig(data.datasetCount);
+
       const tableSettingsConfig =
         this.tableConfigService.getTableSettingsConfig(
           this.tableName,
           tableDefaultSettingsConfig,
         );
-      const pagginationConfig = {
-        pageSizeOptions: [5, 10, 25, 100],
-        pageIndex: data.currentPage || 0,
-        pageSize: data.datasetsPerPage || this.defaultPageSize,
-        length: data.datasetCount,
-      };
 
       if (tableSettingsConfig?.settingList.length) {
-        this.initTable(tableSettingsConfig, pagginationConfig);
+        this.initTable(tableSettingsConfig, paginationConfig);
       }
     });
   }
+  getTablePaginationConfig(dataCount = 0): TablePagination {
+    const { queryParams } = this.route.snapshot;
 
+    return {
+      pageSizeOptions: this.defaultPageSizeOptions,
+      pageIndex: queryParams.pageIndex || 0,
+      pageSize: queryParams.pageSize || this.defaultPageSize,
+      length: dataCount,
+    };
+  }
   initTable(
     settingConfig: ITableSetting,
     paginationConfig: TablePagination,
@@ -201,6 +212,7 @@ export class ProposalDatasetsComponent implements OnInit, OnDestroy {
       pageIndex: pagination.pageIndex,
       pageSize: pagination.pageSize,
     };
+
     const { sortColumn, sortDirection } = this.route.snapshot.queryParams;
 
     this.router.navigate([], {


### PR DESCRIPTION
## Description
This PR fixes proposal datasets table pagination issues.

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Fix pagination behavior in the proposal datasets table by introducing configurable page size options, extracting pagination logic, and dispatching dataset fetch actions with correct limit and offset parameters.

Bug Fixes:
- Ensure initial dataset fetch includes limit and skip parameters for pagination
- Apply correct page index, page size, and total length from route query parameters to the table pagination

Enhancements:
- Add defaultPageSizeOptions property for configurable page sizes
- Extract getTablePaginationConfig method to centralize pagination setup
- Replace inline pagination configuration with the new pagination helper method