### PR TITLE
fix: tree sample metadata editing configuration

### DIFF
--- a/src/app/samples/sample-detail/sample-detail.component.html
+++ b/src/app/samples/sample-detail/sample-detail.component.html
@@ -87,7 +87,7 @@
                         ></metadata-view>
                       </div>
                     </mat-tab>
-                    <mat-tab>
+                    <mat-tab *ngIf="appConfig.editMetadataEnabled">
                       <ng-template mat-tab-label>
                         <mat-icon> edit </mat-icon> Edit
                       </ng-template>


### PR DESCRIPTION
## Description
Tree `sample metadata` exposes editing with no option to disable it.


## Fixes:
Take the value of `editMetadataEnabled` from config, to enable/disable tree sample metadata editing.


## Changes:
updating : `src/app/samples/sample-detail/sample-detail.component.html`


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Summary by Sourcery

Bug Fixes:
- Prevent sample metadata editing from being available when the editMetadataEnabled configuration flag is disabled.