### PR TITLE
fix(deps): include ngx-cookie-service in angular group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
       angular:
         patterns:
           - "@angular*"
+          - "ngx-cookie-service"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
it is tied to the angular version in use

## Summary by Sourcery

Build:
- Update Dependabot configuration to include ngx-cookie-service in the Angular dependency group for minor and patch updates.