### PR TITLE
fix(UI): prevent pop ups from obstructing the view of cell content

### DIFF
--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
@@ -154,7 +154,6 @@
           "
           matTooltipClass="cell-tooltip"
           matTooltipPosition="above"
-          matTooltipPositionAtOrigin
           matTooltipShowDelay="500"
           [disabled]="column.sort === 'none'"
           class="header-caption"
@@ -246,7 +245,6 @@
                   [innerHTML]="columnName(row, column)"
                   matTooltip="{{ columnName(row, column) }}"
                   matTooltipPosition="above"
-                  matTooltipPositionAtOrigin
                   matTooltipShowDelay="500"
                 ></span>
               </ng-template>
@@ -267,7 +265,6 @@
               <span
                 matTooltip="{{ getColumnValue(row, column) }}"
                 matTooltipPosition="above"
-                matTooltipPositionAtOrigin
                 matTooltipShowDelay="500"
               >
                 {{ getColumnValue(row, column) }}


### PR DESCRIPTION
## Description
This PR removes `matTooltipPositionAtOrigin` in `dynamic-mat-table` header and rows so that it now can appear correctly above cells without obstructing content.

Before: 
<img width="849" height="212" alt="image" src="https://github.com/user-attachments/assets/5ecdaea7-0f56-4b77-ad8a-a696c0630b57" />


After:
<img width="865" height="212" alt="image" src="https://github.com/user-attachments/assets/509b88cf-7178-4a52-8cde-c99a96bdb2e0" />


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Bug Fixes:
- Prevent table header and cell tooltips from overlapping and obstructing visible cell content in the dynamic material table.