### PR TITLE
feat: add source to saved columns and always show user added columns

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.spec.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.spec.ts
@@ -300,7 +300,7 @@ describe("DatasetTableComponent", () => {
   });
 
   describe("#saveTableSettings()", () => {
-    it("should persist user-added dataset columns with source and path", () => {
+    it("should persist user-added dataset columns with userAdded and path", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
       const setting: ITableSetting = {
@@ -319,7 +319,7 @@ describe("DatasetTableComponent", () => {
             type: "custom",
             width: 180,
             tooltip: "User-added custom column",
-            source: "user",
+            userAdded: true,
           },
         ],
       };
@@ -337,7 +337,7 @@ describe("DatasetTableComponent", () => {
                 order: 0,
                 width: 250,
                 path: undefined,
-                source: "default",
+                userAdded: undefined,
                 type: "standard",
                 format: undefined,
                 tooltip: undefined,
@@ -349,7 +349,7 @@ describe("DatasetTableComponent", () => {
                 order: 1,
                 width: 180,
                 path: "scientificMetadata.sample.temperature",
-                source: "user",
+                userAdded: true,
                 type: "custom",
                 format: undefined,
                 tooltip: "User-added custom column",
@@ -360,7 +360,7 @@ describe("DatasetTableComponent", () => {
       );
     });
 
-    it("should default missing source metadata to default", () => {
+    it("should leave missing userAdded metadata undefined", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
       const setting: ITableSetting = {
@@ -384,7 +384,7 @@ describe("DatasetTableComponent", () => {
             columns: [
               jasmine.objectContaining({
                 name: "scientificMetadata.sample.temperature",
-                source: "default",
+                userAdded: undefined,
                 type: "custom",
               }),
             ],

--- a/src/app/datasets/dataset-table/dataset-table.component.spec.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.spec.ts
@@ -28,6 +28,7 @@ import {
   clearSelectionAction,
   sortByColumnAction,
 } from "state-management/actions/datasets.actions";
+import { updateUserSettingsAction } from "state-management/actions/user.actions";
 import { provideMockStore } from "@ngrx/store/testing";
 import { selectDatasets } from "state-management/selectors/datasets.selectors";
 import { selectInstruments } from "state-management/selectors/instruments.selectors";
@@ -53,6 +54,7 @@ import { FileSizePipe } from "shared/pipes/filesize.pipe";
 import { TitleCasePipe } from "shared/pipes/title-case.pipe";
 import { TranslateService } from "@ngx-translate/core";
 import { DatasetsListService } from "shared/services/datasets-list.service";
+import { ITableSetting } from "shared/modules/dynamic-material-table/models/table-setting.model";
 
 const auditFields = {
   createdAt: "",
@@ -294,6 +296,101 @@ describe("DatasetTableComponent", () => {
 
       const notFoundInstrument = component.instrumentMap.get("nonexistent");
       expect(notFoundInstrument).toBeUndefined();
+    });
+  });
+
+  describe("#saveTableSettings()", () => {
+    it("should persist user-added dataset columns with source and path", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const setting: ITableSetting = {
+        columnSetting: [
+          {
+            name: "datasetName",
+            display: "visible",
+            type: "standard",
+            width: 250,
+          },
+          {
+            name: "scientificMetadata.sample.temperature",
+            header: "Temperature",
+            path: "scientificMetadata.sample.temperature",
+            display: "visible",
+            type: "custom",
+            width: 180,
+            tooltip: "User-added custom column",
+            source: "user",
+          },
+        ],
+      };
+
+      component.saveTableSettings(setting);
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        updateUserSettingsAction({
+          property: {
+            columns: [
+              {
+                name: "datasetName",
+                header: undefined,
+                enabled: true,
+                order: 0,
+                width: 250,
+                path: undefined,
+                source: "default",
+                type: "standard",
+                format: undefined,
+                tooltip: undefined,
+              },
+              {
+                name: "scientificMetadata.sample.temperature",
+                header: "Temperature",
+                enabled: true,
+                order: 1,
+                width: 180,
+                path: "scientificMetadata.sample.temperature",
+                source: "user",
+                type: "custom",
+                format: undefined,
+                tooltip: "User-added custom column",
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    it("should default missing source metadata to default", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+
+      const setting: ITableSetting = {
+        columnSetting: [
+          {
+            name: "scientificMetadata.sample.temperature",
+            header: "Temperature",
+            path: "scientificMetadata.sample.temperature",
+            display: "visible",
+            type: "custom",
+            width: 180,
+          },
+        ],
+      };
+
+      component.saveTableSettings(setting);
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        updateUserSettingsAction({
+          property: {
+            columns: [
+              jasmine.objectContaining({
+                name: "scientificMetadata.sample.temperature",
+                source: "default",
+                type: "custom",
+              }),
+            ],
+          },
+        }),
+      );
     });
   });
 });

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -224,15 +224,20 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
   saveTableSettings(setting: ITableSetting) {
     this.pending = true;
     const columnsSetting = setting.columnSetting.map((column, index) => {
-      const { name, display, width, type, format } = column;
+      const { name, header, display, width, type, format, path, tooltip } =
+        column;
 
       return {
         name,
+        header,
         enabled: !!(display === "visible"),
         order: index,
         width,
+        path,
+        source: column.source ?? "default",
         type,
         format,
+        tooltip,
       };
     });
     this.store.dispatch(

--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -234,7 +234,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
         order: index,
         width,
         path,
-        source: column.source ?? "default",
+        userAdded: column.userAdded || undefined,
         type,
         format,
         tooltip,

--- a/src/app/shared/modules/dynamic-material-table/models/table-field.model.ts
+++ b/src/app/shared/modules/dynamic-material-table/models/table-field.model.ts
@@ -44,6 +44,7 @@ export interface AbstractField {
   index?: number;
   name: string /* The key of the data */;
   path?: string;
+  source?: "default" | "user";
   type?: FieldType /* Type of data in the field */;
   minWidth?: number /* min width of column */;
   width?: number /* width of column */;

--- a/src/app/shared/modules/dynamic-material-table/models/table-field.model.ts
+++ b/src/app/shared/modules/dynamic-material-table/models/table-field.model.ts
@@ -44,7 +44,7 @@ export interface AbstractField {
   index?: number;
   name: string /* The key of the data */;
   path?: string;
-  source?: "default" | "user";
+  userAdded?: boolean;
   type?: FieldType /* Type of data in the field */;
   minWidth?: number /* min width of column */;
   width?: number /* width of column */;

--- a/src/app/shared/services/datasets-list.service.ts
+++ b/src/app/shared/services/datasets-list.service.ts
@@ -122,6 +122,8 @@ export class DatasetsListService implements OnDestroy {
           index: column.order,
           display: column.enabled ? "visible" : "hidden",
           width: column.width,
+          path: column.path,
+          source: column.source ?? "default",
           type: column.type,
           format: column.format,
           tooltip: column.tooltip,

--- a/src/app/shared/services/datasets-list.service.ts
+++ b/src/app/shared/services/datasets-list.service.ts
@@ -123,7 +123,7 @@ export class DatasetsListService implements OnDestroy {
           display: column.enabled ? "visible" : "hidden",
           width: column.width,
           path: column.path,
-          source: column.source ?? "default",
+          userAdded: column.userAdded,
           type: column.type,
           format: column.format,
           tooltip: column.tooltip,

--- a/src/app/shared/services/table-config.service.spec.ts
+++ b/src/app/shared/services/table-config.service.spec.ts
@@ -53,7 +53,7 @@ describe("TableConfigService", () => {
         display: "visible" as const,
         index: 1,
         type: "custom" as const,
-        source: "user" as const,
+        userAdded: true,
       };
 
       const merged = service.mergeColumnSettings(defaultColumns, [

--- a/src/app/shared/services/table-config.service.spec.ts
+++ b/src/app/shared/services/table-config.service.spec.ts
@@ -1,0 +1,86 @@
+import { TableConfigService } from "./table-config.service";
+import { AbstractField } from "../modules/dynamic-material-table/models/table-field.model";
+
+describe("TableConfigService", () => {
+  let service: TableConfigService;
+
+  beforeEach(() => {
+    service = new TableConfigService();
+  });
+
+  describe("#mergeColumnSettings()", () => {
+    const defaultColumns: AbstractField[] = [
+      { name: "pid", header: "PID", display: "visible", width: 130 },
+      { name: "size", header: "Size", display: "hidden", width: 150 },
+      { name: "createdAt", header: "Created", display: "visible", width: 200 },
+    ];
+
+    it("merges saved settings with matching defaults and appends new defaults", () => {
+      const merged = service.mergeColumnSettings(defaultColumns, [
+        { name: "size", display: "visible", width: 220, index: 0 },
+        { name: "pid", display: "hidden", width: 140, index: 1 },
+      ]);
+
+      expect(merged).toEqual([
+        jasmine.objectContaining({
+          name: "size",
+          header: "Size",
+          display: "visible",
+          width: 220,
+          index: 0,
+        }),
+        jasmine.objectContaining({
+          name: "pid",
+          header: "PID",
+          display: "hidden",
+          width: 140,
+          index: 1,
+        }),
+        jasmine.objectContaining({
+          name: "createdAt",
+          header: "Created",
+          display: "visible",
+          width: 200,
+        }),
+      ]);
+    });
+
+    it("preserves user-added columns that are not part of defaults", () => {
+      const customColumn = {
+        name: "scientificMetadata.sample.temperature",
+        header: "Temperature",
+        path: "scientificMetadata.sample.temperature",
+        display: "visible" as const,
+        index: 1,
+        type: "custom" as const,
+        source: "user" as const,
+      };
+
+      const merged = service.mergeColumnSettings(defaultColumns, [
+        { name: "pid", display: "visible", index: 0 },
+        customColumn,
+      ]);
+
+      expect(merged).toEqual([
+        jasmine.objectContaining({ name: "pid" }),
+        customColumn,
+        jasmine.objectContaining({ name: "size" }),
+        jasmine.objectContaining({ name: "createdAt" }),
+      ]);
+    });
+
+    it("drops unknown saved columns that are not marked as user-added", () => {
+      const merged = service.mergeColumnSettings(defaultColumns, [
+        { name: "pid", display: "visible", index: 0 },
+        { name: "oldColumn", header: "Old", display: "visible", index: 1 },
+      ]);
+
+      expect(merged.some((column) => column.name === "oldColumn")).toBeFalse();
+      expect(merged.map((column) => column.name)).toEqual([
+        "pid",
+        "size",
+        "createdAt",
+      ]);
+    });
+  });
+});

--- a/src/app/shared/services/table-config.service.ts
+++ b/src/app/shared/services/table-config.service.ts
@@ -42,7 +42,7 @@ export class TableConfigService {
     const defaultMap = new Map(defaultColumnSetting.map((c) => [c.name, c]));
 
     // Merge saved columns that still exist in defaults and preserve
-    // user-added columns that intentionally do not exist in defaults.
+    // explicitly user-added columns that intentionally do not exist in defaults.
     const mergedColumns = savedColumnSetting
       .map((saved) => {
         const defCol = defaultMap.get(saved.name);
@@ -53,7 +53,7 @@ export class TableConfigService {
           };
         }
 
-        return saved.source === "user" ? saved : null;
+        return saved.userAdded ? saved : null;
       })
       .filter(Boolean);
 

--- a/src/app/shared/services/table-config.service.ts
+++ b/src/app/shared/services/table-config.service.ts
@@ -41,11 +41,19 @@ export class TableConfigService {
   ) {
     const defaultMap = new Map(defaultColumnSetting.map((c) => [c.name, c]));
 
-    // Merge saved columns that still exist in defaults
+    // Merge saved columns that still exist in defaults and preserve
+    // user-added columns that intentionally do not exist in defaults.
     const mergedColumns = savedColumnSetting
       .map((saved) => {
         const defCol = defaultMap.get(saved.name);
-        return defCol ? { ...defCol, ...saved } : null;
+        if (defCol) {
+          return {
+            ...defCol,
+            ...saved,
+          };
+        }
+
+        return saved.source === "user" ? saved : null;
       })
       .filter(Boolean);
 

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -15,7 +15,7 @@ export interface TableColumn {
   name: string;
   header?: string;
   path?: string;
-  source?: "default" | "user";
+  userAdded?: boolean;
   order: number;
   type: "standard" | "custom" | "date" | "hoverContent" | "editable";
   enabled: boolean;

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -15,6 +15,7 @@ export interface TableColumn {
   name: string;
   header?: string;
   path?: string;
+  source?: "default" | "user";
   order: number;
   type: "standard" | "custom" | "date" | "hoverContent" | "editable";
   enabled: boolean;


### PR DESCRIPTION
## Description
Add source field to saved settings. If source == "user" the column will be shown even if not part of default settings.


## Motivation
Ground work to allow user added columns to be shown even if they are not part of default columns. Currently all columns that are not part of default columns are dropped.


## Changes:
New field source in saved settings. Header, path and tooltip are also saved, since those could be missing if there is no matching default column.


## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

Still interested in knowing where to update...?

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Add support for persisting and restoring user-added dataset table columns, including their metadata, so they remain visible even when not part of the default column configuration.

New Features:
- Persist the source, header, path, and tooltip metadata for dataset table columns in user settings to distinguish default from user-added columns.
- Allow user-added columns to be retained and merged into table configurations even when they do not exist in the default column set.

Enhancements:
- Extend table column and field models to include a source flag indicating whether a column is default or user-defined.
- Propagate the new column metadata through dataset table save/load flows to ensure consistent behavior across the UI and settings.

Tests:
- Add unit tests for dataset table settings persistence and table configuration merging to cover user-added columns and default source behavior.