### PR TITLE
fix(hot fix): disable sorting for 'image' column

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -471,6 +471,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
 
         if (column.name === "image") {
           convertedColumn.renderImage = true;
+          convertedColumn.sort = "none";
         }
 
         if (column.name === "instrumentName") {

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
@@ -114,7 +114,7 @@
                 | translate: localization
             "
             matTooltipClass="cell-tooltip"
-            [disabled]="column.sort === 'none' || column.name === 'image'"
+            [disabled]="column.sort === 'none'"
             class="header-caption"
           >
             {{ column.header || column.name | translate: localization }}


### PR DESCRIPTION
## Description
This PR disables image sort in dynamic material table

## Motivation
Sorting image does not give any value


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Enhancements:
- Prevent image columns from being sortable by adding a check to the disabled sorting condition in the table header