### PR TITLE
feat: add metadata as column from metadata-view

### DIFF
--- a/src/app/admin/schema/frontend.config.jsonforms.json
+++ b/src/app/admin/schema/frontend.config.jsonforms.json
@@ -17,6 +17,7 @@
         }
       },
       "skipSciCatLoginPageEnabled": { "type": "boolean" },
+      "addScientificMetadataKeysAsColumn": { "type": "boolean" },
       "allowConfigOverrides": { "type": "boolean" },
       "checkBoxFilterClickTrigger": { "type": "boolean" },
       "dateFormat": { "type": "string" },

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -78,6 +78,7 @@ export class DefaultTab {
 
 export interface AppConfigInterface {
   allowConfigOverrides?: boolean;
+  addScientificMetadataKeysAsColumn?: boolean;
   skipSciCatLoginPageEnabled?: boolean;
   accessTokenPrefix: string;
   addDatasetEnabled: boolean;

--- a/src/app/shared/modules/dynamic-material-table/table/extensions/row-menu/row-menu.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/extensions/row-menu/row-menu.component.html
@@ -7,7 +7,7 @@
   [matMenuTriggerFor]="menu"
   [dir]="tableSetting.direction === 'rtl' ? 'ltr' : 'rtl'"
 >
-  <mat-icon>more_horiz</mat-icon>
+  <mat-icon>more_vert</mat-icon>
 </button>
 
 <mat-menu
@@ -26,7 +26,7 @@
       [disabled]="menu.disabled"
       (click)="menuButton_OnClick(menu)"
     >
-      <mat-icon>{{ menu.icon }}</mat-icon>
+      <mat-icon *ngIf="menu.icon">{{ menu.icon }}</mat-icon>
       <span
         [class.text-align-right]="tableSetting.direction === 'rtl'"
         class="text-align-left"

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.html
@@ -1,4 +1,10 @@
-<div class="metadataTable" *ngIf="metadata">
+<div
+  class="metadataTable"
+  [class.metadataTable-add-column-enabled]="
+    canAddScientificMetadataKeysAsColumn
+  "
+  *ngIf="metadata"
+>
   <dynamic-mat-table
     [tableName]="tableName"
     [showReload]="showReloadData"
@@ -16,10 +22,12 @@
     [printConfig]="printConfig"
     [showProgress]="showProgress"
     [showGlobalTextSearch]="showGlobalTextSearch"
+    [rowContextMenuItems]="rowContextMenuItems"
     style="height: 100%"
     [emptyMessage]="'No metadata available'"
     [emptyIcon]="'folder'"
     [disableBorder]="true"
+    (onRowEvent)="onRowEvent($event)"
   >
   </dynamic-mat-table>
 </div>

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.scss
@@ -3,6 +3,7 @@
   margin-left: -16px;
   margin-right: -16px;
   margin-top: -16px;
+
   .mat-column-name {
     flex: 1 0 7em;
   }
@@ -17,6 +18,36 @@
 
   &-header {
     font-weight: bold;
+  }
+}
+
+.metadataTable-add-column-enabled {
+  ::ng-deep mat-cell.mat-column-table-menu {
+    order: -1;
+    padding-left: 20px !important;
+    padding-right: 0 !important;
+    box-sizing: border-box;
+  }
+
+  ::ng-deep mat-cell.mat-column-table-menu row-menu {
+    justify-content: flex-start;
+    width: 24px;
+    min-width: 24px;
+  }
+
+  ::ng-deep mat-cell.mat-column-table-menu row-menu .clear {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+  }
+
+  ::ng-deep mat-cell.mat-column-table-menu row-menu .clear mat-icon {
+    color: rgba(0, 0, 0, 0.25);
+  }
+
+  ::ng-deep mat-header-row.header::before {
+    content: "";
+    flex: 0 0 42px;
   }
 }
 

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.spec.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.spec.ts
@@ -9,42 +9,67 @@ import { LinkyPipe } from "ngx-linky";
 import { DatePipe, TitleCasePipe } from "@angular/common";
 import { PrettyUnitPipe } from "shared/pipes/pretty-unit.pipe";
 import { AppConfigService } from "app-config.service";
-import { provideHttpClient } from "@angular/common/http";
 import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
+import { RowEventType } from "shared/modules/dynamic-material-table/models/table-row.model";
+import { ScientificMetadataColumnsService } from "shared/services/scientific-metadata-columns.service";
 
 describe("MetadataViewComponent", () => {
   let component: MetadataViewComponent;
   let fixture: ComponentFixture<MetadataViewComponent>;
+  let scientificMetadataColumnsService: jasmine.SpyObj<ScientificMetadataColumnsService>;
+  let appConfigService: jasmine.SpyObj<AppConfigService>;
 
   beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      schemas: [NO_ERRORS_SCHEMA],
-      imports: [MatTableModule, PipesModule],
-      providers: [
-        ReplaceUnderscorePipe,
-        TitleCasePipe,
-        DatePipe,
-        LinkyPipe,
-        PrettyUnitPipe,
-        FormatNumberPipe,
-        AppConfigService,
-        provideHttpClient(),
-      ],
-      declarations: [MetadataViewComponent],
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    const appConfigService = TestBed.inject(AppConfigService);
-    spyOn(appConfigService as any, "getConfig").and.returnValue({
+    scientificMetadataColumnsService =
+      jasmine.createSpyObj<ScientificMetadataColumnsService>(
+        "ScientificMetadataColumnsService",
+        ["addMetadataColumn"],
+        {
+          addAsColumnAction: {
+            name: "addAsColumn",
+            text: "Add as column",
+            color: "primary",
+            icon: "view_column",
+          },
+        },
+      );
+    appConfigService = jasmine.createSpyObj<AppConfigService>(
+      "AppConfigService",
+      ["getConfig"],
+    );
+    appConfigService.getConfig.and.returnValue({
       metadataFloatFormatEnabled: true,
       metadataFloatFormat: {
         significantDigits: 3,
         minCutoff: 0.001,
         maxCutoff: 1000,
       },
-    });
+    } as any);
 
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [MatTableModule, PipesModule],
+      providers: [
+        {
+          provide: AppConfigService,
+          useValue: appConfigService,
+        },
+        {
+          provide: ScientificMetadataColumnsService,
+          useValue: scientificMetadataColumnsService,
+        },
+        ReplaceUnderscorePipe,
+        TitleCasePipe,
+        DatePipe,
+        LinkyPipe,
+        PrettyUnitPipe,
+        FormatNumberPipe,
+      ],
+      declarations: [MetadataViewComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
     fixture = TestBed.createComponent(MetadataViewComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -52,6 +77,30 @@ describe("MetadataViewComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should hide the add-as-column row action by default", () => {
+    expect(component.rowContextMenuItems).toEqual([]);
+  });
+
+  it("should expose the add-as-column row action when enabled in config", () => {
+    appConfigService.getConfig.and.returnValue({
+      addScientificMetadataKeysAsColumn: true,
+      metadataFloatFormatEnabled: true,
+      metadataFloatFormat: {
+        significantDigits: 3,
+        minCutoff: 0.001,
+        maxCutoff: 1000,
+      },
+    } as any);
+
+    const enabledFixture = TestBed.createComponent(MetadataViewComponent);
+    const enabledComponent = enabledFixture.componentInstance;
+    enabledFixture.detectChanges();
+
+    expect(enabledComponent.rowContextMenuItems).toEqual([
+      scientificMetadataColumnsService.addAsColumnAction,
+    ]);
   });
 
   describe("#createMetadataArray()", () => {
@@ -65,6 +114,9 @@ describe("MetadataViewComponent", () => {
       const metadataArray = component.createMetadataArray(testMetadata);
 
       expect(metadataArray[0]["name"]).toEqual("typedTestName");
+      expect(metadataArray[0]["columnName"]).toEqual(
+        "scientificMetadata.typedTestName.value",
+      );
       expect(metadataArray[0]["value"]).toEqual("test");
       expect(metadataArray[0]["unit"]).toEqual("");
     });
@@ -92,10 +144,100 @@ describe("MetadataViewComponent", () => {
       const metadataArray = component.createMetadataArray(testMetadata);
 
       expect(metadataArray[0]["name"]).toEqual("untypedTestName");
+      expect(metadataArray[0]["columnName"]).toEqual(
+        "scientificMetadata.untypedTestName",
+      );
       expect(metadataArray[0]["value"]).toEqual(
         JSON.stringify({ v: "test", u: "" }),
       );
       expect(metadataArray[0]["unit"]).toEqual("");
+    });
+
+    it("should handle null metadata entries without throwing", () => {
+      const metadataArray = component.createMetadataArray({
+        nullValue: null,
+      });
+
+      expect(metadataArray[0]["name"]).toEqual("nullValue");
+      expect(metadataArray[0]["columnName"]).toEqual(
+        "scientificMetadata.nullValue",
+      );
+      expect(metadataArray[0]["value"]).toEqual("null");
+      expect(metadataArray[0]["unit"]).toEqual("");
+      expect(metadataArray[0]["human_name"]).toBeUndefined();
+    });
+  });
+
+  describe("#onRowEvent()", () => {
+    it("should delegate the selected scientific metadata entry to the shared service", async () => {
+      appConfigService.getConfig.and.returnValue({
+        addScientificMetadataKeysAsColumn: true,
+        metadataFloatFormatEnabled: true,
+        metadataFloatFormat: {
+          significantDigits: 3,
+          minCutoff: 0.001,
+          maxCutoff: 1000,
+        },
+      } as any);
+
+      const enabledFixture = TestBed.createComponent(MetadataViewComponent);
+      const enabledComponent = enabledFixture.componentInstance;
+      enabledFixture.detectChanges();
+
+      await enabledComponent.onRowEvent({
+        event: RowEventType.RowActionMenu,
+        sender: {
+          row: {
+            name: "beam_size",
+            human_name: "Beam Size",
+            columnName: "scientificMetadata.beam_size.value",
+            value: "2.4",
+            unit: "mm",
+          },
+          action: { name: "addAsColumn" },
+        },
+      } as any);
+
+      expect(
+        scientificMetadataColumnsService.addMetadataColumn,
+      ).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          name: "beam_size",
+          human_name: "Beam Size",
+          columnName: "scientificMetadata.beam_size.value",
+        }),
+      );
+    });
+
+    it("should not delegate when add-as-column is disabled in config", async () => {
+      appConfigService.getConfig.and.returnValue({
+        addScientificMetadataKeysAsColumn: false,
+        metadataFloatFormatEnabled: true,
+      } as any);
+
+      const disabledFixture = TestBed.createComponent(MetadataViewComponent);
+      const disabledComponent = disabledFixture.componentInstance;
+      disabledFixture.detectChanges();
+
+      expect(disabledComponent.rowContextMenuItems).toEqual([]);
+
+      await disabledComponent.onRowEvent({
+        event: RowEventType.RowActionMenu,
+        sender: {
+          row: {
+            name: "beam_size",
+            human_name: "Beam Size",
+            columnName: "scientificMetadata.beam_size.value",
+            value: "2.4",
+            unit: "mm",
+          },
+          action: { name: "addAsColumn" },
+        },
+      } as any);
+
+      expect(
+        scientificMetadataColumnsService.addMetadataColumn,
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
@@ -23,6 +23,13 @@ import { MetadataTypes } from "../metadata-edit/metadata-edit.component";
 import { actionMenu } from "shared/modules/dynamic-material-table/utilizes/default-table-settings";
 import { TablePaginationMode } from "shared/modules/dynamic-material-table/models/table-pagination.model";
 import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
+import {
+  IRowEvent,
+  RowEventType,
+} from "shared/modules/dynamic-material-table/models/table-row.model";
+import { ContextMenuItem } from "shared/modules/dynamic-material-table/models/context-menu.model";
+import { ScientificMetadataColumnsService } from "shared/services/scientific-metadata-columns.service";
+import { AppConfigService } from "app-config.service";
 
 @Component({
   selector: "metadata-view",
@@ -71,6 +78,9 @@ export class MetadataViewComponent implements OnInit, OnChanges {
   tablesSettings: object;
 
   showGlobalTextSearch = false;
+
+  rowContextMenuItems: ContextMenuItem[];
+  canAddScientificMetadataKeysAsColumn: boolean;
 
   tableDefaultSettingsConfig: ITableSetting = {
     visibleActionMenu: actionMenu,
@@ -177,12 +187,21 @@ export class MetadataViewComponent implements OnInit, OnChanges {
   };
 
   constructor(
+    private appConfigService: AppConfigService,
     private unitsService: UnitsService,
     private datePipe: DatePipe,
     private formatNumberPipe: FormatNumberPipe,
+    private scientificMetadataColumnsService: ScientificMetadataColumnsService,
     public linkyPipe: LinkyPipe,
     public prettyUnit: PrettyUnitPipe,
-  ) {}
+  ) {
+    this.canAddScientificMetadataKeysAsColumn =
+      this.appConfigService.getConfig().addScientificMetadataKeysAsColumn ===
+      true;
+    this.rowContextMenuItems = this.canAddScientificMetadataKeysAsColumn
+      ? [this.scientificMetadataColumnsService.addAsColumnAction]
+      : [];
+  }
 
   createMetadataArray(
     metadata: Record<string, any>,
@@ -190,46 +209,62 @@ export class MetadataViewComponent implements OnInit, OnChanges {
     const metadataArray: ScientificMetadataTableData[] = [];
     Object.keys(metadata).forEach((key) => {
       let metadataObject: ScientificMetadataTableData;
-      const humanReadableName = metadata[key]["human_name"];
+      const entry = metadata[key];
+      const humanReadableName =
+        entry !== null && typeof entry === "object"
+          ? entry["human_name"]
+          : undefined;
+      const columnName = `scientificMetadata.${key}${
+        entry !== null &&
+        typeof entry === "object" &&
+        "value" in (entry as ScientificMetadata)
+          ? ".value"
+          : ""
+      }`;
 
       if (
-        typeof metadata[key] === "object" &&
-        "value" in (metadata[key] as ScientificMetadata)
+        entry !== null &&
+        typeof entry === "object" &&
+        "value" in (entry as ScientificMetadata)
       ) {
-        const formattedValue = this.formatNumberPipe.transform(
-          metadata[key]["value"],
-        );
+        const formattedValue = this.formatNumberPipe.transform(entry["value"]);
 
         metadataObject = {
           name: key,
+          columnName,
           value: formattedValue,
-          unit: metadata[key]["unit"],
+          unit: entry["unit"],
           human_name: humanReadableName,
-          type: metadata[key]["type"],
-          ontology_reference: metadata[key]["ontology_reference"],
+          type: entry["type"],
+          ontology_reference: entry["ontology_reference"],
         };
 
-        const validUnit = this.unitsService.unitValidation(
-          metadata[key]["unit"],
-        );
+        const validUnit = this.unitsService.unitValidation(entry["unit"]);
 
         metadataObject["validUnit"] = validUnit;
       } else {
         const metadataValue =
-          typeof metadata[key] === MetadataTypes.string ||
-          typeof metadata[key] === MetadataTypes.number
-            ? metadata[key]
-            : JSON.stringify(metadata[key]);
+          typeof entry === MetadataTypes.string ||
+          typeof entry === MetadataTypes.number
+            ? entry
+            : JSON.stringify(entry);
 
         const formattedValue = this.formatNumberPipe.transform(metadataValue);
 
         metadataObject = {
           name: key,
+          columnName,
           value: formattedValue,
           unit: "",
           human_name: humanReadableName,
-          type: metadata[key]["type"],
-          ontology_reference: metadata[key]["ontology_reference"],
+          type:
+            entry !== null && typeof entry === "object"
+              ? entry["type"]
+              : undefined,
+          ontology_reference:
+            entry !== null && typeof entry === "object"
+              ? entry["ontology_reference"]
+              : undefined,
         };
       }
       metadataArray.push(metadataObject);
@@ -246,6 +281,20 @@ export class MetadataViewComponent implements OnInit, OnChanges {
 
       this.pending = false;
     }
+  }
+
+  async onRowEvent({ event, sender }: IRowEvent<ScientificMetadataTableData>) {
+    if (
+      !this.canAddScientificMetadataKeysAsColumn ||
+      event !== RowEventType.RowActionMenu ||
+      sender.action?.name !==
+        this.scientificMetadataColumnsService.addAsColumnAction.name ||
+      !sender.row
+    ) {
+      return;
+    }
+
+    await this.scientificMetadataColumnsService.addMetadataColumn(sender.row);
   }
 
   initTable(settingConfig: ITableSetting): void {

--- a/src/app/shared/modules/scientific-metadata/scientific-metadata.module.ts
+++ b/src/app/shared/modules/scientific-metadata/scientific-metadata.module.ts
@@ -71,9 +71,11 @@ export interface ScientificMetadata {
 
 export interface ScientificMetadataTableData {
   name: string;
+  columnName: string;
   value: string | number;
   unit: string;
   human_name?: string;
   type?: string;
   ontology_reference?: string;
+  validUnit?: boolean;
 }

--- a/src/app/shared/services/scientific-metadata-columns.service.spec.ts
+++ b/src/app/shared/services/scientific-metadata-columns.service.spec.ts
@@ -1,0 +1,163 @@
+import { TestBed } from "@angular/core/testing";
+import { Store } from "@ngrx/store";
+import { of } from "rxjs";
+import {
+  showMessageAction,
+  updateUserSettingsAction,
+} from "state-management/actions/user.actions";
+import {
+  selectColumnsWithHasFetchedSettings,
+  selectCurrentUser,
+} from "state-management/selectors/user.selectors";
+import {
+  ScientificMetadataColumnEntry,
+  ScientificMetadataColumnsService,
+} from "./scientific-metadata-columns.service";
+
+describe("ScientificMetadataColumnsService", () => {
+  let service: ScientificMetadataColumnsService;
+  let store: jasmine.SpyObj<Store>;
+
+  const entry: ScientificMetadataColumnEntry = {
+    name: "beam_size",
+    columnName: "scientificMetadata.beam_size.value",
+    human_name: "Beam Size",
+  };
+
+  beforeEach(() => {
+    store = jasmine.createSpyObj<Store>("Store", ["select", "dispatch"]);
+    store.select.and.returnValue(of(undefined));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ScientificMetadataColumnsService,
+        { provide: Store, useValue: store },
+      ],
+    });
+
+    service = TestBed.inject(ScientificMetadataColumnsService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("should build a standard user-added scientific metadata column without path", () => {
+    expect(service.buildColumn(entry, 3)).toEqual({
+      name: "scientificMetadata.beam_size.value",
+      header: "Beam Size",
+      userAdded: true,
+      order: 3,
+      type: "standard",
+      enabled: true,
+      tooltip: "beam_size",
+      width: 250,
+    });
+  });
+
+  it("should upsert an existing column without duplicating it", () => {
+    const result = service.upsertColumn(
+      [
+        {
+          name: "scientificMetadata.beam_size.value",
+          header: "Old Beam Size",
+          order: 7,
+          type: "standard",
+          enabled: false,
+        },
+      ],
+      entry,
+    );
+
+    expect(result).toEqual([
+      {
+        name: "scientificMetadata.beam_size.value",
+        header: "Beam Size",
+        userAdded: true,
+        order: 7,
+        type: "standard",
+        enabled: true,
+        tooltip: "beam_size",
+        width: 250,
+      },
+    ]);
+  });
+
+  it("should dispatch an info message when no user is logged in", async () => {
+    store.select.and.callFake((selector: unknown) => {
+      if (selector === selectCurrentUser) {
+        return of(undefined);
+      }
+
+      return of(undefined);
+    });
+
+    await service.addMetadataColumn(entry);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      showMessageAction({
+        message: jasmine.objectContaining({
+          content: "Log in to save dataset list columns.",
+        }) as any,
+      }),
+    );
+  });
+
+  it("should dispatch a settings update and success message", async () => {
+    store.select.and.callFake((selector: unknown) => {
+      if (selector === selectCurrentUser) {
+        return of({ id: "user-1" } as any);
+      }
+
+      if (selector === selectColumnsWithHasFetchedSettings) {
+        return of({
+          columns: [
+            {
+              name: "datasetName",
+              order: 0,
+              type: "standard",
+              enabled: true,
+            },
+          ],
+          hasFetchedSettings: true,
+        });
+      }
+
+      return of(undefined);
+    });
+
+    await service.addMetadataColumn(entry);
+
+    expect(store.dispatch.calls.argsFor(0)[0]).toEqual(
+      updateUserSettingsAction({
+        property: {
+          columns: [
+            {
+              name: "datasetName",
+              order: 0,
+              type: "standard",
+              enabled: true,
+            },
+            {
+              name: "scientificMetadata.beam_size.value",
+              header: "Beam Size",
+              userAdded: true,
+              order: 1,
+              type: "standard",
+              enabled: true,
+              tooltip: "beam_size",
+              width: 250,
+            },
+          ],
+        },
+      }),
+    );
+    expect(store.dispatch.calls.argsFor(1)[0]).toEqual(
+      showMessageAction({
+        message: jasmine.objectContaining({
+          content: '"Beam Size" was added to the datasets list.',
+        }) as any,
+      }),
+    );
+  });
+});

--- a/src/app/shared/services/scientific-metadata-columns.service.ts
+++ b/src/app/shared/services/scientific-metadata-columns.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from "@angular/core";
+import { Store } from "@ngrx/store";
+import { firstValueFrom } from "rxjs";
+import { ContextMenuItem } from "shared/modules/dynamic-material-table/models/context-menu.model";
+import {
+  showMessageAction,
+  updateUserSettingsAction,
+} from "state-management/actions/user.actions";
+import { Message, MessageType, TableColumn } from "state-management/models";
+import {
+  selectColumnsWithHasFetchedSettings,
+  selectCurrentUser,
+} from "state-management/selectors/user.selectors";
+
+export interface ScientificMetadataColumnEntry {
+  name: string;
+  columnName: string;
+  human_name?: string;
+}
+
+@Injectable({ providedIn: "root" })
+export class ScientificMetadataColumnsService {
+  readonly addAsColumnAction: ContextMenuItem = {
+    name: "addAsColumn",
+    text: "Add as column",
+    color: undefined,
+  };
+
+  constructor(private store: Store) {}
+
+  private showMessage(content: string, type: MessageType) {
+    this.store.dispatch(
+      showMessageAction({
+        message: new Message(content, type, 3000),
+      }),
+    );
+  }
+
+  buildColumn(
+    entry: ScientificMetadataColumnEntry,
+    order: number,
+  ): TableColumn {
+    return {
+      name: entry.columnName,
+      header: entry.human_name || entry.name,
+      userAdded: true,
+      order,
+      type: "standard",
+      enabled: true,
+      tooltip: entry.name,
+      width: 250,
+    };
+  }
+
+  upsertColumn(
+    columns: TableColumn[],
+    entry: ScientificMetadataColumnEntry,
+  ): TableColumn[] {
+    const nextColumn = this.buildColumn(entry, columns.length);
+    const existingColumnIndex = columns.findIndex(
+      (column) => column.name === nextColumn.name,
+    );
+
+    return existingColumnIndex === -1
+      ? [...columns, nextColumn]
+      : columns.map((column, index) =>
+          index === existingColumnIndex
+            ? {
+                ...column,
+                ...nextColumn,
+                order: column.order ?? existingColumnIndex,
+              }
+            : column,
+        );
+  }
+
+  async addMetadataColumn(entry: ScientificMetadataColumnEntry): Promise<void> {
+    const currentUser = await firstValueFrom(
+      this.store.select(selectCurrentUser),
+    );
+
+    if (!currentUser) {
+      this.showMessage(
+        "Log in to save dataset list columns.",
+        MessageType.Info,
+      );
+      return;
+    }
+
+    const { columns, hasFetchedSettings } = await firstValueFrom(
+      this.store.select(selectColumnsWithHasFetchedSettings),
+    );
+
+    if (!hasFetchedSettings) {
+      this.showMessage("Unable to fetch settings.", MessageType.Info);
+      return;
+    }
+
+    const nextColumns = this.upsertColumn(columns, entry);
+    const nextColumn = nextColumns.find(
+      (column) => column.name === entry.columnName,
+    );
+
+    this.store.dispatch(
+      updateUserSettingsAction({
+        property: {
+          columns: nextColumns,
+        },
+      }),
+    );
+
+    this.showMessage(
+      `"${nextColumn?.header || entry.human_name || entry.name}" was added to the datasets list.`,
+      MessageType.Success,
+    );
+  }
+}

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,6 +1,7 @@
 {
   "accessTokenPrefix": "Bearer ",
   "addDatasetEnabled": false,
+  "addScientificMetadataKeysAsColumn": false,
   "allowConfigOverrides": true,
   "archiveWorkflowEnabled": false,
   "datasetReduceEnabled": true,


### PR DESCRIPTION
## Description
Add configurable feature to allow user to add scientific metadata keys as columns in dataset table. This is for metata-view only, metadata-view-tree should follow.

<img width="468" height="595" alt="image" src="https://github.com/user-attachments/assets/2315b130-bd15-4198-bef2-e21f6be0a250" />

## Motivation
Users should be able to configure the dataset table with columns from scientific metadata.


## Changes:
A ScientificMetadataColumnsService service added that can be reused later for adding columns from metadata-view-tree and from the dataset table itself.

## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)

## Summary by Sourcery

Introduce configurable support for adding scientific metadata entries as columns in the dataset table from the metadata view.

New Features:
- Allow users to add scientific metadata keys as dataset table columns via a row context menu in the metadata view when enabled in app configuration.
- Provide a shared ScientificMetadataColumnsService for constructing and persisting user-added scientific metadata columns and showing related notifications.

Enhancements:
- Extend scientific metadata table rows with column identifiers and optional validity metadata to support column creation.
- Update metadata view styling and row-menu behavior to accommodate the new per-row action in the table UI.

Tests:
- Add unit tests for metadata view row event handling to verify integration with the scientific metadata columns service and configuration gating.
- Add unit tests for the ScientificMetadataColumnsService to cover column creation, upsert logic, and user/settings preconditions.