### PR TITLE
fix: use new sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@ngrx/store": "^19.1.0",
         "@ngx-translate/core": "^17.0.0",
         "@ngxmc/datetime-picker": "^19.3.1",
-        "@scicatproject/scicat-sdk-ts-angular": "^4.27.0",
+        "@scicatproject/scicat-sdk-ts-angular": "^5.1.1",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "ajv-keywords": "^5.1.0",
@@ -6527,9 +6527,10 @@
       }
     },
     "node_modules/@scicatproject/scicat-sdk-ts-angular": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-angular/-/scicat-sdk-ts-angular-4.27.0.tgz",
-      "integrity": "sha512-CidcWzGW1uVgsf+Xz/KWbK+fF1vpyA4MVQ/idatudzXX7woySmVi30v7hsAZfvZxlE+mQlDM74hfKYVR2hT8Kg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-angular/-/scicat-sdk-ts-angular-5.1.1.tgz",
+      "integrity": "sha512-HKrRwThKJk1PDQ8ZgGZaqaKX6k8o4+julK2hCri9y40NRyIv4beTWM/1mwd9xQP6wwxKxEcvnZe3whRQsH3Hsg==",
+      "license": "Unlicense",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@ngrx/store": "^19.1.0",
     "@ngx-translate/core": "^17.0.0",
     "@ngxmc/datetime-picker": "^19.3.1",
