### PR TITLE
chore: run npm lint:fix over all sources

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -85,7 +85,9 @@
         "@angular-eslint/prefer-standalone": "warn",
         "@ngrx/on-function-explicit-return-type": "warn",
         "@ngrx/no-store-subscription": "warn",
-        "@angular-eslint/no-output-native": "warn"
+        "@angular-eslint/no-output-native": "warn",
+	"@angular-eslint/prefer-standalone": "off"
+
       }
     }
   ]

--- a/src/app/app-routing/app-routing.module.ts
+++ b/src/app/app-routing/app-routing.module.ts
@@ -30,9 +30,9 @@ export const routes: Routes = [
       {
         path: "auth-callback",
         loadChildren: () =>
-          import(
-            "./lazy/auth-callback-routing/auth-callback.feature.module"
-          ).then((m) => m.AuthCallbackFeatureModule),
+          import("./lazy/auth-callback-routing/auth-callback.feature.module").then(
+            (m) => m.AuthCallbackFeatureModule,
+          ),
       },
       {
         path: "",
@@ -55,9 +55,9 @@ export const routes: Routes = [
           {
             path: "instruments",
             loadChildren: () =>
-              import(
-                "./lazy/instruments-routing/instruments.feature.module"
-              ).then((m) => m.InstrumentsFeatureModule),
+              import("./lazy/instruments-routing/instruments.feature.module").then(
+                (m) => m.InstrumentsFeatureModule,
+              ),
           },
           {
             path: "proposals",
@@ -69,9 +69,9 @@ export const routes: Routes = [
           {
             path: "publishedDatasets",
             loadChildren: () =>
-              import(
-                "./lazy/publisheddata-routing/publisheddata.feature.module"
-              ).then((m) => m.PublisheddataFeatureModule),
+              import("./lazy/publisheddata-routing/publisheddata.feature.module").then(
+                (m) => m.PublisheddataFeatureModule,
+              ),
           },
           {
             path: "samples",

--- a/src/app/app-routing/lazy/datasets-routing/datasets.routing.module.ts
+++ b/src/app/app-routing/lazy/datasets-routing/datasets.routing.module.ts
@@ -28,9 +28,9 @@ const routes: Routes = [
     path: ":id",
     component: DatasetDetailsDashboardComponent,
     loadChildren: () =>
-      import(
-        "../dataset-details-dashboard-routing/dataset-details-dashboard.feature.module"
-      ).then((m) => m.DatasetDetailsDashboardFeatureModule),
+      import("../dataset-details-dashboard-routing/dataset-details-dashboard.feature.module").then(
+        (m) => m.DatasetDetailsDashboardFeatureModule,
+      ),
   },
   {
     path: ":id/datablocks",


### PR DESCRIPTION
Run npm lint:fix over the source

## Motivation
Should fix unrelated lint errors etc.

## Summary by Sourcery

Apply lint-driven cleanups across Angular routing, components, directives, and pipes to align with current style and type-checking expectations.

Enhancements:
- Reformat lazy-loaded route imports for consistency with linted style.
- Remove redundant `standalone: false` declarations from Angular components, directives, and pipes now relying on default metadata.
- Align several component class declarations with their implemented lifecycle hooks by explicitly adding the corresponding interfaces.