### PR TITLE
docs: use file path after copy

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: SciCatProject/docs-template/.github/actions/mkdocs-pages@v0.1.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && 'true' || '' }}
           # if this file does not need to exist locally, the one in the action is used
           # https://github.com/SciCatProject/docs-template/blob/v0.1.0/.github/actions/mkdocs-pages/mkdocs-nested.yml
           docs_config: .github/mkdocs/mkdocs-nested.yml


### PR DESCRIPTION
## Description
The file path to be used is the one after the copy to the local repo [here](https://github.com/SciCatProject/docs-template/blob/main/.github/actions/mkdocs-pages/action.yml#L45-L49)

## Summary by Sourcery

CI:
- Adjust docs publishing GitHub Actions workflow to use the mkdocs configuration path under .github/mkdocs instead of the action directory.