### PR TITLE
fix: add timezone configuration with UTC as default

### DIFF
--- a/CI/e2e/frontend.config.e2e.json
+++ b/CI/e2e/frontend.config.e2e.json
@@ -6,7 +6,7 @@
   "checkBoxFilterClickTrigger": false,
   "accessTokenPrefix": "Bearer ",
   "addDatasetEnabled": false,
-  "allowConfigOverrides": true,  
+  "allowConfigOverrides": true,
   "archiveWorkflowEnabled": false,
   "datasetReduceEnabled": true,
   "datasetJsonScientificMetadata": true,
@@ -20,7 +20,7 @@
   "siteIcon": "site-header-logo.png",
   "siteHeaderLogoUrl": "https://my.facility.site",
   "sitetitle": "SciCat FE CI repo",
-  "siteSciCatLogo": "full",  
+  "siteSciCatLogo": "full",
   "loginFacilityLabel": "SciCat Vanilla",
   "loginLdapLabel": "Ldap",
   "loginLocalLabel": "Local",
@@ -77,7 +77,7 @@
   "datasetDetailsShowMissingProposalId": false,
   "notificationInterceptorEnabled": true,
   "metadataEditingUnitListDisabled": true,
-  "hideEmptyMetadataTable": false,  
+  "hideEmptyMetadataTable": false,
   "datafilesActionsEnabled": true,
   "datafilesActions": [
     {
@@ -90,19 +90,22 @@
       "type": "form",
       "url": "http://localhost:4200/download/all",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0FilesPath",
         "totalSize": "#Dataset0FilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
       "enabled": "#MaxDownloadableSize(@totalSize)",
-      "inputs" : {
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
       },
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "3072fafc-4363-11ef-b9f9-ebf568222d26",
@@ -114,22 +117,25 @@
       "type": "form",
       "url": "http://localhost:4200/download/selected",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0SelectedFilesPath",
         "selected": "#Dataset0SelectedFilesCount",
         "totalSize": "#Dataset0SelectedFilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
-      "inputs" : {
-        "auth_token" : "#tokenBearer",
-        "jwt" : "#jwt",
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "auth_token": "#tokenBearer",
+        "jwt": "#jwt",
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
       },
       "enabled": "#Length(@files) && #MaxDownloadableSize(@totalSize)",
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "4f974f0e-4364-11ef-9c63-03d19f813f4e",
@@ -141,21 +147,24 @@
       "type": "form",
       "url": "http://localhost:4200/notebook/all/form",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0FilesPath",
         "totalSize": "#Dataset0FilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
       "enabled": "",
-      "inputs" : {
-        "auth_token" : "#token",
-        "jwt" : "#jwt",
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "auth_token": "#token",
+        "jwt": "#jwt",
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
-      },      
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      },
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "fa3ce6ee-482d-11ef-95e9-ff2c80dd50bd",
@@ -166,22 +175,25 @@
       "type": "form",
       "url": "http://localhost:4200/notebook/selected/form",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0SelectedFilesPath",
         "selected": "#Dataset0SelectedFilesCount",
         "totalSize": "#Dataset0SelectedFilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
-      "inputs" : {
-        "auth_token" : "#token",
-        "jwt" : "#jwt",
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "auth_token": "#token",
+        "jwt": "#jwt",
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
       },
       "enabled": "#Length(@files) > 0",
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "0cd5b592-0b1a-11f0-a42c-23e177127ee7",
@@ -193,8 +205,11 @@
       "icon": "/assets/icons/jupyter_logo.png",
       "url": "http://localhost:5000/notebook/all/json",
       "target": "_blank",
-      "authorization": ["#datasetAccess", "#datasetPublic"],
-      "variables" : {
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ],
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0FilesPath",
         "folder": "#Dataset0SourceFolder"
@@ -212,8 +227,11 @@
       "url": "http://localhost:5000/notebook/selected/json",
       "target": "_blank",
       "enabled": "#Length(@files) > 0",
-      "authorization": ["#datasetAccess", "#datasetPublic"],
-      "variables" : {
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ],
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0SelectedFilesPath",
         "selected": "#Dataset0SelectedFilesCount",
@@ -221,7 +239,7 @@
       },
       "payload": "{\"template_id\":\"c975455e-ede3-11ef-94fb-138c9cd51fc0\",\"parameters\":{\"dataset\":\"{{ @pid }}\",\"directory\":\"{{ @folder }}\",\"files\": {{ @files[] }},\"jwt\":\"{{ #jwt }}\",\"scicat_url\":\"https://staging.scicat.ess.url\",\"file_server_url\":\"sftserver2.esss.dk\",\"file_server_port\":\"22\"}}",
       "filename": "{{ #uuid }}.ipynb"
