### PR TITLE
feat: add deleted view when using jobs

### DIFF
--- a/src/app/datasets/dataset-table-actions/dataset-table-actions.component.spec.ts
+++ b/src/app/datasets/dataset-table-actions/dataset-table-actions.component.spec.ts
@@ -105,6 +105,18 @@ describe("DatasetTableActionsComponent", () => {
         setArchiveViewModeAction({ modeToggle }),
       );
     });
+
+    it("should dispatch selected non-default archive mode", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+      const modeToggle = ArchViewMode.deleted;
+
+      component.onModeChange(modeToggle);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        setArchiveViewModeAction({ modeToggle }),
+      );
+    });
   });
 
   describe("#isEmptySelection()", () => {

--- a/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
+++ b/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
@@ -38,6 +38,7 @@ export class DatasetTableActionsComponent implements OnInit, OnDestroy {
     ArchViewMode.work_in_progress,
     ArchViewMode.system_error,
     ArchViewMode.user_error,
+    ArchViewMode.deleted,
   ];
 
   searchPublicDataEnabled = this.appConfig.searchPublicDataEnabled;

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
@@ -3,6 +3,7 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from "@angular/common/http";
+import { Location } from "@angular/common";
 import { of } from "rxjs";
 import { MockStore } from "shared/MockStubs";
 import { BreadcrumbComponent } from "./breadcrumb.component";
@@ -49,12 +50,14 @@ describe("BreadcrumbComponent", () => {
   });
 
   it("should dispatch setFiltersAction and setArchiveViewModeAction for datasets breadcrumb", () => {
-    const dispatchSpy = spyOn(store as any, "dispatch");
-    const selectSpy = spyOn(store as any, "select").and.returnValues(
-      of({ text: "abc", skip: 7 }) as any,
-      of(ArchViewMode.deleted) as any,
+    const dispatchSpy = spyOn(store, "dispatch");
+    const selectSpy = spyOn(store, "select").and.returnValues(
+      of({ text: "abc", skip: 7 }) as unknown as ReturnType<
+        MockStore["select"]
+      >,
+      of(ArchViewMode.deleted) as unknown as ReturnType<MockStore["select"]>,
     );
-    const backSpy = spyOn((component as any).location, "back");
+    const backSpy = spyOn(TestBed.inject(Location), "back");
     const crumb = {
       label: "datasets",
       path: "datasets",
@@ -67,7 +70,7 @@ describe("BreadcrumbComponent", () => {
 
     expect(selectSpy).toHaveBeenCalledTimes(2);
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect((dispatchSpy.calls.argsFor(0) as any[])[0]).toEqual(
+    expect((dispatchSpy.calls.argsFor(0) as object)[0]).toEqual(
       setFiltersAction({
         datasetFilters: {
           text: "abc",
@@ -75,7 +78,7 @@ describe("BreadcrumbComponent", () => {
         },
       }),
     );
-    expect((dispatchSpy.calls.argsFor(1) as any[])[0]).toEqual(
+    expect((dispatchSpy.calls.argsFor(1) as object)[0]).toEqual(
       setArchiveViewModeAction({ modeToggle: ArchViewMode.deleted }),
     );
     expect(backSpy).toHaveBeenCalled();

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
@@ -3,14 +3,22 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from "@angular/common/http";
+import { of } from "rxjs";
 import { MockStore } from "shared/MockStubs";
 import { BreadcrumbComponent } from "./breadcrumb.component";
 import { Store } from "@ngrx/store";
-import { provideRouter } from "@angular/router";
+import { provideRouter, Router } from "@angular/router";
+import { ArchViewMode } from "state-management/models";
+import {
+  prefillFiltersAction,
+  setArchiveViewModeAction,
+} from "state-management/actions/datasets.actions";
 
 describe("BreadcrumbComponent", () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
+  let store: MockStore;
+  let router: Router;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -27,6 +35,8 @@ describe("BreadcrumbComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(BreadcrumbComponent);
     component = fixture.componentInstance;
+    store = TestBed.inject(Store) as unknown as MockStore;
+    router = TestBed.inject(Router);
     fixture.detectChanges();
   });
 
@@ -36,5 +46,51 @@ describe("BreadcrumbComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should dispatch prefillFiltersAction and setArchiveViewModeAction for datasets breadcrumb", () => {
+    const dispatchSpy = spyOn(store as any, "dispatch");
+    const selectSpy = spyOn(store as any, "select").and.returnValues(
+      of({ text: "abc" }) as any,
+      of(ArchViewMode.deleted) as any,
+    );
+    const backSpy = spyOn((component as any).location, "back");
+    const crumb = {
+      label: "datasets",
+      path: "datasets",
+      params: {},
+      url: "/datasets",
+      fallback: "/datasets",
+    };
+
+    component.crumbClick(0, crumb);
+
+    expect(selectSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect((dispatchSpy.calls.argsFor(0) as any[])[0]).toEqual(
+      prefillFiltersAction({ values: { text: "abc" } }),
+    );
+    expect((dispatchSpy.calls.argsFor(1) as any[])[0]).toEqual(
+      setArchiveViewModeAction({ modeToggle: ArchViewMode.deleted }),
+    );
+    expect(backSpy).toHaveBeenCalled();
+  });
+
+  it("should navigate by url for non-datasets breadcrumb", async () => {
+    const navigateSpy = spyOn(router, "navigateByUrl").and.returnValue(
+      Promise.resolve(true),
+    );
+    const crumb = {
+      label: "about",
+      path: "about",
+      params: {},
+      url: "/about",
+      fallback: "/about",
+    };
+
+    component.crumbClick(0, crumb);
+    await fixture.whenStable();
+
+    expect(navigateSpy).toHaveBeenCalledWith("/about");
   });
 });

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
@@ -10,8 +10,8 @@ import { Store } from "@ngrx/store";
 import { provideRouter, Router } from "@angular/router";
 import { ArchViewMode } from "state-management/models";
 import {
-  prefillFiltersAction,
   setArchiveViewModeAction,
+  setFiltersAction,
 } from "state-management/actions/datasets.actions";
 
 describe("BreadcrumbComponent", () => {
@@ -48,10 +48,10 @@ describe("BreadcrumbComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should dispatch prefillFiltersAction and setArchiveViewModeAction for datasets breadcrumb", () => {
+  it("should dispatch setFiltersAction and setArchiveViewModeAction for datasets breadcrumb", () => {
     const dispatchSpy = spyOn(store as any, "dispatch");
     const selectSpy = spyOn(store as any, "select").and.returnValues(
-      of({ text: "abc" }) as any,
+      of({ text: "abc", skip: 7 }) as any,
       of(ArchViewMode.deleted) as any,
     );
     const backSpy = spyOn((component as any).location, "back");
@@ -68,7 +68,12 @@ describe("BreadcrumbComponent", () => {
     expect(selectSpy).toHaveBeenCalledTimes(2);
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
     expect((dispatchSpy.calls.argsFor(0) as any[])[0]).toEqual(
-      prefillFiltersAction({ values: { text: "abc" } }),
+      setFiltersAction({
+        datasetFilters: {
+          text: "abc",
+          skip: 7,
+        },
+      }),
     );
     expect((dispatchSpy.calls.argsFor(1) as any[])[0]).toEqual(
       setArchiveViewModeAction({ modeToggle: ArchViewMode.deleted }),

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
@@ -53,7 +53,7 @@ export class BreadcrumbComponent implements OnInit {
     // Update breadcrumb when navigating to child routes
     this.router.events
       .pipe(filter((event) => event instanceof NavigationEnd))
-      .subscribe((event) => {
+      .subscribe(() => {
         this.setBreadcrumbs();
       });
   }
@@ -123,14 +123,16 @@ export class BreadcrumbComponent implements OnInit {
         this.store.select(selectFilters).pipe(take(1)),
         this.store.select(selectArchiveViewMode).pipe(take(1)),
       ]).subscribe(([filters, modeToggle]) => {
-        this.store.dispatch(setFiltersAction({ datasetFilters: { ...filters } }));
+        this.store.dispatch(
+          setFiltersAction({ datasetFilters: { ...filters } }),
+        );
         this.store.dispatch(setArchiveViewModeAction({ modeToggle }));
         this.location.back();
       });
     } else {
       this.router
         .navigateByUrl(url + crumb.url)
-        .catch((error) => this.router.navigateByUrl(url + crumb.fallback));
+        .catch(() => this.router.navigateByUrl(url + crumb.fallback));
     }
   }
 }

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
@@ -11,7 +11,7 @@ import { take, filter } from "rxjs/operators";
 import { TitleCasePipe } from "shared/pipes/title-case.pipe";
 import { Location } from "@angular/common";
 import {
-  prefillFiltersAction,
+  setFiltersAction,
   setArchiveViewModeAction,
 } from "state-management/actions/datasets.actions";
 
@@ -123,7 +123,7 @@ export class BreadcrumbComponent implements OnInit {
         this.store.select(selectFilters).pipe(take(1)),
         this.store.select(selectArchiveViewMode).pipe(take(1)),
       ]).subscribe(([filters, modeToggle]) => {
-        this.store.dispatch(prefillFiltersAction({ values: { ...filters } }));
+        this.store.dispatch(setFiltersAction({ datasetFilters: { ...filters } }));
         this.store.dispatch(setArchiveViewModeAction({ modeToggle }));
         this.location.back();
       });

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { Router, ActivatedRoute, NavigationEnd, Params } from "@angular/router";
 import { Store } from "@ngrx/store";
+import { combineLatest } from "rxjs";
 
 import {
   selectArchiveViewMode,
@@ -8,8 +9,11 @@ import {
 } from "state-management/selectors/datasets.selectors";
 import { take, filter } from "rxjs/operators";
 import { TitleCasePipe } from "shared/pipes/title-case.pipe";
-import { ArchViewMode } from "state-management/models";
 import { Location } from "@angular/common";
+import {
+  prefillFiltersAction,
+  setArchiveViewModeAction,
+} from "state-management/actions/datasets.actions";
 
 interface Breadcrumb {
   label: string;
@@ -115,18 +119,14 @@ export class BreadcrumbComponent implements OnInit {
     }
     // this catches errors and redirects to the fallback, this could/should be set in the routing module?
     if (crumb.fallback === "/datasets") {
-      this.store
-        .select(selectFilters)
-        .pipe(take(1))
-        .subscribe((filters) => {
-          this.store
-            .select(selectArchiveViewMode)
-            .pipe(take(1))
-            .subscribe((currentMode) => {
-              filters["mode"] = setMode(currentMode);
-              this.location.back();
-            });
-        });
+      combineLatest([
+        this.store.select(selectFilters).pipe(take(1)),
+        this.store.select(selectArchiveViewMode).pipe(take(1)),
+      ]).subscribe(([filters, modeToggle]) => {
+        this.store.dispatch(prefillFiltersAction({ values: { ...filters } }));
+        this.store.dispatch(setArchiveViewModeAction({ modeToggle }));
+        this.location.back();
+      });
     } else {
       this.router
         .navigateByUrl(url + crumb.url)
@@ -134,62 +134,3 @@ export class BreadcrumbComponent implements OnInit {
     }
   }
 }
-
-const setMode = (modeToggle: ArchViewMode) => {
-  switch (modeToggle) {
-    case ArchViewMode.all:
-      return {};
-    case ArchViewMode.archivable:
-      return {
-        "datasetlifecycle.archivable": true,
-        "datasetlifecycle.retrievable": false,
-      };
-    case ArchViewMode.retrievable:
-      return {
-        "datasetlifecycle.retrievable": true,
-        "datasetlifecycle.archivable": false,
-      };
-    case ArchViewMode.work_in_progress:
-      return {
-        $or: [
-          {
-            "datasetlifecycle.retrievable": false,
-            "datasetlifecycle.archivable": false,
-            "datasetlifecycle.archiveStatusMessage": {
-              $ne: "scheduleArchiveJobFailed",
-            },
-            "datasetlifecycle.retrieveStatusMessage": {
-              $ne: "scheduleRetrieveJobFailed",
-            },
-          },
-        ],
-      };
-    case ArchViewMode.system_error:
-      return {
-        $or: [
-          {
-            "datasetlifecycle.retrievable": true,
-            "datasetlifecycle.archivable": true,
-          },
-          {
-            "datasetlifecycle.archiveStatusMessage": "scheduleArchiveJobFailed",
-          },
-          {
-            "datasetlifecycle.retrieveStatusMessage":
-              "scheduleRetrieveJobFailed",
-          },
-        ],
-      };
-    case ArchViewMode.user_error:
-      return {
-        $or: [
-          {
-            "datasetlifecycle.archiveStatusMessage": "missingFilesError",
-          },
-        ],
-      };
-    default: {
-      return {};
-    }
-  }
-};

--- a/src/app/shared/services/datasets-list.service.ts
+++ b/src/app/shared/services/datasets-list.service.ts
@@ -112,6 +112,14 @@ export class DatasetsListService implements OnDestroy {
     return false;
   }
 
+  deletedCondition(dataset: DatasetClass): boolean {
+    if (dataset.datasetlifecycle.archiveStatusMessage === "deleted") {
+      return true;
+    }
+    return false;
+  }
+
+
   convertSavedDatasetColumns(columns: TableColumn[]): TableField<any>[] {
     return columns
       .filter((column) => column.name !== "select")
@@ -188,6 +196,8 @@ export class DatasetsListService implements OnDestroy {
               return "Archivable";
             } else if (this.retrievableCondition(row)) {
               return "Retrievable";
+            } else if (this.deletedCondition(row)) {
+              return "Deleted";
             } else if (this.systemErrorCondition(row)) {
               return "System error";
             } else if (this.userErrorCondition(row)) {
@@ -204,6 +214,8 @@ export class DatasetsListService implements OnDestroy {
               return "Archivable";
             } else if (this.retrievableCondition(row)) {
               return "Retrievable";
+            } else if (this.deletedCondition(row)) {
+              return "Deleted";
             } else if (this.systemErrorCondition(row)) {
               return "System error";
             } else if (this.userErrorCondition(row)) {

--- a/src/app/shared/services/datasets-list.service.ts
+++ b/src/app/shared/services/datasets-list.service.ts
@@ -113,10 +113,7 @@ export class DatasetsListService implements OnDestroy {
   }
 
   deletedCondition(dataset: DatasetClass): boolean {
-    if (dataset.datasetlifecycle.archiveStatusMessage === "deleted") {
-      return true;
-    }
-    return false;
+    return dataset.datasetlifecycle.archiveStatusMessage === "deleted";
   }
 
   convertSavedDatasetColumns(columns: TableColumn[]): TableField<any>[] {

--- a/src/app/shared/services/datasets-list.service.ts
+++ b/src/app/shared/services/datasets-list.service.ts
@@ -119,7 +119,6 @@ export class DatasetsListService implements OnDestroy {
     return false;
   }
 
-
   convertSavedDatasetColumns(columns: TableColumn[]): TableField<any>[] {
     return columns
       .filter((column) => column.name !== "select")

--- a/src/app/state-management/actions/datasets.actions.ts
+++ b/src/app/state-management/actions/datasets.actions.ts
@@ -299,10 +299,7 @@ export const setTextFilterAction = createAction(
 export const setFiltersAction = createAction(
   "[Dataset] Set Filters",
   props<{
-    datasetFilters: Record<
-      string,
-      string | DateRange | string[] | INumericRange
-    >;
+    datasetFilters: Partial<DatasetFilters>;
   }>(),
 );
 export const addDatasetFilterAction = createAction(

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -124,6 +124,7 @@ export enum ArchViewMode {
   work_in_progress = "work in progress",
   system_error = "system error",
   user_error = "user error",
+  deleted = "deleted",
 }
 export enum JobViewMode {
   myJobs = "my jobs",

--- a/src/app/state-management/reducers/datasets.reducer.spec.ts
+++ b/src/app/state-management/reducers/datasets.reducer.spec.ts
@@ -363,6 +363,27 @@ describe("DatasetsReducer", () => {
       expect(state.filters.modeToggle).toEqual(modeToggle);
       expect(state.filters.skip).toEqual(0);
     });
+
+    it("should preserve existing skip when mode changes", () => {
+      const modeToggle = ArchViewMode.archivable;
+      const stateIn = {
+        ...initialDatasetState,
+        filters: {
+          ...initialDatasetState.filters,
+          skip: 42,
+        },
+      };
+
+      const action = fromActions.setArchiveViewModeAction({ modeToggle });
+      const state = fromDatasets.datasetsReducer(stateIn, action);
+
+      expect(state.filters.skip).toEqual(42);
+      expect(state.filters.modeToggle).toEqual(modeToggle);
+      expect(state.filters.mode).toEqual({
+        "datasetlifecycle.archivable": true,
+        "datasetlifecycle.retrievable": false,
+      });
+    });
   });
 
   describe("on setPublicViewMode", () => {

--- a/src/app/state-management/reducers/datasets.reducer.spec.ts
+++ b/src/app/state-management/reducers/datasets.reducer.spec.ts
@@ -390,6 +390,36 @@ describe("DatasetsReducer", () => {
     });
   });
 
+  describe("on setFiltersAction", () => {
+    it("should restore filters without updating searchTerms or hasPrefilledFilters", () => {
+      const stateIn = {
+        ...initialDatasetState,
+        searchTerms: "keep-me",
+        hasPrefilledFilters: false,
+      };
+      const datasetFilters = {
+        text: "restored",
+        skip: 12,
+        modeToggle: ArchViewMode.deleted,
+        mode: {
+          "datasetlifecycle.archiveStatusMessage": "deleted",
+        },
+      };
+
+      const action = fromActions.setFiltersAction({ datasetFilters });
+      const state = fromDatasets.datasetsReducer(stateIn, action);
+
+      expect(state.filters.text).toEqual("restored");
+      expect(state.filters.skip).toEqual(12);
+      expect(state.filters.modeToggle).toEqual(ArchViewMode.deleted);
+      expect(state.filters.mode).toEqual({
+        "datasetlifecycle.archiveStatusMessage": "deleted",
+      });
+      expect(state.searchTerms).toEqual("keep-me");
+      expect(state.hasPrefilledFilters).toEqual(false);
+    });
+  });
+
   describe("on clearFacetsAction", () => {
     it("should clear filters while saving the filters limit and set searchTerms to an empty string", () => {
       const limit = 10;

--- a/src/app/state-management/reducers/datasets.reducer.spec.ts
+++ b/src/app/state-management/reducers/datasets.reducer.spec.ts
@@ -350,6 +350,19 @@ describe("DatasetsReducer", () => {
       expect(state.filters.modeToggle).toEqual(modeToggle);
       expect(state.filters.skip).toEqual(0);
     });
+
+    it("should set deleted mode filter", () => {
+      const modeToggle = ArchViewMode.deleted;
+
+      const action = fromActions.setArchiveViewModeAction({ modeToggle });
+      const state = fromDatasets.datasetsReducer(initialDatasetState, action);
+
+      expect(state.filters.mode).toEqual({
+        "datasetlifecycle.archiveStatusMessage": "deleted",
+      });
+      expect(state.filters.modeToggle).toEqual(modeToggle);
+      expect(state.filters.skip).toEqual(0);
+    });
   });
 
   describe("on setPublicViewMode", () => {

--- a/src/app/state-management/reducers/datasets.reducer.ts
+++ b/src/app/state-management/reducers/datasets.reducer.ts
@@ -352,7 +352,7 @@ const reducer = createReducer(
           break;
         }
       }
-      const filters = { ...state.filters, skip: 0, mode, modeToggle };
+      const filters = { skip: 0, ...state.filters, mode, modeToggle };
       return { ...state, filters };
     },
   ),

--- a/src/app/state-management/reducers/datasets.reducer.ts
+++ b/src/app/state-management/reducers/datasets.reducer.ts
@@ -343,6 +343,11 @@ const reducer = createReducer(
             ],
           };
           break;
+        case ArchViewMode.deleted:
+          mode = {
+            "datasetlifecycle.archiveStatusMessage": "deleted",
+          };
+          break;
         default: {
           break;
         }


### PR DESCRIPTION
## Description
It adds a deleted view fetching from "datasetLifecycle.archiveStatusMessage": "deleted", when jobs are enabled

<img width="728" height="303" alt="image" src="https://github.com/user-attachments/assets/a3935782-096f-401a-958d-5b73a3872e52" />

It also improves the breadcrumb removing code duplication and reusing the RxJS reducer as well as avoiding to override the skip

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Add a deleted archive view mode for datasets and reuse centralized filter state when navigating via breadcrumbs and archive mode controls.

New Features:
- Expose a new deleted archive view mode in the dataset archive mode selector and dataset list status labels.

Enhancements:
- Restore dataset filters and archive view mode via store actions when navigating from the datasets breadcrumb instead of recomputing filters locally.
- Preserve the existing pagination skip value when changing archive view mode while still applying the appropriate mode filter.
- Allow partial restoration of dataset filters through the setFiltersAction to reuse stored filter state across navigations.

Tests:
- Extend reducer, breadcrumb component, and dataset table actions tests to cover the deleted view mode, filter restoration, and mode-change behavior.