### PR TITLE
refactor: rename condition dialog title and make it dynamic

### DIFF
--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -65,6 +65,7 @@
       [conditionType]="'datasets'"
       [addConditionAction]="addCondition"
       [removeConditionAction]="removeCondition"
+      [dialogTitle]="'Add Dataset Metadata Key'"
     ></shared-condition>
 
     <div class="section-container">

--- a/src/app/samples/sample-dashboard/sample-dashboard.component.html
+++ b/src/app/samples/sample-dashboard/sample-dashboard.component.html
@@ -32,6 +32,7 @@
               [conditionType]="'samples'"
               [addConditionAction]="addCondition"
               [removeConditionAction]="removeCondition"
+              [dialogTitle]="'Add Sample Metadata Key'"
             ></shared-condition>
 
             <div class="section-container">

--- a/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.html
+++ b/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.html
@@ -1,4 +1,6 @@
-<h2 mat-dialog-title>Add Characteristic</h2>
+<h2 mat-dialog-title>
+  {{ data.dialogTitle }}
+</h2>
 <form [formGroup]="parametersForm" class="search-parameters-form">
   <mat-dialog-content>
     <mat-form-field class="search-field">

--- a/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
+++ b/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
@@ -13,6 +13,7 @@ export interface SearchParametersDialogData {
   usedFields: string[];
   condition?: ScientificCondition;
   humanNameMap?: { [key: string]: string };
+  dialogTitle?: string;
 }
 
 @Component({

--- a/src/app/shared/modules/shared-condition/shared-condition.component.ts
+++ b/src/app/shared/modules/shared-condition/shared-condition.component.ts
@@ -43,7 +43,7 @@ export class SharedConditionComponent implements OnDestroy {
   @Input() addConditionAction: (condition: ScientificCondition) => void;
   @Input() removeConditionAction: (condition: ScientificCondition) => void;
   @Output() conditionsApplied = new EventEmitter<void>();
-
+  @Input() dialogTitle = "";
   allConditions$ = this.store.select(selectConditions);
 
   conditionConfigs$ = this.allConditions$.pipe(
@@ -262,6 +262,7 @@ export class SharedConditionComponent implements OnDestroy {
                   usedFields: usedFields,
                   parameterKeys: availableKeys,
                   humanNameMap: this.humanNameMap,
+                  dialogTitle: this.dialogTitle || "Add Metadata Key",
                 },
                 restoreFocus: false,
               },

--- a/src/app/shared/modules/shared-condition/shared-condition.component.ts
+++ b/src/app/shared/modules/shared-condition/shared-condition.component.ts
@@ -43,7 +43,7 @@ export class SharedConditionComponent implements OnDestroy {
   @Input() addConditionAction: (condition: ScientificCondition) => void;
   @Input() removeConditionAction: (condition: ScientificCondition) => void;
   @Output() conditionsApplied = new EventEmitter<void>();
-  @Input() dialogTitle = "";
+  @Input() dialogTitle = "Add Metadata Key";
   allConditions$ = this.store.select(selectConditions);
 
   conditionConfigs$ = this.allConditions$.pipe(
@@ -262,7 +262,7 @@ export class SharedConditionComponent implements OnDestroy {
                   usedFields: usedFields,
                   parameterKeys: availableKeys,
                   humanNameMap: this.humanNameMap,
-                  dialogTitle: this.dialogTitle || "Add Metadata Key",
+                  dialogTitle: this.dialogTitle,
                 },
                 restoreFocus: false,
               },


### PR DESCRIPTION
## Description
This PR renames the search parameters dialog(condition) from "Add Characteristic" to "Add Metadata Key" and makes the title dynamic. 

Dataset page with default title:
<img width="1302" height="507" alt="image" src="https://github.com/user-attachments/assets/5bf06631-6a6b-476c-a033-b7b1fbf6a96a" />

Dataset page with dynamic title:

<img width="1303" height="451" alt="image" src="https://github.com/user-attachments/assets/fc7b16d4-b2cb-4d2c-b977-1240676e5a4f" />

Sample page with dynamic title:

<img width="1304" height="469" alt="image" src="https://github.com/user-attachments/assets/92f66432-7a05-45f5-8f06-9e711afbc2d0" />

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Make the search parameters dialog title configurable and update usages to use metadata-specific titles.

New Features:
- Allow the search parameters dialog to receive a customizable title via dialog data and component input.

Enhancements:
- Set context-specific default titles for dataset and sample metadata key dialogs in their respective filter/dashboard components.