### PR TITLE
feat(publish): allow to configure default metadata

### DIFF
--- a/src/app/datasets/publish/publish.component.ts
+++ b/src/app/datasets/publish/publish.component.ts
@@ -24,7 +24,7 @@ import {
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { AppConfigService } from "app-config.service";
 import { EditableComponent } from "app-routing/pending-changes.guard";
-import { isEmpty } from "lodash-es";
+import { cloneDeep, isEmpty } from "lodash-es";
 import { fromEvent, Subscription } from "rxjs";
 import {
   AccordionArrayLayoutRendererComponent,
@@ -134,7 +134,7 @@ export class PublishComponent implements OnInit, OnDestroy, EditableComponent {
             1,
           );
           this.uiSchema = publishedDataConfig.uiSchema;
-          this.metadata = publishedDataConfig.defaultValues ?? {};
+          this.metadata = cloneDeep(publishedDataConfig.defaultValues) ?? {};
         }
       },
     );


### PR DESCRIPTION
## Description
Allows to configure default metadata for publisheddata


## Motivation
Automatically set properties like `publisher` to something like:
```json
"publisher": {
    "lang": "en",
    "name": "Example Publisher",
    "schemeUri": "https://ror.org/",
    "publisherIdentifier": "https://ror.org/04z8jg394",
    "publisherIdentifierScheme": "ROR"
  }
```


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

New Features:
- Support configuring default metadata values for published datasets that are applied on initialization.