-    "@scicatproject/scicat-sdk-ts-angular": "^4.27.0",
+    "@scicatproject/scicat-sdk-ts-angular": "^5.1.1",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "ajv-keywords": "^5.1.0",

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
@@ -45,7 +45,7 @@ import {
   OutputDatasetObsoleteDto,
   ProposalClass,
   ReturnedUserDto,
-  SampleClass,
+  OutputSampleDto,
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { AttachmentService } from "shared/services/attachment.service";
 
@@ -80,7 +80,7 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
   loading$ = this.store.select(selectIsLoading);
   instrument: Instrument | undefined;
   proposal: ProposalClass | undefined;
-  sample: SampleClass | undefined;
+  sample: OutputSampleDto | undefined;
   user: ReturnedUserDto | undefined;
   editingAllowed = false;
   editEnabled = false;

--- a/src/app/datasets/sample-edit/sample-edit.component.spec.ts
+++ b/src/app/datasets/sample-edit/sample-edit.component.spec.ts
@@ -31,7 +31,7 @@ import {
 } from "state-management/actions/samples.actions";
 
 import { SampleEditComponent } from "./sample-edit.component";
-import { SampleClass } from "@scicatproject/scicat-sdk-ts-angular";
+import { OutputSampleDto } from "@scicatproject/scicat-sdk-ts-angular";
 
 describe("SampleEditComponent", () => {
   let component: SampleEditComponent;
@@ -162,7 +162,7 @@ describe("SampleEditComponent", () => {
     it("should return false if sample in form has same id as current sample", () => {
       const sampleId = "abc123";
 
-      const sample = createMock<SampleClass>({
+      const sample = createMock<OutputSampleDto>({
         sampleId,
         owner: "test",
         description: "test",
@@ -187,7 +187,7 @@ describe("SampleEditComponent", () => {
     it("should return true if form is valid", () => {
       const sampleId = "abc123";
 
-      const sample = createMock<SampleClass>({
+      const sample = createMock<OutputSampleDto>({
         sampleId: "123abc",
         owner: "test",
         description: "test",
@@ -224,7 +224,7 @@ describe("SampleEditComponent", () => {
     it("should close the dialog and emit data", () => {
       const dialogCloseSpy = spyOn(component.dialogRef, "close");
 
-      const sample = createMock<SampleClass>({
+      const sample = createMock<OutputSampleDto>({
         sampleId: "123abc",
         owner: "test",
         description: "test",

--- a/src/app/datasets/sample-edit/sample-edit.component.ts
+++ b/src/app/datasets/sample-edit/sample-edit.component.ts
@@ -21,7 +21,7 @@ import {
   PageChangeEvent,
   SortChangeEvent,
 } from "shared/modules/table/table.component";
-import { SampleClass } from "@scicatproject/scicat-sdk-ts-angular";
+import { OutputSampleDto } from "@scicatproject/scicat-sdk-ts-angular";
 import {
   changePageAction,
   fetchSamplesAction,
@@ -58,7 +58,7 @@ export class SampleEditComponent implements OnInit, OnDestroy {
     );
 
   samplesSubscription: Subscription = new Subscription();
-  samples: SampleClass[] = [];
+  samples: OutputSampleDto[] = [];
 
   selectedSampleId = "";
   displayedColumns = [
@@ -70,7 +70,7 @@ export class SampleEditComponent implements OnInit, OnDestroy {
   ];
 
   form = new FormGroup({
-    sample: new FormControl<SampleClass>(null, [
+    sample: new FormControl<OutputSampleDto>(null, [
       Validators.required,
       this.sampleValidator(),
     ]),
@@ -129,7 +129,7 @@ export class SampleEditComponent implements OnInit, OnDestroy {
       sortByColumnAction({ column: event.active, direction: event.direction }),
     );
 
-  onRowClick = (sample: SampleClass): void => {
+  onRowClick = (sample: OutputSampleDto): void => {
     this.selectedSampleId = sample.sampleId;
     this.sample?.setValue(sample);
   };

--- a/src/app/samples/sample-dashboard/sample-dashboard.component.ts
+++ b/src/app/samples/sample-dashboard/sample-dashboard.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy, ViewChild } from "@angular/core";
 import { Store } from "@ngrx/store";
-import { SampleClass } from "@scicatproject/scicat-sdk-ts-angular";
+import { OutputSampleDto } from "@scicatproject/scicat-sdk-ts-angular";
 import {
   changePageAction,
   fetchSamplesAction,
@@ -125,8 +125,8 @@ export class SampleDashboardComponent implements OnInit, OnDestroy {
 
   paginationMode: TablePaginationMode = "server-side";
 
-  dataSource: BehaviorSubject<SampleClass[]> = new BehaviorSubject<
-    SampleClass[]
+  dataSource: BehaviorSubject<OutputSampleDto[]> = new BehaviorSubject<
+    OutputSampleDto[]
   >([]);
 
   pagination: TablePagination = {};
@@ -228,7 +228,7 @@ export class SampleDashboardComponent implements OnInit, OnDestroy {
     );
   };
 
-  formatTableData(samples: SampleClass[]): any {
+  formatTableData(samples: OutputSampleDto[]): any {
     if (samples) {
       return samples.map((sample) => ({
         sampleId: sample.sampleId,
@@ -363,7 +363,7 @@ export class SampleDashboardComponent implements OnInit, OnDestroy {
     }
   }
 
-  onRowClick(event: IRowEvent<SampleClass>) {
+  onRowClick(event: IRowEvent<OutputSampleDto>) {
     if (event.event === RowEventType.RowClick) {
       const id = encodeURIComponent(event.sender.row.sampleId);
       this.router.navigateByUrl("/samples/" + id);

--- a/src/app/samples/sample-detail/sample-detail.component.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.ts
@@ -31,7 +31,7 @@ import {
   OutputAttachmentV3Dto,
   OutputDatasetObsoleteDto,
   ReturnedUserDto,
-  SampleClass,
+  OutputSampleDto,
 } from "@scicatproject/scicat-sdk-ts-angular";
 
 export interface TableData {
@@ -58,7 +58,7 @@ export class SampleDetailComponent
 
   appConfig = this.appConfigService.getConfig();
 
-  sample: SampleClass;
+  sample: OutputSampleDto;
   user: ReturnedUserDto;
   attachment: CreateAttachmentV3Dto;
   attachments: OutputAttachmentV3Dto[] = [];

--- a/src/app/samples/sample-dialog/sample-dialog.component.ts
+++ b/src/app/samples/sample-dialog/sample-dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit, OnDestroy } from "@angular/core";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
-import { SampleClass } from "@scicatproject/scicat-sdk-ts-angular";
+import { OutputSampleDto } from "@scicatproject/scicat-sdk-ts-angular";
 import { Store } from "@ngrx/store";
 import {
   addSampleAction,
@@ -23,7 +23,7 @@ export class SampleDialogComponent implements OnInit, OnDestroy {
   private vm$ = this.store.select(selectSampleDialogPageViewModel);
   public form: FormGroup;
   description: string;
-  sample: SampleClass;
+  sample: OutputSampleDto;
 
   username = "";
   userGroups: string[] | undefined;
@@ -34,7 +34,7 @@ export class SampleDialogComponent implements OnInit, OnDestroy {
     private fb: FormBuilder,
     public dialogRef: MatDialogRef<SampleDialogComponent>,
     @Inject(MAT_DIALOG_DATA)
-    { description, sampleCharacteristics, ownerGroup }: SampleClass,
+    { description, sampleCharacteristics, ownerGroup }: OutputSampleDto,
   ) {
     this.description = description;
 

--- a/src/app/shared/MockStubs.ts
+++ b/src/app/shared/MockStubs.ts
@@ -15,7 +15,7 @@ import {
   OutputDatasetObsoleteDto,
   ProposalClass,
   PublishedData,
-  SampleClass,
+  OutputSampleDto,
   Logbook,
   Policy,
   ReturnedUserDto,
@@ -339,7 +339,7 @@ export function createMock<T>(data?: Partial<T>): T {
 
 export const mockDataset = createMock<OutputDatasetObsoleteDto>({});
 export const mockAttachment = createMock<OutputAttachmentV3Dto>({});
-export const mockSample = createMock<SampleClass>({});
+export const mockSample = createMock<OutputSampleDto>({});
 export const mockProposal = createMock<ProposalClass>({});
 export const mockInstrument = createMock<Instrument>({});
 export const mockOrigDatablock = createMock<OrigDatablock>({});

--- a/src/app/state-management/actions/samples.actions.ts
+++ b/src/app/state-management/actions/samples.actions.ts
@@ -3,14 +3,14 @@ import {
   CreateAttachmentV3Dto,
   OutputAttachmentV3Dto,
   OutputDatasetObsoleteDto,
-  SampleClass,
+  OutputSampleDto,
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { SampleFilters, ScientificCondition } from "state-management/models";
 
 export const fetchSamplesAction = createAction("[Sample] Fetch Samples");
 export const fetchSamplesCompleteAction = createAction(
   "[Sample] Fetch Samples Complete",
-  props<{ samples: SampleClass[] }>(),
+  props<{ samples: OutputSampleDto[] }>(),
 );
 export const fetchSamplesFailedAction = createAction(
   "[Sample] Fetch Samples Failed",
@@ -44,7 +44,7 @@ export const fetchSampleAction = createAction(
 );
 export const fetchSampleCompleteAction = createAction(
   "[Sample] Fetch Sample Complete",
-  props<{ sample: SampleClass }>(),
+  props<{ sample: OutputSampleDto }>(),
 );
 export const fetchSampleFailedAction = createAction(
   "[Sample] Fetch Sample Failed",
@@ -90,11 +90,11 @@ export const fetchSampleDatasetsCountFailedAction = createAction(
 
 export const addSampleAction = createAction(
   "[Sample] Add Sample",
-  props<{ sample: SampleClass }>(),
+  props<{ sample: OutputSampleDto }>(),
 );
 export const addSampleCompleteAction = createAction(
   "[Sample] Add Sample Complete",
-  props<{ sample: SampleClass }>(),
+  props<{ sample: OutputSampleDto }>(),
 );
 export const addSampleFailedAction = createAction("[Sample] Add Sample Failed");
 
@@ -104,7 +104,7 @@ export const saveCharacteristicsAction = createAction(
 );
 export const saveCharacteristicsCompleteAction = createAction(
   "[Sample] Save Characteristics Complete",
-  props<{ sample: SampleClass }>(),
+  props<{ sample: OutputSampleDto }>(),
 );
 export const saveCharacteristicsFailedAction = createAction(
   "[Sample] Save Characteristics Failed",

--- a/src/app/state-management/effects/datasets.effects.ts
+++ b/src/app/state-management/effects/datasets.effects.ts
@@ -227,7 +227,7 @@ export class DatasetEffects {
           };
         }
         return this.datasetsService
-          .datasetsControllerFindAllV3(JSON.stringify(queryFilter))
+          .datasetsControllerFindAllV3(queryFilter)
           .pipe(
             map((relatedDatasets) =>
               fromActions.fetchRelatedDatasetsCompleteAction({

--- a/src/app/state-management/effects/jobs.effects.ts
+++ b/src/app/state-management/effects/jobs.effects.ts
@@ -30,7 +30,7 @@ export class JobEffects {
       concatLatestFrom(() => this.queryParams$),
       map(([action, params]) => params),
       switchMap((params) =>
-        this.jobsService.jobsControllerFindAllV3(JSON.stringify(params)).pipe(
+        this.jobsService.jobsControllerFindAllV3(params).pipe(
           switchMap((jobs) => [
             fromActions.fetchJobsCompleteAction({ jobs }),
             fromActions.fetchCountAction(),

--- a/src/app/state-management/effects/proposals.effects.ts
+++ b/src/app/state-management/effects/proposals.effects.ts
@@ -116,18 +116,16 @@ export class ProposalEffects {
       ofType(fromActions.fetchProposalDatasetsAction),
       mergeMap(({ skip, limit, sortColumn, sortDirection, proposalId }) => {
         return this.datasetsService
-          .datasetsControllerFindAllV3(
-            JSON.stringify({
-              where: { proposalId },
-              limits: {
-                skip: skip,
-                limit: limit,
-                order: sortDirection
-                  ? `${sortColumn}:${sortDirection}`
-                  : undefined,
-              },
-            }),
-          )
+          .datasetsControllerFindAllV3({
+            where: { proposalId },
+            limits: {
+              skip: skip,
+              limit: limit,
+              order: sortDirection
+                ? `${sortColumn}:${sortDirection}`
+                : undefined,
+            },
+          })
           .pipe(
             mergeMap((datasets) => [
               fromActions.fetchProposalDatasetsCompleteAction({

--- a/src/app/state-management/effects/published-data.effects.ts
+++ b/src/app/state-management/effects/published-data.effects.ts
@@ -363,11 +363,9 @@ export class PublishedDataEffects {
       ofType(fromActions.fetchRelatedDatasetsAndAddToBatchAction),
       switchMap(({ datasetPids, publishedDataDoi }) =>
         this.datasetsV4Service
-          .datasetsV4ControllerFindAllV4(
-            JSON.stringify({
-              where: { pid: { $in: datasetPids } },
-            }),
-          )
+          .datasetsV4ControllerFindAllV4({
+            where: { pid: { $in: datasetPids } },
+          })
           .pipe(
             mergeMap((datasets) => [
               datasetActions.clearBatchAction(),

--- a/src/app/state-management/effects/samples.effects.spec.ts
+++ b/src/app/state-management/effects/samples.effects.spec.ts
@@ -16,7 +16,7 @@ import {
 import { Type } from "@angular/core";
 import {
   DatasetsService,
-  SampleClass,
+  OutputSampleDto,
   SamplesService,
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { TestObservable } from "jasmine-marbles/src/test-observables";
@@ -26,7 +26,7 @@ import {
   mockAttachment as attachment,
 } from "shared/MockStubs";
 
-const sample = createMock<SampleClass>({
+const sample = createMock<OutputSampleDto>({
   sampleId: "testId",
   ownerGroup: "testGroup",
   createdBy: "",

--- a/src/app/state-management/effects/samples.effects.ts
+++ b/src/app/state-management/effects/samples.effects.ts
@@ -131,14 +131,12 @@ export class SampleEffects {
       concatLatestFrom(() => this.datasetsQueryParams$),
       mergeMap(([{ sampleId }, { order, skip, limit }]) =>
         this.datasetApi
-          .datasetsControllerFindAllV3(
-            JSON.stringify({
-              where: { sampleId },
-              order,
-              skip,
-              limit,
-            }),
-          )
+          .datasetsControllerFindAllV3({
+            where: { sampleId },
+            order,
+            skip,
+            limit,
+          })
           .pipe(
             mergeMap((datasets) => [
               fromActions.fetchSampleDatasetsCompleteAction({ datasets }),
@@ -155,7 +153,7 @@ export class SampleEffects {
       ofType(fromActions.fetchSampleDatasetsCountAction),
       switchMap(({ sampleId }) =>
         this.datasetApi
-          .datasetsControllerFindAllV3(JSON.stringify({ where: { sampleId } }))
+          .datasetsControllerFindAllV3({ where: { sampleId } })
           .pipe(
             map((datasets) =>
               fromActions.fetchSampleDatasetsCountCompleteAction({

--- a/src/app/state-management/reducers/samples.reducer.spec.ts
+++ b/src/app/state-management/reducers/samples.reducer.spec.ts
@@ -7,9 +7,9 @@ import {
   mockDataset as dataset,
   mockAttachment as attachment,
 } from "shared/MockStubs";
-import { SampleClass } from "@scicatproject/scicat-sdk-ts-angular";
+import { OutputSampleDto } from "@scicatproject/scicat-sdk-ts-angular";
 
-const sample = createMock<SampleClass>({
+const sample = createMock<OutputSampleDto>({
   sampleId: "testId",
   ownerGroup: "testGroup",
   createdBy: "",

--- a/src/app/state-management/selectors/samples.selectors.spec.ts
+++ b/src/app/state-management/selectors/samples.selectors.spec.ts
@@ -2,9 +2,9 @@ import * as fromSelectors from "./samples.selectors";
 import { SampleState } from "state-management/state/samples.store";
 import { initialUserState } from "state-management/state/user.store";
 import { createMock } from "shared/MockStubs";
-import { SampleClass } from "@scicatproject/scicat-sdk-ts-angular";
+import { OutputSampleDto } from "@scicatproject/scicat-sdk-ts-angular";
 
-const sample = createMock<SampleClass>({
+const sample = createMock<OutputSampleDto>({
   sampleId: "testId",
   ownerGroup: "testGroup",
   createdBy: "",

--- a/src/app/state-management/state/samples.store.ts
+++ b/src/app/state-management/state/samples.store.ts
@@ -1,14 +1,14 @@
 import {
   OutputAttachmentV3Dto,
   OutputDatasetObsoleteDto,
-  SampleClass,
+  OutputSampleDto,
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { SampleFilters, GenericFilters } from "state-management/models";
 
 export interface SampleState {
-  samples: SampleClass[];
+  samples: OutputSampleDto[];
   attachments: OutputAttachmentV3Dto[];
-  currentSample: SampleClass | undefined;
+  currentSample: OutputSampleDto | undefined;
   datasets: OutputDatasetObsoleteDto[];
   metadataKeys: string[];
 


### PR DESCRIPTION
## Description
Update sdk calls for next release:
- Replace `SampleClass` by `OutputSampleDto`
- `filter` query param are passed as objects rather than a json string

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Update frontend to use the new SDK data model for samples and query parameters.

Bug Fixes:
- Adjust dataset and job API calls to pass filter parameters as objects instead of JSON strings to match the updated SDK interface.

Enhancements:
- Replace usages of SampleClass with OutputSampleDto across state, components, and tests to align with the new SDK contract.

Tests:
- Update unit tests and shared mocks to use OutputSampleDto and the new API call signatures.