### PR TITLE
fix(deps): bump ngx-layout to 19.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@jsonforms/angular": "^3.5.1",
         "@jsonforms/angular-material": "^3.5.1",
         "@jsonforms/core": "^3.5.1",
-        "@ngbracket/ngx-layout": "^16.0.0",
+        "@ngbracket/ngx-layout": "^19.0.0",
         "@ngrx/effects": "^19.1.0",
         "@ngrx/operators": "^19.1.0",
         "@ngrx/router-store": "^19.1.0",
@@ -4997,19 +4997,19 @@
       }
     },
     "node_modules/@ngbracket/ngx-layout": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/@ngbracket/ngx-layout/-/ngx-layout-16.1.3.tgz",
-      "integrity": "sha512-N24KX2BIBYXbCfLyr8Q/wXHh5x9w8yGn2G5GLo99inOJ2BtBNu3AvBdvz1oYIsuLEdqgWZIqt0JqlBeIm4u/iQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@ngbracket/ngx-layout/-/ngx-layout-19.0.0.tgz",
+      "integrity": "sha512-odQu2uKdUEzGmHAJgBPCXxMA0/AG3vWks+NHLwWr7hOMhJMVqtaHJd76OqZ+X9xs05Q2M+qCtmb01aeet0r/3A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.5.0"
       },
       "peerDependencies": {
-        "@angular/cdk": ">=16.0.0",
-        "@angular/common": ">=16.0.0",
-        "@angular/core": ">=16.0.0",
-        "@angular/platform-browser": ">=16.0.0",
-        "rxjs": "^6.5.3 || ^7.8.0"
+        "@angular/cdk": ">=19.0.0",
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0",
+        "@angular/platform-browser": ">=19.0.0",
+        "rxjs": "^6.5.3 || ^7.8.1"
       }
     },
     "node_modules/@ngrx/effects": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@jsonforms/angular": "^3.5.1",
     "@jsonforms/angular-material": "^3.5.1",
     "@jsonforms/core": "^3.5.1",
-    "@ngbracket/ngx-layout": "^16.0.0",
+    "@ngbracket/ngx-layout": "^19.0.0",
     "@ngrx/effects": "^19.1.0",
     "@ngrx/operators": "^19.1.0",
     "@ngrx/router-store": "^19.1.0",


### PR DESCRIPTION
A ngx-layout version for angular19 is now available, so use it

## Summary by Sourcery

Build:
- Bump @ngbracket/ngx-layout from version 16.x to 19.x in package.json and lockfile.