### PR TITLE
fix: truncate table cell text if too long

### DIFF
--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
@@ -153,6 +153,9 @@
               | translate: localization
           "
           matTooltipClass="cell-tooltip"
+          matTooltipPosition="above"
+          matTooltipPositionAtOrigin
+          matTooltipShowDelay="500"
           [disabled]="column.sort === 'none'"
           class="header-caption"
         >

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
@@ -42,9 +42,12 @@
 }
 
 .label-cell {
-  display: flex;
-  cursor: inherit;
-  justify-content: flex-start;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  cursor: pointer;
 }
 
 mat-cell .label-cell {
@@ -263,7 +266,6 @@ cdk-virtual-scroll-viewport {
 }
 
 ::ng-deep .cell-tooltip {
-  padding: 8px;
   font-size: 12px;
   min-width: 100px;
   text-align: center;


### PR DESCRIPTION
## Description
Added CSS text truncation with text-overflow: ellipsis for table cells so long content is clipped and displayed with “…” at the end.
<img width="854" height="359" alt="image" src="https://github.com/user-attachments/assets/8a520b3c-2aeb-4ffb-aa05-fb101db4d404" />


## Motivation
long texts were cut off without indication 


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Improve table cell text handling and header tooltips for dynamic material tables.

Bug Fixes:
- Ensure long table cell labels are truncated with ellipsis instead of overflowing or being cut off without indication.

Enhancements:
- Adjust label cell styling to use block layout with pointer cursor and full-width ellipsis truncation.
- Refine header cell tooltip behavior by positioning it above, anchoring it at the origin, and adding a slight show delay.
- Simplify cell tooltip styling by removing extra padding for a more compact appearance.