### PR TITLE
feat: add marked for deletion view

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -170,6 +170,7 @@ export interface AppConfigInterface {
   defaultTab?: DefaultTab;
   statusBannerMessage?: string;
   statusBannerCode?: "INFO" | "WARN";
+  markForDeletionWorkflowEnabled?: boolean;
 }
 
 function isMainPageConfiguration(obj: any): obj is MainPageConfiguration {

--- a/src/app/datasets/dataset-table-actions/dataset-table-actions.component.spec.ts
+++ b/src/app/datasets/dataset-table-actions/dataset-table-actions.component.spec.ts
@@ -117,6 +117,18 @@ describe("DatasetTableActionsComponent", () => {
         setArchiveViewModeAction({ modeToggle }),
       );
     });
+
+    it("should dispatch selected marked_for_deletion archive mode", () => {
+      dispatchSpy = spyOn(store, "dispatch");
+      const modeToggle = ArchViewMode.marked_for_deletion;
+
+      component.onModeChange(modeToggle);
+
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        setArchiveViewModeAction({ modeToggle }),
+      );
+    });
   });
 
   describe("#isEmptySelection()", () => {

--- a/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
+++ b/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
@@ -38,6 +38,7 @@ export class DatasetTableActionsComponent implements OnInit, OnDestroy {
     ArchViewMode.work_in_progress,
     ArchViewMode.system_error,
     ArchViewMode.user_error,
+    ArchViewMode.marked_for_deletion,
     ArchViewMode.deleted,
   ];
 

--- a/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
+++ b/src/app/datasets/dataset-table-actions/dataset-table-actions.component.ts
@@ -40,7 +40,12 @@ export class DatasetTableActionsComponent implements OnInit, OnDestroy {
     ArchViewMode.user_error,
     ArchViewMode.marked_for_deletion,
     ArchViewMode.deleted,
-  ];
+  ].filter(
+    (mode) =>
+      this.appConfig.archiveWorkflowEnabled &&
+      (mode !== ArchViewMode.marked_for_deletion ||
+        this.appConfig.markForDeletionWorkflowEnabled),
+  );
 
   searchPublicDataEnabled = this.appConfig.searchPublicDataEnabled;
 

--- a/src/app/shared/services/datasets-list.service.ts
+++ b/src/app/shared/services/datasets-list.service.ts
@@ -112,6 +112,12 @@ export class DatasetsListService implements OnDestroy {
     return false;
   }
 
+  markedForDeletionCondition(dataset: DatasetClass): boolean {
+    return (
+      dataset.datasetlifecycle.archiveStatusMessage === "markedForDeletion"
+    );
+  }
+
   deletedCondition(dataset: DatasetClass): boolean {
     return dataset.datasetlifecycle.archiveStatusMessage === "deleted";
   }
@@ -192,6 +198,8 @@ export class DatasetsListService implements OnDestroy {
               return "Archivable";
             } else if (this.retrievableCondition(row)) {
               return "Retrievable";
+            } else if (this.markedForDeletionCondition(row)) {
+              return "Marked for deletion";
             } else if (this.deletedCondition(row)) {
               return "Deleted";
             } else if (this.systemErrorCondition(row)) {
@@ -210,6 +218,8 @@ export class DatasetsListService implements OnDestroy {
               return "Archivable";
             } else if (this.retrievableCondition(row)) {
               return "Retrievable";
+            } else if (this.markedForDeletionCondition(row)) {
+              return "Marked for deletion";
             } else if (this.deletedCondition(row)) {
               return "Deleted";
             } else if (this.systemErrorCondition(row)) {

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -124,6 +124,7 @@ export enum ArchViewMode {
   work_in_progress = "work in progress",
   system_error = "system error",
   user_error = "user error",
+  marked_for_deletion = "marked for deletion",
   deleted = "deleted",
 }
 export enum JobViewMode {

--- a/src/app/state-management/reducers/datasets.reducer.ts
+++ b/src/app/state-management/reducers/datasets.reducer.ts
@@ -343,6 +343,11 @@ const reducer = createReducer(
             ],
           };
           break;
+        case ArchViewMode.marked_for_deletion:
+          mode = {
+            "datasetlifecycle.archiveStatusMessage": "markedForDeletion",
+          };
+          break;
         case ArchViewMode.deleted:
           mode = {
             "datasetlifecycle.archiveStatusMessage": "deleted",


### PR DESCRIPTION
## Description
Add marked for deletion view to display datasets that should be deleted after 3 months

Depends on #2318 

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Add support for a "marked for deletion" archive view mode across dataset listing and filtering.

New Features:
- Introduce a "marked for deletion" archive view mode option in the dataset table actions.
- Classify datasets with a "markedForDeletion" lifecycle status as "Marked for deletion" in dataset lists and views.

Tests:
- Extend dataset table actions tests to cover dispatching the new "marked for deletion" archive mode.