-    },    
+    },
     {
       "id": "9c6a11b6-a526-11f0-8795-6f025b320cc3",
       "description": "This action let users make a call an arbitrary URL and store the reply in the store",
@@ -229,14 +247,14 @@
       "label": "Publish",
       "type": "xhr",
       "mat_icon": "lock_open",
-      "method" : "PATCH",
+      "method": "PATCH",
       "url": "http://localhost:3000/dataset/{{ @pid }}/",
       "target": "_blank",
       "enabled": "(#datasetOwner || #userIsAdmin) && !@isPublished",
       "authorization": "#datasetOwner && !@isPublished",
-      "variables" : {
+      "variables": {
         "pid": "@Dataset0Pid",
-        "isPublished" : "#Dataset[0]Field[isPublished]"
+        "isPublished": "#Dataset[0]Field[isPublished]"
       },
       "payload": "{\"isPublished\":\"true\"}",
       "headers": {
@@ -251,14 +269,14 @@
       "label": "Unpublish",
       "type": "xhr",
       "mat_icon": "lock",
-      "method" : "PATCH",
+      "method": "PATCH",
       "url": "http://localhost:3000/dataset/{{ @pid }}/",
       "target": "_blank",
       "enabled": "(#datasetOwner || #userIsAdmin) && @isPublished",
       "authorization": "#datasetOwner && @isPublished",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
-        "isPublished" : "#Dataset[0]Field[isPublished]"
+        "isPublished": "#Dataset[0]Field[isPublished]"
       },
       "payload": "{\"isPublished\":\"false\"}",
       "headers": {
@@ -292,219 +310,219 @@
       "TextFilter": "Text"
     }
   },
-"defaultDatasetsListSettings": {
+  "defaultDatasetsListSettings": {
     "columns": [
       {
         "name": "select",
         "type": "standard",
-	      "width": 120,
+        "width": 120,
         "enabled": true
       },
       {
         "name": "pid",
         "type": "standard",
-	      "width": 130,
+        "width": 130,
         "enabled": true
       },
       {
         "name": "datasetName",
         "type": "standard",
-	      "width": 250,
+        "width": 250,
         "enabled": true
       },
       {
         "name": "runNumber",
         "type": "standard",
-	      "width": 120,
+        "width": 120,
         "enabled": true
       },
       {
         "name": "sourceFolder",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "sourceFolderHost",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "size",
         "type": "standard",
-	      "width": 150,
+        "width": 150,
         "enabled": true
       },
       {
         "name": "numberOfFiles",
         "type": "standard",
-	      "width": 120,
+        "width": 120,
         "enabled": false
       },
       {
         "name": "creationTime",
         "type": "date",
         "enabled": true,
-	      "width": 200,
-	      "format": "yyyy-mm-dd HH:MM"
+        "width": 200,
+        "format": "yyyy-mm-dd HH:MM"
       },
       {
         "name": "keywords",
         "type": "list",
         "enabled": false,
-	      "width": 200
+        "width": 200
       },
       {
         "name": "description",
         "type": "hovercontent",
         "enabled": false,
-	      "width": 150
+        "width": 150
       },
       {
         "name": "type",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "image",
         "type": "standard",
-	      "width": 250,
+        "width": 250,
         "enabled": true
       },
       {
         "name": "scientificMetadata",
         "type": "hovercontent",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "scientificMetadataSchema",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "scientificMetadataValid",
         "type": "standard",
-	      "width": 100,
+        "width": 100,
         "enabled": false
       },
       {
         "name": "owner",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "ownerEmail",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "orcidOfOwner",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "contactEmail",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "proposalId",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": true
       },
       {
         "name": "proposalIds",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "license",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "isPublished",
         "type": "standard",
-	      "width": 100,
+        "width": 100,
         "enabled": false
       },
       {
         "name": "techniques",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "comment",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "dataQualityMetrics",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "principalInvestigator",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "startTime",
         "type": "date",
-	      "width": 200,
+        "width": 200,
         "enabled": false,
-	      "format": "yyyy-mm-dd HH:MM"
+        "format": "yyyy-mm-dd HH:MM"
       },
       {
         "name": "endTime",
         "type": "date",
-	      "width": 200,
+        "width": 200,
         "enabled": false,
-	      "format": "yyyy-mm-dd HH:MM"
+        "format": "yyyy-mm-dd HH:MM"
       },
       {
         "name": "creationLocation",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "sampleIds",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "ownerGroup",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "dataStatus",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "accessGroups",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       }
     ],
@@ -711,6 +729,7 @@
     }
   },
   "dateFormat": "yyyy-MM-dd HH:mm",
+  "timezone": "UTC",
   "datasetDetailComponent": {
     "enableCustomizedComponent": false,
     "customization": [

--- a/src/app/admin/schema/frontend.config.jsonforms.json
+++ b/src/app/admin/schema/frontend.config.jsonforms.json
@@ -20,6 +20,7 @@
       "allowConfigOverrides": { "type": "boolean" },
       "checkBoxFilterClickTrigger": { "type": "boolean" },
       "dateFormat": { "type": "string" },
+      "timezone": { "type": "string" },
       "accessTokenPrefix": { "type": "string" },
       "addDatasetEnabled": { "type": "boolean" },
       "archiveWorkflowEnabled": { "type": "boolean" },
@@ -433,6 +434,7 @@
         },
         "elements": [
           { "type": "Control", "scope": "#/properties/dateFormat" },
+          { "type": "Control", "scope": "#/properties/timezone" },
           { "type": "Control", "scope": "#/properties/accessTokenPrefix" },
           { "type": "Control", "scope": "#/properties/landingPage" },
           { "type": "Control", "scope": "#/properties/metadataStructure" },

--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -5,6 +5,7 @@ import {
   AppConfigService,
   HelpMessages,
 } from "app-config.service";
+import { time } from "node:console";
 import { Observable, of } from "rxjs";
 import { MockHttp } from "shared/MockStubs";
 
@@ -42,6 +43,7 @@ const appConfig: AppConfigInterface = {
   ingestManual: null,
   jobsEnabled: true,
   dateFormat: "yyyy-MM-dd HH:mm",
+  timezone: "UTC",
   jsonMetadataEnabled: true,
   jupyterHubUrl: "https://jupyterhub.esss.lu.se/",
   landingPage: "doi2.psi.ch/detail/",
@@ -280,6 +282,7 @@ describe("AppConfigService", () => {
         },
         mainMenu: { nonAuthenticatedUser: { datasets: true } },
         dateFormat: "yyyy-MM-dd HH:mm",
+        timezone: "UTC",
         oAuth2Endpoints: [
           {
             authURL: "abcd",
@@ -308,6 +311,7 @@ describe("AppConfigService", () => {
       mainMenu: { nonAuthenticatedUser: { datasets: true, files: true } },
       oAuth2Endpoints: [],
       dateFormat: "yyyy-MM-dd HH:mm",
+      timezone: "UTC",
     };
 
     const mockHttpGet = (

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -264,6 +264,10 @@ export class AppConfigService {
       config.dateFormat = "yyyy-MM-dd HH:mm";
     }
 
+    if (!config.timezone) {
+      config.timezone = "UTC";
+    }
+
     if (config.metadataFloatFormatEnabled && !config.metadataFloatFormat) {
       config.metadataFloatFormat = {
         significantDigits: 3,

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -160,6 +160,7 @@ export interface AppConfigInterface {
   datasetDetailComponent?: DatasetDetailComponentConfig;
   labelsLocalization?: LabelsLocalization;
   dateFormat?: string;
+  timezone?: string;
   defaultMainPage?: MainPageConfiguration;
   siteHeaderLogoUrl?: string;
   mainMenu?: MainMenuConfiguration;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -124,6 +124,7 @@ const apiConfigurationFn = (
         return {
           dateFormat:
             appConfigService.getConfig().dateFormat || "yyyy-MM-dd HH:mm",
+          timezone: appConfigService.getConfig().timezone || "UTC",
         };
       },
       deps: [AppConfigService],

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -5,7 +5,12 @@
   "archiveWorkflowEnabled": false,
   "datasetReduceEnabled": true,
   "datasetJsonScientificMetadata": true,
-  "datasetPageSizeOptions": [5, 10, 25, 100],
+  "datasetPageSizeOptions": [
+    5,
+    10,
+    25,
+    100
+  ],
   "editDatasetEnabled": true,
   "editDatasetSampleEnabled": true,
   "editMetadataEnabled": true,
@@ -43,7 +48,7 @@
   },
   "logbookEnabled": true,
   "loginFormEnabled": true,
-  "thumbnailFetchLimitPerPage": 100,  
+  "thumbnailFetchLimitPerPage": 100,
   "metadataPreviewEnabled": true,
   "metadataStructure": "",
   "multipleDownloadAction": "http://localhost:3012/zip",
@@ -85,19 +90,22 @@
       "type": "form",
       "url": "https://zip.scicatproject.org/download/all",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0FilesPath",
         "totalSize": "#Dataset0FilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
       "enabled": "#MaxDownloadableSize(@totalSize)",
-      "inputs" : {
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
       },
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "3072fafc-4363-11ef-b9f9-ebf568222d26",
@@ -109,22 +117,25 @@
       "type": "form",
       "url": "https://zip.scicatproject.org/download/selected",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0SelectedFilesPath",
         "selected": "#Dataset0SelectedFilesCount",
         "totalSize": "#Dataset0SelectedFilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
-      "inputs" : {
-        "auth_token" : "#tokenBearer",
-        "jwt" : "#jwt",
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "auth_token": "#tokenBearer",
+        "jwt": "#jwt",
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
       },
       "enabled": "#Length(@files) && #MaxDownloadableSize(@totalSize)",
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "4f974f0e-4364-11ef-9c63-03d19f813f4e",
@@ -136,21 +147,24 @@
       "type": "form",
       "url": "https://www.scicat.info/notebook/all",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0FilesPath",
         "totalSize": "#Dataset0FilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
       "enabled": "",
-      "inputs" : {
-        "auth_token" : "#token",
-        "jwt" : "#jwt",
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "auth_token": "#token",
+        "jwt": "#jwt",
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
-      },      
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      },
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "fa3ce6ee-482d-11ef-95e9-ff2c80dd50bd",
@@ -161,22 +175,25 @@
       "type": "form",
       "url": "https://www.scicat.info/notebook/selected",
       "target": "_blank",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0SelectedFilesPath",
         "selected": "#Dataset0SelectedFilesCount",
         "totalSize": "#Dataset0SelectedFilesTotalSize",
         "folder": "#Dataset0SourceFolder"
       },
-      "inputs" : {
-        "auth_token" : "#token",
-        "jwt" : "#jwt",
-        "item[]" : "@pid",
-        "directory[]" : "@folder",
+      "inputs": {
+        "auth_token": "#token",
+        "jwt": "#jwt",
+        "item[]": "@pid",
+        "directory[]": "@folder",
         "files[]": "@files"
       },
       "enabled": "#Length(@files) > 0",
-      "authorization": ["#datasetAccess", "#datasetPublic"]
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ]
     },
     {
       "id": "0cd5b592-0b1a-11f0-a42c-23e177127ee7",
@@ -188,8 +205,11 @@
       "icon": "/assets/icons/jupyter_logo.png",
       "url": "https://www.sciwyrm.info/notebook",
       "target": "_blank",
-      "authorization": ["#datasetAccess", "#datasetPublic"],
-      "variables" : {
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ],
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0FilesPath",
         "folder": "#Dataset0SourceFolder"
@@ -207,8 +227,11 @@
       "url": "https://www.sciwyrm.info/notebook",
       "target": "_blank",
       "enabled": "#Length(@files) > 0",
-      "authorization": ["#datasetAccess", "#datasetPublic"],
-      "variables" : {
+      "authorization": [
+        "#datasetAccess",
+        "#datasetPublic"
+      ],
+      "variables": {
         "pid": "#Dataset0Pid",
         "files": "#Dataset0SelectedFilesPath",
         "selected": "#Dataset0SelectedFiles",
@@ -216,7 +239,7 @@
       },
       "payload": "{\"template_id\":\"c975455e-ede3-11ef-94fb-138c9cd51fc0\",\"parameters\":{\"dataset\":\"{{ @pid }}\",\"directory\":\"{{ @folder }}\",\"files\": {{ @files[] }},\"jwt\":\"{{ #jwt }}\",\"scicat_url\":\"https://staging.scicat.ess.url\",\"file_server_url\":\"sftserver2.esss.dk\",\"file_server_port\":\"22\"}}",
       "filename": "{{ #uuid }}.ipynb"
-    },    
+    },
     {
       "id": "9c6a11b6-a526-11f0-8795-6f025b320cc3",
       "description": "This action let users make a call an arbitrary URL and store the reply in the store",
@@ -224,14 +247,14 @@
       "label": "Publish",
       "type": "xhr",
       "mat_icon": "lock_open",
-      "method" : "PATCH",
+      "method": "PATCH",
       "url": "http://localhost:3000/dataset/{{ @pid }}/",
       "target": "_blank",
       "enabled": "(#datasetOwner || #userIsAdmin) && !@isPublished",
       "authorization": "#datasetOwner && !@isPublished",
-      "variables" : {
+      "variables": {
         "pid": "@Dataset0Pid",
-        "isPublished" : "#Dataset[0]Field[isPublished]"
+        "isPublished": "#Dataset[0]Field[isPublished]"
       },
       "payload": "{\"isPublished\":\"true\"}",
       "headers": {
@@ -246,14 +269,14 @@
       "label": "Unpublish",
       "type": "xhr",
       "mat_icon": "lock",
-      "method" : "PATCH",
+      "method": "PATCH",
       "url": "http://localhost:3000/dataset/{{ @pid }}/",
       "target": "_blank",
       "enabled": "(#datasetOwner || #userIsAdmin) && @isPublished",
       "authorization": "#datasetOwner && @isPublished",
-      "variables" : {
+      "variables": {
         "pid": "#Dataset0Pid",
-        "isPublished" : "#Dataset[0]Field[isPublished]"
+        "isPublished": "#Dataset[0]Field[isPublished]"
       },
       "payload": "{\"isPublished\":\"false\"}",
       "headers": {
@@ -275,7 +298,7 @@
   "datasetDetailsActionsEnabled": false,
   "datasetDetailsActions": [],
   "selectionActionsEnabled": true,
-  "selectionActions": [],  
+  "selectionActions": [],
   "labelMaps": {
     "filters": {
       "LocationFilter": "Location",
@@ -292,215 +315,215 @@
       {
         "name": "select",
         "type": "standard",
-	      "width": 120,
+        "width": 120,
         "enabled": true
       },
       {
         "name": "pid",
         "type": "standard",
-	      "width": 130,
+        "width": 130,
         "enabled": true
       },
       {
         "name": "datasetName",
         "type": "standard",
-	      "width": 250,
+        "width": 250,
         "enabled": true
       },
       {
         "name": "runNumber",
         "type": "standard",
-	      "width": 120,
+        "width": 120,
         "enabled": true
       },
       {
         "name": "sourceFolder",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "sourceFolderHost",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "size",
         "type": "standard",
-	      "width": 150,
+        "width": 150,
         "enabled": true
       },
       {
         "name": "numberOfFiles",
         "type": "standard",
-	      "width": 120,
+        "width": 120,
         "enabled": false
       },
       {
         "name": "creationTime",
         "type": "date",
         "enabled": true,
-	      "width": 200,
-	      "format": "yyyy-mm-dd HH:MM"
+        "width": 200,
+        "format": "yyyy-mm-dd HH:MM"
       },
       {
         "name": "keywords",
         "type": "list",
         "enabled": false,
-	      "width": 200
+        "width": 200
       },
       {
         "name": "description",
         "type": "hovercontent",
         "enabled": false,
-	      "width": 150
+        "width": 150
       },
       {
         "name": "type",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "image",
         "type": "standard",
-	      "width": 250,
+        "width": 250,
         "enabled": true
       },
       {
         "name": "scientificMetadata",
         "type": "hovercontent",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "scientificMetadataSchema",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "scientificMetadataValid",
         "type": "standard",
-	      "width": 100,
+        "width": 100,
         "enabled": false
       },
       {
         "name": "owner",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "ownerEmail",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "orcidOfOwner",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "contactEmail",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "proposalId",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": true
       },
       {
         "name": "proposalIds",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "license",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "isPublished",
         "type": "standard",
-	      "width": 100,
+        "width": 100,
         "enabled": false
       },
       {
         "name": "techniques",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "comment",
         "type": "editable",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "dataQualityMetrics",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "principalInvestigator",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "startTime",
         "type": "date",
-	      "width": 200,
+        "width": 200,
         "enabled": false,
-	      "format": "yyyy-mm-dd HH:MM",
+        "format": "yyyy-mm-dd HH:MM",
         "sort": "desc"
       },
       {
         "name": "endTime",
         "type": "date",
-	      "width": 200,
+        "width": 200,
         "enabled": false,
-	      "format": "yyyy-mm-dd HH:MM"
+        "format": "yyyy-mm-dd HH:MM"
       },
       {
         "name": "creationLocation",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "sampleIds",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "ownerGroup",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "dataStatus",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       },
       {
         "name": "accessGroups",
         "type": "standard",
-	      "width": 200,
+        "width": 200,
         "enabled": false
       }
     ],
@@ -703,6 +726,7 @@
     }
   },
   "dateFormat": "yyyy-MM-dd HH:mm",
+  "timezone": "UTC",
   "datasetDetailComponent": {
     "enableCustomizedComponent": false,
     "customization": [


### PR DESCRIPTION
## Description
Adds default timezone value "UTC", to the date pipe function to render times as backend.

## Fixes:
Avoid unexpected time conversions for users in different timezones

## Changes:

Optional `timezone` field added to the configuration
```json
  "dateFormat": "yyyy-MM-dd HH:mm",
  "timezone": "UTC",
```

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Add configurable timezone support with a default of UTC for date formatting.

New Features:
- Introduce optional timezone field in the app configuration used by the date pipe.

Bug Fixes:
- Prevent inconsistent date display caused by client-side timezone differences by defaulting to UTC.

Enhancements:
- Extend AppConfig interface and configuration provider to expose timezone alongside dateFormat.
- Update configuration tests and default assets config to include the timezone setting.