### PR TITLE
fix(proposals): update state to store pagination in datasetFilters

### DIFF
--- a/src/app/proposals/proposal-datasets/proposal-datasets.component.ts
+++ b/src/app/proposals/proposal-datasets/proposal-datasets.component.ts
@@ -140,7 +140,11 @@ export class ProposalDatasetsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.store.dispatch(
-      fetchProposalDatasetsAction({ proposalId: this.proposalId }),
+      fetchProposalDatasetsAction({
+        proposalId: this.proposalId,
+        skip: 0,
+        limit: this.defaultPageSize,
+      }),
     );
 
     this.subscription = this.proposalDatasets$.subscribe((data) => {
@@ -152,7 +156,7 @@ export class ProposalDatasetsComponent implements OnInit, OnDestroy {
           this.tableName,
           tableDefaultSettingsConfig,
         );
-      const pagginationConfig = {
+      const paginationConfig = {
         pageSizeOptions: [5, 10, 25, 100],
         pageIndex: data.currentPage || 0,
         pageSize: data.datasetsPerPage || this.defaultPageSize,
@@ -160,7 +164,7 @@ export class ProposalDatasetsComponent implements OnInit, OnDestroy {
       };
 
       if (tableSettingsConfig?.settingList.length) {
-        this.initTable(tableSettingsConfig, pagginationConfig);
+        this.initTable(tableSettingsConfig, paginationConfig);
       }
     });
   }

--- a/src/app/state-management/actions/proposals.actions.spec.ts
+++ b/src/app/state-management/actions/proposals.actions.spec.ts
@@ -103,12 +103,19 @@ describe("Proposal Actions", () => {
   describe("fetchProposalDatasetsCompleteAction", () => {
     it("should create an action", () => {
       const datasets = [mockDataset];
+      const skip = 50;
+      const limit = 50;
+
       const action = fromActions.fetchProposalDatasetsCompleteAction({
         datasets,
+        skip,
+        limit,
       });
       expect({ ...action }).toEqual({
         type: "[Proposal] Fetch Datasets Complete",
         datasets,
+        skip,
+        limit,
       });
     });
   });

--- a/src/app/state-management/actions/proposals.actions.ts
+++ b/src/app/state-management/actions/proposals.actions.ts
@@ -94,7 +94,11 @@ export const fetchProposalDatasetsAction = createAction(
 );
 export const fetchProposalDatasetsCompleteAction = createAction(
   "[Proposal] Fetch Datasets Complete",
-  props<{ datasets: OutputDatasetObsoleteDto[] }>(),
+  props<{
+    datasets: OutputDatasetObsoleteDto[];
+    limit: number;
+    skip: number;
+  }>(),
 );
 export const fetchProposalDatasetsFailedAction = createAction(
   "[Proposal] Fetch Datasets Failed",

--- a/src/app/state-management/effects/proposals.effects.spec.ts
+++ b/src/app/state-management/effects/proposals.effects.spec.ts
@@ -242,9 +242,18 @@ describe("ProposalEffects", () => {
 
     it("should result in a fetchProposalDatasetsCompleteAction and a fetchProposalDatasetsCountAction", () => {
       const datasets = [dataset];
-      const action = fromActions.fetchProposalDatasetsAction({ proposalId });
+      const skip = 0;
+      const limit = 50;
+
+      const action = fromActions.fetchProposalDatasetsAction({
+        proposalId,
+        skip: skip,
+        limit: limit,
+      });
       const outcome1 = fromActions.fetchProposalDatasetsCompleteAction({
         datasets,
+        skip: skip,
+        limit: limit,
       });
       const outcome2 = fromActions.fetchProposalDatasetsCountAction({
         proposalId,
@@ -620,6 +629,8 @@ describe("ProposalEffects", () => {
         const datasets = [dataset];
         const action = fromActions.fetchProposalDatasetsCompleteAction({
           datasets,
+          skip: 25,
+          limit: 25,
         });
         const outcome = loadingCompleteAction();
 

--- a/src/app/state-management/effects/proposals.effects.ts
+++ b/src/app/state-management/effects/proposals.effects.ts
@@ -116,7 +116,11 @@ export class ProposalEffects {
           )
           .pipe(
             mergeMap((datasets) => [
-              fromActions.fetchProposalDatasetsCompleteAction({ datasets }),
+              fromActions.fetchProposalDatasetsCompleteAction({
+                datasets,
+                limit,
+                skip,
+              }),
               fromActions.fetchProposalDatasetsCountAction({ proposalId }),
             ]),
             catchError(() =>

--- a/src/app/state-management/reducers/proposals.reducer.spec.ts
+++ b/src/app/state-management/reducers/proposals.reducer.spec.ts
@@ -56,7 +56,7 @@ describe("ProposalsReducer", () => {
     });
   });
 
-  describe("on fetchCountCompletAction", () => {
+  describe("on fetchCountCompleteAction", () => {
     it("should set proposalsCount", () => {
       const count = { facetCounts: {}, allCounts: 100 };
       const action = fromActions.fetchFacetCountsCompleteAction(count);
@@ -78,16 +78,23 @@ describe("ProposalsReducer", () => {
   describe("on fetchProposalDatasetsCompleteAction", () => {
     it("should set datasets", () => {
       const datasets = [dataset];
+      const skip = 50;
+      const limit = 50;
+
       const action = fromActions.fetchProposalDatasetsCompleteAction({
         datasets,
+        skip,
+        limit,
       });
       const state = proposalsReducer(initialProposalsState, action);
 
       expect(state.datasets).toEqual(datasets);
+      expect(state.datasetFilters.skip).toBe(skip);
+      expect(state.datasetFilters.limit).toBe(limit);
     });
   });
 
-  describe("on fetchProposalDatasetsCountCompletAction", () => {
+  describe("on fetchProposalDatasetsCountCompleteAction", () => {
     it("should set datasetsCount", () => {
       const count = 100;
       const action = fromActions.fetchProposalDatasetsCountCompleteAction({

--- a/src/app/state-management/reducers/proposals.reducer.ts
+++ b/src/app/state-management/reducers/proposals.reducer.ts
@@ -51,7 +51,15 @@ const reducer = createReducer(
 
   on(
     fromActions.fetchProposalDatasetsCompleteAction,
-    (state, { datasets }): ProposalsState => ({ ...state, datasets }),
+    (state, { datasets, limit, skip }): ProposalsState => ({
+      ...state,
+      datasets,
+      datasetFilters: {
+        ...state.datasetFilters,
+        skip,
+        limit,
+      },
+    }),
   ),
 
   on(


### PR DESCRIPTION
## Description
Fix for bug where pagination for datasets under proposals is broken

## Fixes:
Closes #2028 

## Changes:
- fetchProposalDatasetsCompleteAction now requires skip and limit
- reducer stores skip and limit in datasetFilters


## Tests included
- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)

## Summary by Sourcery

Fix broken pagination for proposal datasets by tracking and persisting skip and limit parameters throughout actions, reducer, effects, and component

Bug Fixes:
- Persist skip and limit values to restore pagination state for proposal datasets

Enhancements:
- Extend fetchProposalDatasets actions to include skip and limit parameters and update reducer to store them in datasetFilters
- Modify ProposalEffects and ProposalDatasetsComponent to dispatch and handle skip and limit values
- Update tests across actions, reducer, and effects to cover pagination parameters