### PR TITLE
feat: add configurable dialog action

### DIFF
--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -3,6 +3,8 @@ import { Injectable } from "@angular/core";
 import { mergeWith } from "lodash-es";
 import { firstValueFrom, of } from "rxjs";
 import { catchError, timeout } from "rxjs/operators";
+import { ActionConfig } from "shared/modules/configurable-actions/configurable-action.interfaces";
+import { DialogOptionData } from "shared/modules/dialog/dialog.component";
 import {
   DatasetDetailComponentConfig,
   IngestorComponentConfig,
@@ -88,13 +90,13 @@ export interface AppConfigInterface {
   datasetReduceEnabled: boolean;
   datasetDetailsShowMissingProposalId: boolean;
   datasetActionsEnabled: boolean;
-  datasetActions: any[];
+  datasetActions: ActionConfig[];
   datafilesActionsEnabled: boolean;
-  datafilesActions: any[];
+  datafilesActions: ActionConfig[];
   datasetDetailsActionsEnabled: boolean;
-  datasetDetailsActions: any[];
+  datasetDetailsActions: ActionConfig[];
   datasetSelectionActionsEnabled: boolean;
-  datasetSelectionActions: any[];
+  datasetSelectionActions: ActionConfig[];
   editDatasetEnabled: boolean;
   editDatasetSampleEnabled: boolean;
   editMetadataEnabled: boolean;
@@ -172,6 +174,8 @@ export interface AppConfigInterface {
   defaultTab?: DefaultTab;
   statusBannerMessage?: string;
   statusBannerCode?: "INFO" | "WARN";
+  batchActionsEnabled?: boolean;
+  batchActions?: ActionConfig[];
 }
 
 function isMainPageConfiguration(obj: any): obj is MainPageConfiguration {

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -3,6 +3,8 @@ import { Injectable } from "@angular/core";
 import { mergeWith } from "lodash-es";
 import { firstValueFrom, of } from "rxjs";
 import { catchError, timeout } from "rxjs/operators";
+import { ActionConfig } from "shared/modules/configurable-actions/configurable-action.interfaces";
+import { DialogOptionData } from "shared/modules/dialog/dialog.component";
 import {
   DatasetDetailComponentConfig,
   IngestorComponentConfig,
@@ -88,13 +90,13 @@ export interface AppConfigInterface {
   datasetReduceEnabled: boolean;
   datasetDetailsShowMissingProposalId: boolean;
   datasetActionsEnabled: boolean;
-  datasetActions: any[];
+  datasetActions: ActionConfig[];
   datafilesActionsEnabled: boolean;
-  datafilesActions: any[];
+  datafilesActions: ActionConfig[];
   datasetDetailsActionsEnabled: boolean;
-  datasetDetailsActions: any[];
+  datasetDetailsActions: ActionConfig[];
   datasetSelectionActionsEnabled: boolean;
-  datasetSelectionActions: any[];
+  datasetSelectionActions: ActionConfig[];
   editDatasetEnabled: boolean;
   editDatasetSampleEnabled: boolean;
   editMetadataEnabled: boolean;
@@ -172,6 +174,8 @@ export interface AppConfigInterface {
   statusBannerMessage?: string;
   statusBannerCode?: "INFO" | "WARN";
   autoApplyFilters?: boolean;
+  batchActionsEnabled?: boolean;
+  batchActions?: ActionConfig[];
 }
 
 function isMainPageConfiguration(obj: any): obj is MainPageConfiguration {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.html
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.html
@@ -1,14 +1,19 @@
 <ng-template [ngIf]="visible">
   <button
+    *ngIf="buttonStyle.raised" 
     mat-raised-button
-    class="action-button"
-    type="button"
-    (click)="perform_action()"
-    color="accent"
-    [disabled]="disabled"
-  >
-    <mat-icon *ngIf="use_mat_icon">{{ actionConfig.mat_icon }}</mat-icon>
-    <img *ngIf="use_icon" src="{{ actionConfig.icon }}" />
+    (click)="performAction()"
+    [color]="buttonStyle.color" 
+    [disabled]="disabled">
+    <mat-icon *ngIf="useMatIcon">{{ actionConfig.mat_icon }}</mat-icon>
+    <img *ngIf="useIcon" src="{{ actionConfig.icon }}" />
+    {{ actionConfig.label }}
+  </button>
+  <button *ngIf="!buttonStyle.raised" mat-button
+    [color]="buttonStyle.color" (click)="performAction()"
+    [disabled]="disabled">
+    <mat-icon *ngIf="useMatIcon">{{ actionConfig.mat_icon }}</mat-icon>
+    <img *ngIf="useIcon" src="{{ actionConfig.icon }}" />
     {{ actionConfig.label }}
   </button>
 </ng-template>

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -632,7 +632,7 @@ describe("1000: ConfigurableActionComponent", () => {
 
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -660,7 +660,7 @@ describe("1000: ConfigurableActionComponent", () => {
       .url.replace(/\/$/, "");
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     expect(component.form.action.replace(/\/$/, "")).toEqual(action_url);
   });
@@ -675,7 +675,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -700,7 +700,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -727,7 +727,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -751,7 +751,7 @@ describe("1000: ConfigurableActionComponent", () => {
       .url.replace(/\/$/, "");
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     expect(component.form.action.replace(/\/$/, "")).toEqual(action_url);
   });
@@ -766,7 +766,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -876,7 +876,7 @@ describe("1000: ConfigurableActionComponent", () => {
       ),
     );
 
-    component.perform_action();
+    component.performAction();
 
     const spy = window.fetch as jasmine.Spy;
     expect(spy.calls.any()).toBeTrue();
@@ -929,7 +929,7 @@ describe("1000: ConfigurableActionComponent", () => {
       ),
     );
 
-    component.perform_action();
+    component.performAction();
 
     const spy = window.fetch as jasmine.Spy;
 
@@ -973,7 +973,7 @@ describe("1000: ConfigurableActionComponent", () => {
       result: false,
     } as TestCase);
     spyOn(window, "open");
-    component.perform_action();
+    component.performAction();
 
     const current_action = mockActionsConfig.filter(
       (a) => a.id == actionSelectorType.link,

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -9,7 +9,7 @@ import { PipesModule } from "shared/pipes/pipes.module";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MatDialogModule, MatDialogRef } from "@angular/material/dialog";
 import { RouterModule } from "@angular/router";
-import { Store, StoreModule } from "@ngrx/store";
+import { StoreModule } from "@ngrx/store";
 import {
   MockAuthService,
   MockHtmlElement,
@@ -36,10 +36,10 @@ import {
   mockAppConfigService,
   mockUserProfiles,
 } from "./configurable-actions.test.data";
-import { Subject } from "rxjs";
+import { of } from "rxjs";
 import { MockStore, provideMockStore } from "@ngrx/store/testing";
 import { selectProfile } from "state-management/selectors/user.selectors";
-import { ActionItems } from "./configurable-action.interfaces";
+import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 
 describe("1000: ConfigurableActionComponent", () => {
   let component: ConfigurableActionComponent;
@@ -59,6 +59,8 @@ describe("1000: ConfigurableActionComponent", () => {
     publish = "9c6a11b6-a526-11f0-8795-6f025b320cc3",
     unpublish = "94a1d694-a526-11f0-947b-038d53cd837a",
     link = "c3bcbd40-a526-11f0-915a-93eeff0860ab",
+    dialog_open = "6a4d5226-1cf8-4dbf-a7db-9a4a16b1f523",
+    dialog_xhr = "4fcf5658-95f4-4fbd-99fd-8df4bb4bf0d0",
   }
 
   const usersControllerGetUserJWTV3 = () => ({
@@ -70,10 +72,6 @@ describe("1000: ConfigurableActionComponent", () => {
   // const getCurrentToken = () => ({
   //   id: "4ac45f3e-4d79-11ef-856c-6339dab93bee",
   // });
-
-  class MockUserProfile {
-    userProfile$ = new Subject<any>();
-  }
 
   beforeAll(() => {
     htmlForm = document.createElement("form");
@@ -124,7 +122,10 @@ describe("1000: ConfigurableActionComponent", () => {
     store = TestBed.inject(MockStore);
   }));
 
-  function createComponent(componentActionConfig, componentsActionItems) {
+  function createComponent(
+    componentActionConfig: ActionConfig,
+    componentsActionItems: ActionItems,
+  ) {
     fixture = TestBed.createComponent(ConfigurableActionComponent);
     component = fixture.componentInstance;
     component.actionConfig = componentActionConfig;
@@ -793,8 +794,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.download_all,
       )[0].label,
@@ -811,8 +813,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.download_selected,
       )[0].label,
@@ -829,8 +832,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.notebook_all_form,
       )[0].label,
@@ -847,8 +851,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.notebook_selected_form,
       )[0].label,
@@ -879,7 +884,7 @@ describe("1000: ConfigurableActionComponent", () => {
     component.performAction();
 
     const spy = window.fetch as jasmine.Spy;
-    expect(spy.calls.any()).toBeTrue();
+    expect(spy.calls.count()).toBeGreaterThan(0);
     const call = spy.calls.mostRecent();
     expect(call).toBeDefined();
     const [url, opts] = call.args;
@@ -933,7 +938,7 @@ describe("1000: ConfigurableActionComponent", () => {
 
     const spy = window.fetch as jasmine.Spy;
 
-    expect(spy.calls.any()).toBeTrue();
+    expect(spy.calls.count()).toBeGreaterThan(0);
     const call = spy.calls.mostRecent();
 
     expect(call).toBeDefined();
@@ -982,5 +987,61 @@ describe("1000: ConfigurableActionComponent", () => {
       current_action.url,
       current_action.target,
     );
+  });
+
+  it("1140: dialog action should open dialog with configured data", () => {
+    selectTestCase({
+      test: "n/a",
+      action: actionSelectorType.dialog_open,
+      limit: maxSizeType.higher,
+      actionItems: mockActionItemsDatafilesNofiles,
+      result: false,
+    } as TestCase);
+
+    spyOn(component.dialog, "open").and.returnValue({
+      afterClosed: () => of(undefined),
+    } as MatDialogRef<unknown>);
+
+    component.performAction();
+
+    expect(component.dialog.open).toHaveBeenCalled();
+  });
+
+  it("1150: dialog action should execute xhr on close using dialog variables", () => {
+    selectTestCase({
+      test: "n/a",
+      action: actionSelectorType.dialog_xhr,
+      limit: maxSizeType.higher,
+      actionItems: mockActionItemsDatafilesNofiles,
+      result: false,
+    } as TestCase);
+
+    spyOn(component.dialog, "open").and.returnValue({
+      afterClosed: () => of({ reason: "integration-test" }),
+    } as MatDialogRef<unknown>);
+
+    spyOn(window, "fetch").and.returnValue(
+      Promise.resolve(
+        new Response(new Blob(), {
+          status: 200,
+          statusText: "OK",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    component.performAction();
+
+    const fetchSpy = window.fetch as jasmine.Spy;
+    expect(fetchSpy.calls.count()).toBe(1);
+    const [url, opts] = fetchSpy.calls.mostRecent().args;
+    expect(url).toBe("https://example.org/action");
+
+    const requestOptions = opts as RequestInit;
+    expect(requestOptions.method).toBe("POST");
+
+    const body = JSON.parse(String(requestOptions.body));
+    expect(body.dataset).toBe(mockActionItemsDatafilesNofiles.datasets[0].pid);
+    expect(body.reason).toBe("integration-test");
   });
 });

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -38,7 +38,10 @@ import {
 } from "./configurable-actions.test.data";
 import { of } from "rxjs";
 import { MockStore, provideMockStore } from "@ngrx/store/testing";
-import { selectProfile } from "state-management/selectors/user.selectors";
+import {
+  selectIsAdmin,
+  selectProfile,
+} from "state-management/selectors/user.selectors";
 import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 
 describe("1000: ConfigurableActionComponent", () => {
@@ -1043,5 +1046,271 @@ describe("1000: ConfigurableActionComponent", () => {
     const body = JSON.parse(String(requestOptions.body));
     expect(body.dataset).toBe(mockActionItemsDatafilesNofiles.datasets[0].pid);
     expect(body.reason).toBe("integration-test");
+  });
+
+  it("1152: #datasetOwner token should enable action for owner", () => {
+    store.overrideSelector(selectProfile, mockUserProfiles[1]);
+    store.overrideSelector(selectIsAdmin, false);
+    store.refreshState();
+
+    const ownerConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "owner-enabled-test",
+      enabled: "#datasetOwner",
+      variables: {},
+    };
+
+    createComponent(ownerConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1153: #userIsAdmin token should enable action for admin", () => {
+    store.overrideSelector(selectProfile, mockUserProfiles[2]);
+    store.overrideSelector(selectIsAdmin, true);
+    store.refreshState();
+
+    const adminConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "admin-enabled-test",
+      enabled: "#userIsAdmin",
+      variables: {},
+    };
+
+    createComponent(adminConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1154: #isPublished token should follow dataset publish status", () => {
+    const publishedItems: ActionItems = {
+      datasets: structuredClone(mockActionItemsDatafilesNofiles.datasets),
+    };
+    publishedItems.datasets[0].isPublished = true;
+
+    const publishedConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "published-enabled-test",
+      enabled: "#isPublished",
+      variables: {},
+    };
+
+    createComponent(publishedConfig, publishedItems);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1155: #!isPublished token should follow dataset publish status", () => {
+    const unpublishedItems: ActionItems = {
+      datasets: structuredClone(mockActionItemsDatafilesNofiles.datasets),
+    };
+    unpublishedItems.datasets[0].isPublished = false;
+
+    const unpublishedConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "unpublished-enabled-test",
+      enabled: "#!isPublished",
+      variables: {},
+    };
+
+    createComponent(unpublishedConfig, unpublishedItems);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1156: #Length should evaluate selected file list length", () => {
+    const lengthConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "length-enabled-test",
+      enabled: "#Length(@files) > 0",
+      variables: {
+        files: "#Dataset0SelectedFilesPath",
+      },
+    };
+
+    createComponent(lengthConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeTrue();
+
+    createComponent(lengthConfig, mockActionItemsDatafilesFile1);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1157: #MaxDownloadableSize should compare against configured max size", () => {
+    mockAppConfigService.appConfig.maxDirectDownloadSize =
+      lowerMaxFileSizeLimit;
+
+    const sizeConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "max-download-enabled-test",
+      enabled: "#MaxDownloadableSize(@totalSize)",
+      variables: {
+        totalSize: "#Dataset0FilesTotalSize",
+      },
+    };
+
+    createComponent(sizeConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeTrue();
+
+    mockAppConfigService.appConfig.maxDirectDownloadSize =
+      higherMaxFileSizeLimit;
+    createComponent(sizeConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1158: hidden expression should hide action when condition is true", () => {
+    const hiddenConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "hidden-test",
+      hidden: "#Length(@files) === 0",
+      variables: {
+        files: "#Dataset0SelectedFilesPath",
+      },
+    };
+
+    createComponent(hiddenConfig, mockActionItemsDatafilesNofiles);
+    expect(component.visible).toBeFalse();
+
+    createComponent(hiddenConfig, mockActionItemsDatafilesFile1);
+    expect(component.visible).toBeTrue();
+  });
+
+  interface SelectorCoverageCase {
+    name: string;
+    selector: string;
+    expected: unknown;
+  }
+
+  const allKeywordMapSelectors: SelectorCoverageCase[] = [
+    {
+      name: "Dataset0Pid",
+      selector: "#Dataset0Pid",
+      expected: mockActionItems.datasets[0].pid,
+    },
+    {
+      name: "Dataset0FilesPath",
+      selector: "#Dataset0FilesPath",
+      expected: (mockActionItems.datasets[0].files || []).map((f) => f.path),
+    },
+    {
+      name: "Dataset0FilesTotalSize",
+      selector: "#Dataset0FilesTotalSize",
+      expected: (mockActionItems.datasets[0].files || []).reduce(
+        (sum, f) => sum + Number(f.size || 0),
+        0,
+      ),
+    },
+    {
+      name: "Dataset0SourceFolder",
+      selector: "#Dataset0SourceFolder",
+      expected: mockActionItems.datasets[0].sourceFolder,
+    },
+    {
+      name: "Dataset0SelectedFilesPath",
+      selector: "#Dataset0SelectedFilesPath",
+      expected: (mockActionItems.datasets[0].files || [])
+        .filter((f) => f.selected)
+        .map((f) => f.path),
+    },
+    {
+      name: "Dataset0SelectedFilesCount",
+      selector: "#Dataset0SelectedFilesCount",
+      expected: (mockActionItems.datasets[0].files || []).filter(
+        (f) => f.selected,
+      ).length,
+    },
+    {
+      name: "Dataset0SelectedFilesTotalSize",
+      selector: "#Dataset0SelectedFilesTotalSize",
+      expected: (mockActionItems.datasets[0].files || [])
+        .filter((f) => f.selected)
+        .reduce((sum, f) => sum + Number(f.size || 0), 0),
+    },
+    {
+      name: "DatasetIndexedField",
+      selector: "#Dataset[0]Field[isPublished]",
+      expected: mockActionItems.datasets[0].isPublished,
+    },
+    {
+      name: "DatasetsPid",
+      selector: "#DatasetsPid",
+      expected: mockActionItems.datasets.map((d) => d.pid),
+    },
+    {
+      name: "DatasetsSourceFolder",
+      selector: "#DatasetsSourceFolder",
+      expected: mockActionItems.datasets.map((d) => d.sourceFolder),
+    },
+    {
+      name: "DatasetsFilesPath",
+      selector: "#DatasetsFilesPath",
+      expected: mockActionItems.datasets.flatMap((d) =>
+        (d.files || []).map((f) => f.path),
+      ),
+    },
+    {
+      name: "DatasetsFilesTotalSize",
+      selector: "#DatasetsFilesTotalSize",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .reduce((sum, f) => sum + Number(f.size || 0), 0),
+    },
+    {
+      name: "DatasetsSelectedFilesPath",
+      selector: "#DatasetsSelectedFilesPath",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .filter((f) => f.selected)
+        .map((f) => f.path),
+    },
+    {
+      name: "DatasetsSelectedFilesCount",
+      selector: "#DatasetsSelectedFilesCount",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .filter((f) => f.selected).length,
+    },
+    {
+      name: "DatasetsSelectedFilesTotalSize",
+      selector: "#DatasetsSelectedFilesTotalSize",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .filter((f) => f.selected)
+        .reduce((sum, f) => sum + Number(f.size || 0), 0),
+    },
+    {
+      name: "DatasetsField",
+      selector: "#DatasetsField[sourceFolder]",
+      expected: mockActionItems.datasets.map((d) => d.sourceFolder),
+    },
+    {
+      name: "Dataset[0]Field[size]",
+      selector: "#Dataset[0]Field[size]",
+      expected: mockActionItems.datasets[0].size,
+    },
+    {
+      name: "#user.username",
+      selector: "#user.username",
+      expected: "abc",
+    },
+    {
+      name: "#prop1",
+      selector: "#prop1",
+      expected: "prop1Value",
+    },
+  ];
+
+  allKeywordMapSelectors.forEach((testCase) => {
+    it(`1160: ${testCase.name} selector should resolve`, () => {
+      const selectorConfig: ActionConfig = {
+        ...mockActionsConfig[0],
+        id: `selector-${testCase.name}`,
+        type: "link",
+        variables: {
+          value: testCase.selector,
+        },
+      };
+      createComponent(selectorConfig, {
+        ...mockActionItems,
+        user: { username: "abc" },
+        prop1: "prop1Value",
+      });
+      expect(component.variables["value"]).toEqual(testCase.expected);
+    });
   });
 });

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -79,7 +79,7 @@ describe("1000: ConfigurableActionComponent", () => {
 
   beforeAll(() => {
     htmlForm = document.createElement("form");
-    (htmlForm as HTMLFormElement).submit = () => { };
+    (htmlForm as HTMLFormElement).submit = () => {};
     htmlInput = document.createElement("input");
   });
 
@@ -1089,8 +1089,13 @@ describe("1000: ConfigurableActionComponent", () => {
     const requestOptions = opts as RequestInit;
     expect(requestOptions.method).toBe("POST");
 
-    const body = JSON.parse(String(requestOptions.body)) as Record<string, unknown>;
-    expect(body["dataset"]).toBe(mockActionItemsDatafilesNofiles.datasets[0].pid);
+    const body = JSON.parse(String(requestOptions.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(body["dataset"]).toBe(
+      mockActionItemsDatafilesNofiles.datasets[0].pid,
+    );
     expect(body["reason"]).toBe("integration-test");
   });
 

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -993,7 +993,40 @@ describe("1000: ConfigurableActionComponent", () => {
     );
   });
 
-  it("1140: should resolve dependent variables with array index extraction", () => {
+  it("1140: should build dependency graph", () => {
+    const variables: Record<string, unknown> = {
+      files: "#Dataset0FilesPath",
+      first: "@files[0]",
+      copy: "@first",
+    };
+
+    const graph = component.buildDependenciesGraph(variables);
+
+    expect(graph["files"]).toEqual(new Set<string>());
+    expect(graph["first"]).toEqual(new Set<string>(["files"]));
+    expect(graph["copy"]).toEqual(new Set<string>(["first"]));
+  });
+
+  it("1150: should support multiple dependencies", () => {
+    const variables: Record<string, unknown> = {
+      a: "@b",
+      b: "@c",
+      c: "@a",
+    };
+
+    const graph = component.buildDependenciesGraph(variables);
+
+    expect(graph["a"]).toEqual(new Set<string>(["b"]));
+    expect(graph["b"]).toEqual(new Set<string>(["c"]));
+    expect(graph["c"]).toEqual(new Set<string>(["a"]));
+  });
+
+  it("1160: should resolve dependent variables with array index extraction", () => {
+    // Mock the static dataset handler to return the files array when requested
+    spyOn(component as any, "buildDatasetStaticMap").and.returnValue({
+      "#Dataset0FilesPath": () => ["/file/1", "/file/2", "/file/3"],
+    });
+
     component.actionConfig = {
       variables: {
         files: "#Dataset0FilesPath",
@@ -1008,11 +1041,14 @@ describe("1000: ConfigurableActionComponent", () => {
       "/file/2",
       "/file/3",
     ]);
-
     expect(component.variables["first"]).toBe("/file/1");
   });
 
-  it("1150: should resolve chained configuration aliases", () => {
+  it("1170: should resolve chained dependencies", () => {
+    spyOn(component as any, "buildDatasetStaticMap").and.returnValue({
+      "#Dataset0FilesPath": () => ["/file/1", "/file/2", "/file/3"],
+    });
+
     component.actionConfig = {
       variables: {
         files: "#Dataset0FilesPath",
@@ -1026,7 +1062,29 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.variables["copy"]).toBe("/file/1");
   });
 
-  it("1160: should resolve selectors after variable substitution", () => {
+  it("1180: should detect cyclic dependencies", () => {
+    spyOn(console, "error");
+
+    component.actionConfig = {
+      variables: {
+        a: "@b",
+        b: "@a",
+      },
+    } as unknown as ActionConfig;
+
+    component["resolveVariableContext"]();
+
+    expect(console.error).toHaveBeenCalledWith(
+      jasmine.stringContaining("Cyclic dependency detected in variable"),
+    );
+  });
+
+  it("1190: should resolve selectors after variable substitution", () => {
+    // Mock datePipe transform response
+    (component as any).datePipe = {
+      transform: (date: Date, format: string) => "2026",
+    };
+
     component.actionConfig = {
       variables: {
         year: "#date_format(2026-05-12T14:53:45Z, yyyy)",

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -1001,7 +1001,7 @@ describe("1000: ConfigurableActionComponent", () => {
       },
     } as unknown as ActionConfig;
 
-    component.resolveVariableContext();
+    component["resolveVariableContext"]();
 
     expect(component.variables["files"]).toEqual([
       "/file/1",
@@ -1021,7 +1021,7 @@ describe("1000: ConfigurableActionComponent", () => {
       },
     } as unknown as ActionConfig;
 
-    component.resolveVariableContext();
+    component["resolveVariableContext"]();
 
     expect(component.variables["copy"]).toBe("/file/1");
   });
@@ -1033,7 +1033,7 @@ describe("1000: ConfigurableActionComponent", () => {
       },
     } as unknown as ActionConfig;
 
-    component.resolveVariableContext();
+    component["resolveVariableContext"]();
 
     expect(component.variables["year"]).toBe("2026");
   });

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -1096,7 +1096,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.variables["year"]).toBe("2026");
   });
 
-  it("1170: dialog action should open dialog with configured data", () => {
+  it("1200: dialog action should open dialog with configured data", () => {
     selectTestCase({
       test: "n/a",
       action: actionSelectorType.dialog_open,
@@ -1114,7 +1114,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.dialog.open).toHaveBeenCalled();
   });
 
-  it("1180: dialog action should execute xhr on close using dialog variables", () => {
+  it("1210: dialog action should execute xhr on close using dialog variables", () => {
     selectTestCase({
       test: "n/a",
       action: actionSelectorType.dialog_xhr,
@@ -1157,7 +1157,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(body["reason"]).toBe("integration-test");
   });
 
-  it("1152: #datasetOwner token should enable action for owner", () => {
+  it("1220: #datasetOwner token should enable action for owner", () => {
     store.overrideSelector(selectProfile, mockUserProfiles[1]);
     store.overrideSelector(selectIsAdmin, false);
     store.refreshState();
@@ -1173,7 +1173,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.disabled).toBeFalse();
   });
 
-  it("1153: #userIsAdmin token should enable action for admin", () => {
+  it("1230: #userIsAdmin token should enable action for admin", () => {
     store.overrideSelector(selectProfile, mockUserProfiles[2]);
     store.overrideSelector(selectIsAdmin, true);
     store.refreshState();
@@ -1189,7 +1189,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.disabled).toBeFalse();
   });
 
-  it("1154: #isPublished token should follow dataset publish status", () => {
+  it("1240: #isPublished token should follow dataset publish status", () => {
     const publishedItems: ActionItems = {
       datasets: structuredClone(mockActionItemsDatafilesNofiles.datasets),
     };
@@ -1206,7 +1206,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.disabled).toBeFalse();
   });
 
-  it("1155: #!isPublished token should follow dataset publish status", () => {
+  it("1250: #!isPublished token should follow dataset publish status", () => {
     const unpublishedItems: ActionItems = {
       datasets: structuredClone(mockActionItemsDatafilesNofiles.datasets),
     };
@@ -1223,7 +1223,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.disabled).toBeFalse();
   });
 
-  it("1156: #Length should evaluate selected file list length", () => {
+  it("1260: #Length should evaluate selected file list length", () => {
     const lengthConfig: ActionConfig = {
       ...mockActionsConfig[0],
       id: "length-enabled-test",
@@ -1240,7 +1240,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.disabled).toBeFalse();
   });
 
-  it("1157: #MaxDownloadableSize should compare against configured max size", () => {
+  it("1270: #MaxDownloadableSize should compare against configured max size", () => {
     mockAppConfigService.appConfig.maxDirectDownloadSize =
       lowerMaxFileSizeLimit;
 
@@ -1262,7 +1262,7 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.disabled).toBeFalse();
   });
 
-  it("1158: hidden expression should hide action when condition is true", () => {
+  it("1280: hidden expression should hide action when condition is true", () => {
     const hiddenConfig: ActionConfig = {
       ...mockActionsConfig[0],
       id: "hidden-test",
@@ -1405,7 +1405,7 @@ describe("1000: ConfigurableActionComponent", () => {
   ];
 
   allKeywordMapSelectors.forEach((testCase) => {
-    it(`1160: ${testCase.name} selector should resolve`, () => {
+    it(`1290: ${testCase.name} selector should resolve`, () => {
       const selectorConfig: ActionConfig = {
         ...mockActionsConfig[0],
         id: `selector-${testCase.name}`,

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -10,7 +10,7 @@ import { DatePipe } from "@angular/common";
 import { ReactiveFormsModule } from "@angular/forms";
 import { MatDialogModule, MatDialogRef } from "@angular/material/dialog";
 import { RouterModule } from "@angular/router";
-import { Store, StoreModule } from "@ngrx/store";
+import { StoreModule } from "@ngrx/store";
 import {
   MockAuthService,
   MockHtmlElement,
@@ -37,10 +37,10 @@ import {
   mockAppConfigService,
   mockUserProfiles,
 } from "./configurable-actions.test.data";
-import { Subject } from "rxjs";
+import { of } from "rxjs";
 import { MockStore, provideMockStore } from "@ngrx/store/testing";
 import { selectProfile } from "state-management/selectors/user.selectors";
-import { ActionItems } from "./configurable-action.interfaces";
+import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 
 describe("1000: ConfigurableActionComponent", () => {
   let component: ConfigurableActionComponent;
@@ -60,6 +60,8 @@ describe("1000: ConfigurableActionComponent", () => {
     publish = "9c6a11b6-a526-11f0-8795-6f025b320cc3",
     unpublish = "94a1d694-a526-11f0-947b-038d53cd837a",
     link = "c3bcbd40-a526-11f0-915a-93eeff0860ab",
+    dialog_open = "6a4d5226-1cf8-4dbf-a7db-9a4a16b1f523",
+    dialog_xhr = "4fcf5658-95f4-4fbd-99fd-8df4bb4bf0d0",
   }
 
   const usersControllerGetUserJWTV3 = () => ({
@@ -72,13 +74,9 @@ describe("1000: ConfigurableActionComponent", () => {
   //   id: "4ac45f3e-4d79-11ef-856c-6339dab93bee",
   // });
 
-  class MockUserProfile {
-    userProfile$ = new Subject<any>();
-  }
-
   beforeAll(() => {
     htmlForm = document.createElement("form");
-    (htmlForm as HTMLFormElement).submit = () => {};
+    (htmlForm as HTMLFormElement).submit = () => { };
     htmlInput = document.createElement("input");
   });
 
@@ -125,7 +123,10 @@ describe("1000: ConfigurableActionComponent", () => {
     store = TestBed.inject(MockStore);
   }));
 
-  function createComponent(componentActionConfig, componentsActionItems) {
+  function createComponent(
+    componentActionConfig: ActionConfig,
+    componentsActionItems: ActionItems,
+  ) {
     fixture = TestBed.createComponent(ConfigurableActionComponent);
     component = fixture.componentInstance;
     component.actionConfig = componentActionConfig;
@@ -794,8 +795,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.download_all,
       )[0].label,
@@ -812,8 +814,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.download_selected,
       )[0].label,
@@ -830,8 +833,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.notebook_all_form,
       )[0].label,
@@ -848,8 +852,9 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
 
     const componentElement: HTMLElement = fixture.nativeElement;
-    const actionButton = componentElement.querySelector(".action-button");
-    expect(actionButton.innerHTML).toContain(
+    const actionButton = componentElement.querySelector("button");
+    expect(actionButton).not.toBeNull();
+    expect(actionButton?.textContent).toContain(
       mockActionsConfig.filter(
         (a) => a.id == actionSelectorType.notebook_selected_form,
       )[0].label,
@@ -880,7 +885,7 @@ describe("1000: ConfigurableActionComponent", () => {
     component.performAction();
 
     const spy = window.fetch as jasmine.Spy;
-    expect(spy.calls.any()).toBeTrue();
+    expect(spy.calls.count()).toBeGreaterThan(0);
     const call = spy.calls.mostRecent();
     expect(call).toBeDefined();
     const [url, opts] = call.args;
@@ -934,7 +939,7 @@ describe("1000: ConfigurableActionComponent", () => {
 
     const spy = window.fetch as jasmine.Spy;
 
-    expect(spy.calls.any()).toBeTrue();
+    expect(spy.calls.count()).toBeGreaterThan(0);
     const call = spy.calls.mostRecent();
 
     expect(call).toBeDefined();
@@ -985,43 +990,15 @@ describe("1000: ConfigurableActionComponent", () => {
     );
   });
 
-  it("1140: should build dependency graph", () => {
-    const variables = {
-      files: "#Dataset0FilesPath",
-      first: "@files[0]",
-      copy: "@first",
-    };
-
-    const graph = component.buildDependenciesGraph(variables);
-
-    expect(graph["files"]).toEqual(new Set());
-    expect(graph["first"]).toEqual(new Set(["files"]));
-    expect(graph["copy"]).toEqual(new Set(["first"]));
-  });
-
-  it("1150:should support multiple dependencies", () => {
-    const variables = {
-      a: "@b",
-      b: "@c",
-      c: "@a",
-    };
-
-    const graph = component.buildDependenciesGraph(variables);
-
-    expect(graph["a"]).toEqual(new Set(["b"]));
-    expect(graph["b"]).toEqual(new Set(["c"]));
-    expect(graph["c"]).toEqual(new Set(["a"]));
-  });
-
-  it("1160: should resolve dependent variables", () => {
+  it("1140: should resolve dependent variables with array index extraction", () => {
     component.actionConfig = {
       variables: {
         files: "#Dataset0FilesPath",
         first: "@files[0]",
       },
-    } as any;
+    } as unknown as ActionConfig;
 
-    component.update_status();
+    component.resolveVariableContext();
 
     expect(component.variables["files"]).toEqual([
       "/file/1",
@@ -1032,44 +1009,85 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.variables["first"]).toBe("/file/1");
   });
 
-  it("1170: should resolve chained dependencies", () => {
+  it("1150: should resolve chained configuration aliases", () => {
     component.actionConfig = {
       variables: {
         files: "#Dataset0FilesPath",
         first: "@files[0]",
         copy: "@first",
       },
-    } as any;
+    } as unknown as ActionConfig;
 
-    component.update_status();
+    component.resolveVariableContext();
 
     expect(component.variables["copy"]).toBe("/file/1");
   });
 
-  it("1180: should detect cyclic dependencies", () => {
-    spyOn(console, "error");
-
-    component.actionConfig = {
-      variables: {
-        a: "@b",
-        b: "@a",
-      },
-    } as any;
-
-    component.update_status();
-
-    expect(console.error).toHaveBeenCalled();
-  });
-
-  it("1190: should resolve selectors after variable substitution", () => {
+  it("1160: should resolve selectors after variable substitution", () => {
     component.actionConfig = {
       variables: {
         year: "#date_format(2026-05-12T14:53:45Z, yyyy)",
       },
-    } as any;
+    } as unknown as ActionConfig;
 
-    component.update_status();
+    component.resolveVariableContext();
 
     expect(component.variables["year"]).toBe("2026");
+  });
+
+  it("1170: dialog action should open dialog with configured data", () => {
+    selectTestCase({
+      test: "n/a",
+      action: actionSelectorType.dialog_open,
+      limit: maxSizeType.higher,
+      actionItems: mockActionItemsDatafilesNofiles,
+      result: false,
+    } as TestCase);
+
+    spyOn(component.dialog, "open").and.returnValue({
+      afterClosed: () => of(undefined),
+    } as MatDialogRef<unknown>);
+
+    component.performAction();
+
+    expect(component.dialog.open).toHaveBeenCalled();
+  });
+
+  it("1180: dialog action should execute xhr on close using dialog variables", () => {
+    selectTestCase({
+      test: "n/a",
+      action: actionSelectorType.dialog_xhr,
+      limit: maxSizeType.higher,
+      actionItems: mockActionItemsDatafilesNofiles,
+      result: false,
+    } as TestCase);
+
+    spyOn(component.dialog, "open").and.returnValue({
+      afterClosed: () => of({ reason: "integration-test" }),
+    } as MatDialogRef<unknown>);
+
+    spyOn(window, "fetch").and.returnValue(
+      Promise.resolve(
+        new Response(new Blob(), {
+          status: 200,
+          statusText: "OK",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    component.performAction();
+
+    const fetchSpy = window.fetch as jasmine.Spy;
+    expect(fetchSpy.calls.count()).toBe(1);
+    const [url, opts] = fetchSpy.calls.mostRecent().args;
+    expect(url).toBe("https://example.org/action");
+
+    const requestOptions = opts as RequestInit;
+    expect(requestOptions.method).toBe("POST");
+
+    const body = JSON.parse(String(requestOptions.body)) as Record<string, unknown>;
+    expect(body["dataset"]).toBe(mockActionItemsDatafilesNofiles.datasets[0].pid);
+    expect(body["reason"]).toBe("integration-test");
   });
 });

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -39,7 +39,10 @@ import {
 } from "./configurable-actions.test.data";
 import { of } from "rxjs";
 import { MockStore, provideMockStore } from "@ngrx/store/testing";
-import { selectProfile } from "state-management/selectors/user.selectors";
+import {
+  selectIsAdmin,
+  selectProfile,
+} from "state-management/selectors/user.selectors";
 import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 
 describe("1000: ConfigurableActionComponent", () => {
@@ -1089,5 +1092,271 @@ describe("1000: ConfigurableActionComponent", () => {
     const body = JSON.parse(String(requestOptions.body)) as Record<string, unknown>;
     expect(body["dataset"]).toBe(mockActionItemsDatafilesNofiles.datasets[0].pid);
     expect(body["reason"]).toBe("integration-test");
+  });
+
+  it("1152: #datasetOwner token should enable action for owner", () => {
+    store.overrideSelector(selectProfile, mockUserProfiles[1]);
+    store.overrideSelector(selectIsAdmin, false);
+    store.refreshState();
+
+    const ownerConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "owner-enabled-test",
+      enabled: "#datasetOwner",
+      variables: {},
+    };
+
+    createComponent(ownerConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1153: #userIsAdmin token should enable action for admin", () => {
+    store.overrideSelector(selectProfile, mockUserProfiles[2]);
+    store.overrideSelector(selectIsAdmin, true);
+    store.refreshState();
+
+    const adminConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "admin-enabled-test",
+      enabled: "#userIsAdmin",
+      variables: {},
+    };
+
+    createComponent(adminConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1154: #isPublished token should follow dataset publish status", () => {
+    const publishedItems: ActionItems = {
+      datasets: structuredClone(mockActionItemsDatafilesNofiles.datasets),
+    };
+    publishedItems.datasets[0].isPublished = true;
+
+    const publishedConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "published-enabled-test",
+      enabled: "#isPublished",
+      variables: {},
+    };
+
+    createComponent(publishedConfig, publishedItems);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1155: #!isPublished token should follow dataset publish status", () => {
+    const unpublishedItems: ActionItems = {
+      datasets: structuredClone(mockActionItemsDatafilesNofiles.datasets),
+    };
+    unpublishedItems.datasets[0].isPublished = false;
+
+    const unpublishedConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "unpublished-enabled-test",
+      enabled: "#!isPublished",
+      variables: {},
+    };
+
+    createComponent(unpublishedConfig, unpublishedItems);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1156: #Length should evaluate selected file list length", () => {
+    const lengthConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "length-enabled-test",
+      enabled: "#Length(@files) > 0",
+      variables: {
+        files: "#Dataset0SelectedFilesPath",
+      },
+    };
+
+    createComponent(lengthConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeTrue();
+
+    createComponent(lengthConfig, mockActionItemsDatafilesFile1);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1157: #MaxDownloadableSize should compare against configured max size", () => {
+    mockAppConfigService.appConfig.maxDirectDownloadSize =
+      lowerMaxFileSizeLimit;
+
+    const sizeConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "max-download-enabled-test",
+      enabled: "#MaxDownloadableSize(@totalSize)",
+      variables: {
+        totalSize: "#Dataset0FilesTotalSize",
+      },
+    };
+
+    createComponent(sizeConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeTrue();
+
+    mockAppConfigService.appConfig.maxDirectDownloadSize =
+      higherMaxFileSizeLimit;
+    createComponent(sizeConfig, mockActionItemsDatafilesNofiles);
+    expect(component.disabled).toBeFalse();
+  });
+
+  it("1158: hidden expression should hide action when condition is true", () => {
+    const hiddenConfig: ActionConfig = {
+      ...mockActionsConfig[0],
+      id: "hidden-test",
+      hidden: "#Length(@files) === 0",
+      variables: {
+        files: "#Dataset0SelectedFilesPath",
+      },
+    };
+
+    createComponent(hiddenConfig, mockActionItemsDatafilesNofiles);
+    expect(component.visible).toBeFalse();
+
+    createComponent(hiddenConfig, mockActionItemsDatafilesFile1);
+    expect(component.visible).toBeTrue();
+  });
+
+  interface SelectorCoverageCase {
+    name: string;
+    selector: string;
+    expected: unknown;
+  }
+
+  const allKeywordMapSelectors: SelectorCoverageCase[] = [
+    {
+      name: "Dataset0Pid",
+      selector: "#Dataset0Pid",
+      expected: mockActionItems.datasets[0].pid,
+    },
+    {
+      name: "Dataset0FilesPath",
+      selector: "#Dataset0FilesPath",
+      expected: (mockActionItems.datasets[0].files || []).map((f) => f.path),
+    },
+    {
+      name: "Dataset0FilesTotalSize",
+      selector: "#Dataset0FilesTotalSize",
+      expected: (mockActionItems.datasets[0].files || []).reduce(
+        (sum, f) => sum + Number(f.size || 0),
+        0,
+      ),
+    },
+    {
+      name: "Dataset0SourceFolder",
+      selector: "#Dataset0SourceFolder",
+      expected: mockActionItems.datasets[0].sourceFolder,
+    },
+    {
+      name: "Dataset0SelectedFilesPath",
+      selector: "#Dataset0SelectedFilesPath",
+      expected: (mockActionItems.datasets[0].files || [])
+        .filter((f) => f.selected)
+        .map((f) => f.path),
+    },
+    {
+      name: "Dataset0SelectedFilesCount",
+      selector: "#Dataset0SelectedFilesCount",
+      expected: (mockActionItems.datasets[0].files || []).filter(
+        (f) => f.selected,
+      ).length,
+    },
+    {
+      name: "Dataset0SelectedFilesTotalSize",
+      selector: "#Dataset0SelectedFilesTotalSize",
+      expected: (mockActionItems.datasets[0].files || [])
+        .filter((f) => f.selected)
+        .reduce((sum, f) => sum + Number(f.size || 0), 0),
+    },
+    {
+      name: "DatasetIndexedField",
+      selector: "#Dataset[0]Field[isPublished]",
+      expected: mockActionItems.datasets[0].isPublished,
+    },
+    {
+      name: "DatasetsPid",
+      selector: "#DatasetsPid",
+      expected: mockActionItems.datasets.map((d) => d.pid),
+    },
+    {
+      name: "DatasetsSourceFolder",
+      selector: "#DatasetsSourceFolder",
+      expected: mockActionItems.datasets.map((d) => d.sourceFolder),
+    },
+    {
+      name: "DatasetsFilesPath",
+      selector: "#DatasetsFilesPath",
+      expected: mockActionItems.datasets.flatMap((d) =>
+        (d.files || []).map((f) => f.path),
+      ),
+    },
+    {
+      name: "DatasetsFilesTotalSize",
+      selector: "#DatasetsFilesTotalSize",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .reduce((sum, f) => sum + Number(f.size || 0), 0),
+    },
+    {
+      name: "DatasetsSelectedFilesPath",
+      selector: "#DatasetsSelectedFilesPath",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .filter((f) => f.selected)
+        .map((f) => f.path),
+    },
+    {
+      name: "DatasetsSelectedFilesCount",
+      selector: "#DatasetsSelectedFilesCount",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .filter((f) => f.selected).length,
+    },
+    {
+      name: "DatasetsSelectedFilesTotalSize",
+      selector: "#DatasetsSelectedFilesTotalSize",
+      expected: mockActionItems.datasets
+        .flatMap((d) => d.files || [])
+        .filter((f) => f.selected)
+        .reduce((sum, f) => sum + Number(f.size || 0), 0),
+    },
+    {
+      name: "DatasetsField",
+      selector: "#DatasetsField[sourceFolder]",
+      expected: mockActionItems.datasets.map((d) => d.sourceFolder),
+    },
+    {
+      name: "Dataset[0]Field[size]",
+      selector: "#Dataset[0]Field[size]",
+      expected: mockActionItems.datasets[0].size,
+    },
+    {
+      name: "#user.username",
+      selector: "#user.username",
+      expected: "abc",
+    },
+    {
+      name: "#prop1",
+      selector: "#prop1",
+      expected: "prop1Value",
+    },
+  ];
+
+  allKeywordMapSelectors.forEach((testCase) => {
+    it(`1160: ${testCase.name} selector should resolve`, () => {
+      const selectorConfig: ActionConfig = {
+        ...mockActionsConfig[0],
+        id: `selector-${testCase.name}`,
+        type: "link",
+        variables: {
+          value: testCase.selector,
+        },
+      };
+      createComponent(selectorConfig, {
+        ...mockActionItems,
+        user: { username: "abc" },
+        prop1: "prop1Value",
+      });
+      expect(component.variables["value"]).toEqual(testCase.expected);
+    });
   });
 });

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -1000,7 +1000,7 @@ describe("1000: ConfigurableActionComponent", () => {
       copy: "@first",
     };
 
-    const graph = component.buildDependenciesGraph(variables);
+    const graph = component["buildDependenciesGraph"](variables);
 
     expect(graph["files"]).toEqual(new Set<string>());
     expect(graph["first"]).toEqual(new Set<string>(["files"]));
@@ -1014,7 +1014,7 @@ describe("1000: ConfigurableActionComponent", () => {
       c: "@a",
     };
 
-    const graph = component.buildDependenciesGraph(variables);
+    const graph = component["buildDependenciesGraph"](variables);
 
     expect(graph["a"]).toEqual(new Set<string>(["b"]));
     expect(graph["b"]).toEqual(new Set<string>(["c"]));

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -633,7 +633,7 @@ describe("1000: ConfigurableActionComponent", () => {
 
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -661,7 +661,7 @@ describe("1000: ConfigurableActionComponent", () => {
       .url.replace(/\/$/, "");
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     expect(component.form.action.replace(/\/$/, "")).toEqual(action_url);
   });
@@ -676,7 +676,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -701,7 +701,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -728,7 +728,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -752,7 +752,7 @@ describe("1000: ConfigurableActionComponent", () => {
       .url.replace(/\/$/, "");
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     expect(component.form.action.replace(/\/$/, "")).toEqual(action_url);
   });
@@ -767,7 +767,7 @@ describe("1000: ConfigurableActionComponent", () => {
     } as TestCase);
     spyOn(document, "createElement").and.callFake(createFakeElement);
 
-    component.perform_action();
+    component.performAction();
 
     const formChildren = Array.from(component.form.children).map(
       (item) => item as unknown as MockHtmlElement,
@@ -877,7 +877,7 @@ describe("1000: ConfigurableActionComponent", () => {
       ),
     );
 
-    component.perform_action();
+    component.performAction();
 
     const spy = window.fetch as jasmine.Spy;
     expect(spy.calls.any()).toBeTrue();
@@ -930,7 +930,7 @@ describe("1000: ConfigurableActionComponent", () => {
       ),
     );
 
-    component.perform_action();
+    component.performAction();
 
     const spy = window.fetch as jasmine.Spy;
 
@@ -974,7 +974,7 @@ describe("1000: ConfigurableActionComponent", () => {
       result: false,
     } as TestCase);
     spyOn(window, "open");
-    component.perform_action();
+    component.performAction();
 
     const current_action = mockActionsConfig.filter(
       (a) => a.id == actionSelectorType.link,

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -1,117 +1,37 @@
 import {
   Component,
+  EventEmitter,
   Input,
   OnChanges,
   OnInit,
+  Output,
   SimpleChanges,
 } from "@angular/core";
-
-import { UsersService } from "@scicatproject/scicat-sdk-ts-angular";
-import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
-import { DataFiles_File } from "datasets/datafiles/datafiles.interfaces";
+import {
+  DatasetClass,
+  UsersService,
+} from "@scicatproject/scicat-sdk-ts-angular";
+import {
+  ActionButtonStyle,
+  ActionConfig,
+  ActionItemDataset,
+  ActionItems,
+  ActionType,
+  DialogField,
+} from "./configurable-action.interfaces";
 import { AuthService } from "shared/services/auth/auth.service";
-import { v4 } from "uuid";
+import { v4 as uuidv4 } from "uuid";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { Store } from "@ngrx/store";
-import { updatePropertyAction } from "state-management/actions/datasets.actions";
-import { Router } from "@angular/router";
 import { AppConfigService } from "app-config.service";
 import {
   selectIsAdmin,
   selectProfile,
 } from "state-management/selectors/user.selectors";
 import { Subscription } from "rxjs";
-import { result } from "lodash-es";
-
-type JSONValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JSONValue }
-  | JSONValue[];
-
-function processSelector(
-  jsonObject: ActionItems,
-  selector: string,
-): string | string[] | number | number[] {
-  let match: RegExpMatchArray | null;
-
-  // Map of static patterns to processing functions
-  const keywordMap: { [pattern: string]: (RegExpMatchArray) => any } = {
-    "#Dataset0Pid": (m) => jsonObject.datasets[0]?.pid,
-    "#Dataset0FilesPath": (m) =>
-      jsonObject.datasets[0]?.files?.map((i) => i.path),
-    "#Dataset0FilesTotalSize": (m) =>
-      jsonObject.datasets[0]?.files
-        ?.map((i) => Number(i.size))
-        .reduce((acc, val) => acc + val, 0),
-    "#Dataset0SourceFolder": (m) => jsonObject.datasets[0]?.sourceFolder,
-    "#Dataset0SelectedFilesPath": (m) =>
-      jsonObject.datasets[0]?.files
-        ?.filter((i) => i.selected)
-        .map((i) => i.path),
-    "#Dataset0SelectedFilesCount": (m) =>
-      jsonObject.datasets[0]?.files?.filter((i) => i.selected).length,
-    "#Dataset0SelectedFilesTotalSize": (m) =>
-      jsonObject.datasets[0]?.files
-        ?.filter((i) => i.selected)
-        .map((i) => Number(i.size))
-        .reduce((acc, val) => acc + val, 0),
-    // eslint-disable-next-line no-useless-escape
-    "#Dataset\\[(\\d+)\\]Field\\[(\\w+)\\]": (m) =>
-      jsonObject.datasets[Number(m[1])][m[2]],
-    "#DatasetsPid": (m) => jsonObject.datasets?.map((i) => i.pid),
-    "#DatasetsFilesPath": (m) =>
-      jsonObject.datasets
-        ?.map((i) => i.files)
-        .flat()
-        .map((i) => i.path),
-    "#DatasetsFilesTotalSize": (m) =>
-      jsonObject.datasets
-        ?.map((i) => i.files)
-        .flat()
-        .map((i) => Number(i.size))
-        .reduce((acc, val) => acc + val, 0),
-    "#DatasetsSourceFolder": (m) =>
-      jsonObject.datasets?.map((i) => i.sourceFolder),
-    "#DatasetsSelectedFilesPath": (m) =>
-      jsonObject.datasets
-        ?.map((i) => i.files)
-        .flat()
-        .filter((i) => i.selected)
-        .map((i) => i.path),
-    "#DatasetsSelectedFilesCount": (m) =>
-      jsonObject.datasets
-        ?.map((i) => i.files)
-        .flat()
-        .filter((i) => i.selected).length,
-    "#DatasetsSelectedFilesTotalSize": (m) =>
-      jsonObject.datasets
-        ?.map((i) => i.files)
-        .flat()
-        .filter((i) => i.selected)
-        .map((i) => Number(i.size))
-        .reduce((acc, val) => acc + val, 0),
-    // eslint-disable-next-line no-useless-escape
-    "#DatasetsField\\[(\\w+)\\]": (m) =>
-      jsonObject.datasets.map((i) => i[m[1]]),
-  };
-
-  // Check for direct pattern matches
-  for (const [pattern, fn] of Object.entries(keywordMap)) {
-    const match = selector.match(new RegExp(pattern));
-
-    if (match) {
-      const res = fn(match);
-
-      return res;
-    }
-  }
-
-  // No pattern matched, return selector itself
-  return selector;
-}
+import { DialogComponent, DynamicDialogData } from "../dialog/dialog.component";
+import { MatDialog } from "@angular/material/dialog";
+import _ from "lodash";
 
 @Component({
   selector: "configurable-action",
@@ -120,24 +40,38 @@ function processSelector(
   standalone: false,
 })
 export class ConfigurableActionComponent implements OnInit, OnChanges {
+  private authorizationTokens = {
+    "#jwt": () => this.jwt,
+    "#token": () => this.authService.getToken()?.id,
+    "#tokenSimple": () => this.authService.getToken()?.id,
+    "#tokenBearer": () => `Bearer ${this.authService.getToken()?.id}`,
+    "#uuid": () => uuidv4(),
+  };
+
   @Input({ required: true }) actionConfig: ActionConfig;
   @Input({ required: true }) actionItems: ActionItems;
-  //@Input() files?: DataFiles_File[];
+  @Input({ required: false }) buttonStyle: ActionButtonStyle = {
+    raised: true,
+    color: "accent",
+  };
+  @Output() actionFinished = new EventEmitter<{
+    success: boolean;
+    result?: unknown;
+    error?: Error;
+  }>();
+
   userProfile$ = this.store.select(selectProfile);
   isAdmin$ = this.store.select(selectIsAdmin);
 
   jwt = "";
-  use_mat_icon = false;
-  use_icon = false;
-  disabled_condition = "false";
-  variables: Record<string, any> = {};
+  useMatIcon = false;
+  useIcon = false;
 
-  form: HTMLFormElement = null;
-
-  subscriptions: Subscription[] = [];
-
+  variables: Record<string, unknown> = {};
   userProfile: any = {};
   isAdmin = false;
+  subscriptions: Subscription[] = [];
+  form: HTMLFormElement | null = null;
 
   constructor(
     private usersService: UsersService,
@@ -145,164 +79,309 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
     private configService: AppConfigService,
     private snackBar: MatSnackBar,
     private store: Store,
-    private router: Router,
+    public dialog: MatDialog,
   ) {
     this.usersService.usersControllerGetUserJWTV3().subscribe((jwt) => {
       this.jwt = jwt.jwt;
     });
   }
 
-  private evaluate_hidden_condition(condition: string) {
-    return condition
-      .replaceAll(
-        "#isPublished",
-        String(this.actionItems[0].isPublished === true),
-      )
-      .replaceAll(
-        "#!isPublished",
-        String(this.actionItems[0].isPublished === false),
-      );
-  }
-
-  private prepare_action_condition(condition: string) {
-    // Define replacements for specific functions and variables
-    return (
-      condition
-        // Handle #Length({{ files }})
-        .replace(
-          // eslint-disable-next-line no-useless-escape
-          /\#Length\(\s*\@(\w+)\s*\)/g,
-          (_, variableName) => `(variables.${variableName}?.length ?? 0)`,
-        )
-        // Handle #MaxDownloadableSize({{ totalSize }})
-        .replace(
-          ///#MaxDownloadableSize\(\{\{\s(\w+)\s\}\}\)/g,
-          // eslint-disable-next-line no-useless-escape
-          /\#MaxDownloadableSize\(@*(\w+)\)/g,
-          (_, variableName) =>
-            `variables.${variableName} <= maxDownloadableSize`,
-        )
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\#datasetOwner/g, (_) => `datasetOwner`)
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\#userIsAdmin/g, (_) => `isAdmin`)
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\#uuid/g, (_) => v4())
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\@(\w+)/g, (_, variableName) => `variables.${variableName}`)
+  private variableHandler(selector: string): unknown {
+    const dynamicKey = Object.keys(this.actionItems).find((key) =>
+      selector.startsWith(`#${key}`),
     );
+
+    if (dynamicKey) return this.dynamicVariableHandler(selector, dynamicKey);
+
+    const staticMap = this.buildDatasetStaticMap();
+
+    if (selector in staticMap) return staticMap[selector]();
+
+    if (selector.includes("Field[")) return this.fieldMatch(selector);
+
+    return undefined;
   }
 
-  private prepare_disabled_condition() {
-    if (this.actionConfig.enabled) {
-      this.disabled_condition =
-        "!(" + this.prepare_action_condition(this.actionConfig.enabled) + ")";
-    } else if (this.actionConfig.disabled) {
-      this.disabled_condition = this.prepare_action_condition(
-        this.actionConfig.disabled,
-      );
-    } else {
-      this.disabled_condition = "false";
-    }
+  private dynamicVariableHandler(
+    selector: string,
+    dynamicKey: string,
+  ): unknown {
+    if (selector === `#${dynamicKey}`) return this.actionItems[dynamicKey];
+    const path = selector.slice(dynamicKey.length + 2);
+    return _.get(this.actionItems[dynamicKey], path);
   }
 
-  private prepare_hidden_condition() {
-    if (this.actionConfig.hidden) {
-      return (
-        "!(" + this.evaluate_hidden_condition(this.actionConfig.hidden) + ")"
-      );
-    } else {
-      return "false";
-    }
-  }
-
-  ngOnInit() {
-    this.subscriptions.push(
-      this.userProfile$.subscribe((userProfile) => {
-        if (userProfile) {
-          this.userProfile = userProfile;
-        }
-      }),
+  private fieldMatch(selector: string): unknown {
+    const datasets = _.get(
+      this.actionItems,
+      "datasets",
+      [],
+    ) as ActionItemDataset[];
+    const allFieldMatch = selector.match(/^#DatasetsField\[(\w+)\]$/);
+    if (allFieldMatch) return _.map(datasets, allFieldMatch[1]);
+    const datasetFieldMatch = selector.match(
+      /^#Dataset\[(\d+)\]Field\[(\w+)\]$/,
     );
-    this.subscriptions.push(
-      this.isAdmin$.subscribe((isAdmin) => {
-        if (isAdmin) {
-          this.isAdmin = isAdmin;
-        }
-      }),
+    if (datasetFieldMatch) {
+      const index = Number(datasetFieldMatch[1]);
+      const field = datasetFieldMatch[2];
+      return _.get(datasets, `[${index}].${field}`);
+    }
+    return undefined;
+  }
+
+  private buildDatasetStaticMap() {
+    const datasets = _.get(
+      this.actionItems,
+      "datasets",
+      [],
+    ) as ActionItemDataset[];
+    const ds0 = _.get(datasets, "[0]");
+
+    const staticMap: Record<string, () => unknown> = {
+      "#Dataset0Pid": () => ds0?.pid,
+      "#Dataset0SourceFolder": () => ds0?.sourceFolder,
+      "#Dataset0FilesPath": () => _.map(ds0?.files, "path"),
+      "#Dataset0FilesTotalSize": () =>
+        _.sumBy(ds0?.files, (f) => Number(f.size || 0)),
+      "#Dataset0SelectedFilesPath": () =>
+        _(ds0?.files).filter("selected").map("path").value(),
+      "#Dataset0SelectedFilesCount": () =>
+        _(ds0?.files).filter("selected").size(),
+      "#Dataset0SelectedFilesTotalSize": () =>
+        _(ds0?.files)
+          .filter("selected")
+          .sumBy((f) => Number(f.size || 0)),
+      "#DatasetsPid": () => _.map(datasets, "pid"),
+      "#DatasetsSourceFolder": () => _.map(datasets, "sourceFolder"),
+      "#DatasetsFilesPath": () =>
+        _(datasets).flatMap("files").map("path").value(),
+      "#DatasetsFilesTotalSize": () =>
+        _(datasets)
+          .flatMap("files")
+          .sumBy((f) => Number(f.size || 0)),
+      "#DatasetsSelectedFilesPath": () =>
+        _(datasets).flatMap("files").filter("selected").map("path").value(),
+      "#DatasetsSelectedFilesCount": () =>
+        _(datasets).flatMap("files").filter("selected").size(),
+      "#DatasetsSelectedFilesTotalSize": () =>
+        _(datasets)
+          .flatMap("files")
+          .filter("selected")
+          .sumBy((f) => Number(f.size || 0)),
+    };
+    return staticMap;
+  }
+
+  private viewHandlers(condition: string): string {
+    let expr = condition;
+    const symbols: Record<string, string> = {
+      "#datasetOwner": "context.isOwner",
+      "#userIsAdmin": "context.isAdmin",
+      "#isPublished": String(
+        this.actionItems.datasets?.[0]?.isPublished === true,
+      ),
+      "#!isPublished": String(
+        this.actionItems.datasets?.[0]?.isPublished === false,
+      ),
+    };
+
+    Object.entries(symbols).forEach(([k, v]) => (expr = expr.replaceAll(k, v)));
+    expr = expr.replace(/@([\w.]+)/g, "variables.$1");
+    expr = expr.replace(/#Length\((.*?)\)/g, "($1?.length ?? 0)");
+    expr = expr.replace(
+      /#MaxDownloadableSize\((.*?)\)/g,
+      "$1 <= context.maxSize",
     );
-    this.use_mat_icon = !!this.actionConfig.mat_icon;
-    this.use_icon = this.actionConfig.icon !== undefined;
-    try {
-      this.prepare_disabled_condition();
-      this.update_status();
-    } catch (error) {
-      console.error("Configurable action error on init", error);
-    }
+
+    return expr;
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes["actionItems"]) {
-      try {
-        this.update_status();
-      } catch (error) {
-        console.error("Configurable action error on changes", error);
-      }
-    }
+  private authorizationHandlers(definition: string): string {
+    return this.authorizationTokens[definition]?.() ?? definition;
   }
 
-  update_status() {
-    Object.entries(this.actionConfig.variables ?? {}).forEach(
-      ([key, selector]) => {
-        this.variables[key] = processSelector(this.actionItems, selector);
+  private resolve(definition: string): unknown {
+    if (definition.startsWith("@"))
+      return _.get(this.variables, definition.slice(1));
+    if (definition in this.authorizationTokens)
+      return this.authorizationHandlers(definition);
+    return definition;
+  }
+
+  private interpolate(template: string): string {
+    if (!template) return "";
+    return template.replace(
+      /\{\{\s*([@#][\w.]+(\[\])?)\s*\}\}/g,
+      (fullMatch, match) => {
+        const isArray = match.endsWith("[]");
+        const clean = match.replace("[]", "");
+
+        const value = this.resolve(clean);
+        return isArray
+          ? JSON.stringify(_.castArray(value ?? []))
+          : String(value ?? "");
       },
     );
   }
 
-  get context() {
-    return {
-      variables: this.variables,
-      maxDownloadableSize: this.configService.getConfig().maxDirectDownloadSize,
-      datasetOwner: (
-        this.actionItems.datasets.map((d): boolean => {
-          return this.userProfile.accessGroups?.includes(d.ownerGroup) || false;
-        }) as Array<boolean>
-      ).some(Boolean),
-      isAdmin: this.isAdmin,
-    };
-  }
-
-  get disabled() {
-    let res = false;
+  private evaluate(expr: string): boolean {
     try {
-      this.update_status();
-
-      const expr = this.disabled_condition;
-      const fn = new Function("ctx", `with (ctx) { return (${expr}); }`);
-      const { context } = this;
-      res = fn(context);
-    } catch (error) {
-      console.error("Configurable action error on get disabled", error);
-    }
-    return res;
-  }
-
-  get visible() {
-    if (!this.actionConfig.hidden) {
-      return true;
-    } else {
-      const expr = this.prepare_hidden_condition();
-      const fn = new Function("ctx", `with (ctx) { return (${expr}); }`);
-
-      return fn({
+      const context = {
         variables: this.variables,
-        maxDownloadableSize:
-          this.configService.getConfig().maxDirectDownloadSize,
-      });
+        context: {
+          isAdmin: this.isAdmin,
+          isOwner: this.isDatasetOwner,
+          maxSize: this.configService.getConfig().maxDirectDownloadSize,
+        },
+      };
+      const fn = new Function("ctx", `with(ctx){ return ${expr}; }`);
+      return fn(context);
+    } catch (e) {
+      console.error("Evaluation error:", expr, e);
+      return false;
     }
   }
 
-  add_input(name: string, value: string) {
+  private get isDatasetOwner(): boolean {
+    const datasets = _.get(this.actionItems, "datasets", []) as DatasetClass[];
+    const userGroups = _.get(this.userProfile, "accessGroups", []) as string[];
+    return _.some(datasets, (d) => userGroups.includes(d.ownerGroup));
+  }
+
+  private resolveVariableContext() {
+    Object.entries(this.actionConfig.variables ?? {}).forEach(
+      ([key, selector]) => {
+        this.variables[key] = this.variableHandler(selector);
+      },
+    );
+  }
+  private typeXhr() {
+    const url = this.interpolate(this.actionConfig.url);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    Object.entries(this.actionConfig.headers || {}).forEach(([k, v]) => {
+      headers[k] = String(this.resolve(v));
+    });
+
+    fetch(url, {
+      method: this.actionConfig.method || "POST",
+      headers,
+      body: this.preparePayload(),
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const data = await r.json().catch(() => ({}));
+
+        this.actionFinishedEmit(true, data);
+      })
+      .catch((err: Error) => {
+        this.snackBar.open("Action failed", "Close", { duration: 2000 });
+        this.actionFinishedEmit(false, err);
+      });
+    return true;
+  }
+
+  private typeForm() {
+    if (this.form) document.body.removeChild(this.form);
+    this.form = document.createElement("form");
+    this.form.target = this.actionConfig.target || "_self";
+    this.form.method = this.actionConfig.method || "POST";
+    this.form.action = this.actionConfig.url;
+    this.form.style.display = "none";
+
+    Object.entries(this.actionConfig.inputs || {}).forEach(([input, def]) => {
+      const value = this.resolve(def);
+
+      if (input.endsWith("[]")) {
+        const name = input.slice(0, -2);
+        _.castArray(value).forEach((v, i) =>
+          this.form!.appendChild(
+            this.addInputElement(`${name}[${i}]`, String(v)),
+          ),
+        );
+      } else {
+        this.form!.appendChild(this.addInputElement(input, String(value)));
+      }
+    });
+
+    document.body.appendChild(this.form);
+    this.form.submit();
+    return true;
+  }
+
+  private preparePayload(): string {
+    const { payload } = this.actionConfig;
+    if (payload === "#dump") return JSON.stringify(this.variables);
+    if (!payload || payload === "#empty") return "{}";
+    return this.interpolate(payload);
+  }
+
+  private typeJsonToDownload() {
+    const filename = this.interpolate(
+      this.actionConfig.filename || "download.json",
+    );
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    Object.entries(this.actionConfig.headers || {}).forEach(([k, v]) => {
+      headers[k] = String(this.resolve(v));
+    });
+
+    fetch(this.actionConfig.url, {
+      method: this.actionConfig.method || "POST",
+      headers,
+      body: this.preparePayload(),
+    })
+      .then((r) => (r.ok ? r.blob() : Promise.reject()))
+      .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+      })
+      .catch(() =>
+        this.snackBar.open("Download failed", "Close", { duration: 2000 }),
+      );
+    return true;
+  }
+
+  private typeLink() {
+    window.open(this.actionConfig.url, this.actionConfig.target || "_self");
+  }
+
+  private typeDialog() {
+    const dialogRef = this.dialog.open(DialogComponent, {
+      width: this.actionConfig.dialog?.width || "450px",
+      data: this.prepareDialogData(),
+    });
+
+    dialogRef.afterClosed().subscribe((result: Record<string, any>) => {
+      if (!result) return;
+      const dialogRes: Record<string, any> = {};
+      this.actionConfig.dialog?.fields?.forEach((f) => {
+        const v = result[f.key];
+        dialogRes[f.key] =
+          v && typeof v === "object" && "option" in v ? v.option : v;
+      });
+      this.variables["dialog"] = dialogRes;
+      if (this.actionConfig.onSuccess)
+        this.executeNextStep(this.actionConfig.onSuccess);
+    });
+  }
+
+  private executeNextStep(nextStep: ActionType) {
+    if (nextStep === "xhr") this.typeXhr();
+    if (nextStep === "form") this.typeForm();
+    if (nextStep === "json-download") this.typeJsonToDownload();
+  }
+
+  private addInputElement(name: string, value: string): HTMLInputElement {
     const input = document.createElement("input");
     input.type = "hidden";
     input.name = name;
@@ -310,216 +389,85 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
     return input;
   }
 
-  perform_action() {
-    const action_type = this.actionConfig.type || "form";
-    switch (action_type) {
-      case "json-download":
-        return this.type_json_to_download();
-      case "xhr":
-        return this.type_xhr();
-      case "link":
-        return this.type_link();
-      case "form":
-      default:
-        return this.type_form();
-    }
-  }
+  private prepareDialogData(): DynamicDialogData {
+    const conf = this.actionConfig.dialog!;
+    const data: DynamicDialogData = {
+      title: conf.title || "Confirm",
+      question: conf.description || "",
+      additionalFields: {},
+    };
 
-  get_value_from_definition(definition: string) {
-    if (definition == "#token" || definition == "#tokenSimple") {
-      return this.authService.getToken().id;
-    } else if (definition == "#tokenBearer") {
-      return `Bearer ${this.authService.getToken().id}`;
-    } else if (definition == "#jwt") {
-      return this.jwt;
-    } else if (definition == "#uuid") {
-      return v4();
-    } else if (definition.startsWith("@")) {
-      return this.variables[definition.slice(1)];
-    }
-    return definition;
-  }
-
-  get_auth_headers(headers: Record<string, string>) {
-    const headerKey = "Authorization";
-    if (headerKey in headers) {
-      const currentValue = headers[headerKey];
-      const updatedValue = this.get_value_from_definition(currentValue);
-
-      headers[headerKey] = updatedValue;
-    }
-    return headers;
-  }
-
-  type_form() {
-    if (this.form !== null) {
-      document.body.removeChild(this.form);
-    }
-
-    this.form = document.createElement("form");
-    this.form.target = this.actionConfig.target || "_self";
-    this.form.method = this.actionConfig.method || "POST";
-    this.form.action = this.actionConfig.url;
-    this.form.style.display = "none";
-
-    // use the configuration under inputs to create the form
-    Object.entries(this.actionConfig.inputs).forEach(([input, definition]) => {
-      const value = this.get_value_from_definition(definition);
-
-      if (input.endsWith("[]")) {
-        const itemInput = input.slice(0, -2);
-
-        const iteratable = Array.isArray(value) ? value : [value];
-        iteratable.forEach((itemValue, itemIndex) => {
-          this.form.appendChild(
-            this.add_input(`${itemInput}[${itemIndex}]`, itemValue),
-          );
-        });
-      } else {
-        this.form.appendChild(this.add_input(input, value));
-      }
+    conf.fields?.forEach((f: DialogField) => {
+      data.additionalFields![f.key] = {
+        label: f.label,
+        type: f.type,
+        required: f.required,
+        options: f.options?.map((opt) => {
+          if (typeof opt === "string") return { option: opt };
+          return {
+            option: opt.option,
+            tooltip: opt.tooltip,
+            thumbnail: (opt as any).thumbnail || null,
+          };
+        }),
+      };
     });
 
-    document.body.appendChild(this.form);
-    this.form.submit();
-
-    return true;
+    return data;
   }
 
-  get_payload() {
-    let payload = "";
-    if (this.actionConfig.payload == "#dump") {
-      payload = JSON.stringify(this.variables);
-    } else if (
-      this.actionConfig.payload != "#empty" &&
-      this.actionConfig.payload
-    ) {
-      payload = this.actionConfig.payload;
+  private actionFinishedEmit(success: boolean, payload?: unknown) {
+    this.actionFinished.emit({
+      success,
+      result: success ? payload : undefined,
+      error: !success ? (payload as Error) : undefined,
+    });
+  }
+  get visible(): boolean {
+    this.resolveVariableContext();
+    if (!this.actionConfig.hidden) return true;
+    return !this.evaluate(this.viewHandlers(this.actionConfig.hidden));
+  }
+
+  get disabled(): boolean {
+    this.resolveVariableContext();
+    const raw = this.actionConfig.enabled
+      ? `!(${this.actionConfig.enabled})`
+      : this.actionConfig.disabled || "false";
+    return this.evaluate(this.viewHandlers(raw));
+  }
+
+  ngOnInit() {
+    this.subscriptions.push(
+      this.userProfile$.subscribe((up) => up && (this.userProfile = up)),
+    );
+    this.subscriptions.push(
+      this.isAdmin$.subscribe((ia) => (this.isAdmin = ia)),
+    );
+    this.useMatIcon = !!this.actionConfig.mat_icon;
+    this.useIcon = this.actionConfig.icon !== undefined;
+    this.resolveVariableContext();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes["actionItems"]) this.resolveVariableContext();
+  }
+
+  performAction() {
+    this.resolveVariableContext();
+    const type = this.actionConfig.type || "form";
+    switch (type) {
+      case "json-download":
+        return this.typeJsonToDownload();
+      case "xhr":
+        return this.typeXhr();
+      case "link":
+        return this.typeLink();
+      case "dialog":
+        return this.typeDialog();
+      case "form":
+      default:
+        return this.typeForm();
     }
-
-    const readyPayload = payload.replace(
-      /\{\{\s*([@#]\w+(\[\])?)\s*\}\}/g,
-      (_, variableName) => {
-        if (variableName.endsWith("[]")) {
-          const variableNameClean = variableName.slice(0, -2);
-          const value = this.get_value_from_definition(variableNameClean);
-
-          const iteratable = !value
-            ? []
-            : Array.isArray(value)
-              ? value
-              : [value];
-          return JSON.stringify(iteratable);
-        } else {
-          return this.get_value_from_definition(variableName);
-        }
-      },
-    );
-
-    return readyPayload;
-  }
-
-  type_json_to_download() {
-    const filename = this.actionConfig.filename.replace(
-      /\{\{\s*([@#]\w+)\s*\}\}/g,
-      (_, variableName) => this.get_value_from_definition(variableName),
-    );
-
-    const method = this.actionConfig.method || "POST";
-    const payload = this.get_payload();
-    const headers = this.get_auth_headers(this.actionConfig.headers || {});
-    fetch(this.actionConfig.url, {
-      method: method,
-      headers: {
-        ...{
-          "Content-Type": "application/json",
-        },
-        ...(headers || {}),
-      },
-      body: payload,
-    })
-      .then((response) => {
-        if (response.ok) {
-          return response.blob();
-        } else {
-          // http error
-          return Promise.reject(
-            new Error(`HTTP Error code: ${response.status}`),
-          );
-        }
-      })
-      .then((blob) => URL.createObjectURL(blob))
-      .then((url) => {
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = filename;
-        a.click();
-        URL.revokeObjectURL(url);
-      })
-      .catch((error) => {
-        this.snackBar.open(
-          "There has been an error performing the action",
-          "Close",
-          {
-            duration: 2000,
-          },
-        );
-      });
-
-    return true;
-  }
-
-  type_xhr() {
-    const url = this.actionConfig.url.replace(
-      /{{\s*(\w+)\s*}}/g,
-      (_, variableName) =>
-        encodeURIComponent(this.get_value_from_definition(variableName)),
-    );
-    const headers = this.get_auth_headers(this.actionConfig.headers || {});
-
-    fetch(url, {
-      method: this.actionConfig.method || "POST",
-      headers: {
-        ...{
-          "Content-Type": "application/json",
-        },
-        ...(headers || {}),
-      },
-      body: this.get_payload(),
-    })
-      .then((response) => {
-        if (!response.ok) {
-          return Promise.reject(
-            new Error(`HTTP Error code: ${response.status}`),
-          );
-        }
-
-        // specific only for datasets
-        // cannot be used
-        // this.store.dispatch(
-        //   updatePropertyAction({
-        //     method: this.actionConfig.method,
-        //     pid: element.pid,
-        //     property: JSON.parse(this.actionConfig.payload),
-        //   }),
-        // );
-
-        return response;
-      })
-      .catch((error) => {
-        this.snackBar.open(
-          "There has been an error performing the action",
-          "Close",
-          {
-            duration: 2000,
-          },
-        );
-      });
-
-    return true;
-  }
-
-  type_link() {
-    window.open(this.actionConfig.url, this.actionConfig.target || "_self");
   }
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -400,9 +400,11 @@ export class ConfigurableActionComponent
   }
 
   private typeDialog() {
+    const dialogData = this.prepareDialogData();
+    if (!dialogData) return;
     const dialogRef = this.dialog.open(DialogComponent, {
       width: this.actionConfig.dialog?.width || "450px",
-      data: this.prepareDialogData(),
+      data: dialogData,
     });
 
     dialogRef
@@ -419,14 +421,23 @@ export class ConfigurableActionComponent
         });
         this.variables["dialog"] = dialogRes;
         if (this.actionConfig.onSuccess)
-          this.executeNextStep(this.actionConfig.onSuccess);
+          try {
+            this.executeNextStep(this.actionConfig.onSuccess);
+          } catch (error) {
+            console.error("Configurable action error on dialog success", error);
+          }
       });
   }
 
   private executeNextStep(nextStep: ActionType) {
-    if (nextStep === "xhr") this.typeXhr();
-    if (nextStep === "form") this.typeForm();
-    if (nextStep === "json-download") this.typeJsonToDownload();
+    try {
+      if (nextStep === "xhr") this.typeXhr();
+      if (nextStep === "form") this.typeForm();
+      if (nextStep === "json-download") this.typeJsonToDownload();
+      else console.warn("Unsupported onSuccess action type:", nextStep);
+    } catch (error) {
+      console.error("Configurable action error on execute next step", error);
+    }
   }
 
   private addInputElement(name: string, value: string): HTMLInputElement {
@@ -437,8 +448,9 @@ export class ConfigurableActionComponent
     return input;
   }
 
-  private prepareDialogData(): DynamicDialogData {
-    const conf = this.actionConfig.dialog!;
+  private prepareDialogData(): DynamicDialogData | null {
+    const conf = this.actionConfig.dialog;
+    if (!conf) return null;
     const data: DynamicDialogData = {
       title: conf.title || "Confirm",
       question: conf.description || "",

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -292,7 +292,7 @@ export class ConfigurableActionComponent
     return _.some(datasets, (d) => userGroups.includes(d.ownerGroup));
   }
 
-  buildDependenciesGraph(
+  private buildDependenciesGraph(
     variables: Record<string, unknown>,
   ): Record<string, Set<string>> {
     /**

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -104,8 +104,8 @@ export class ConfigurableActionComponent
   private variableHandler(selector: unknown): unknown {
     if (typeof selector !== "string") return selector;
 
-    const processedSelector = this.interpolateCrossReferences(selector);
-
+    let processedSelector = this.interpolateCrossReferences(selector);
+    processedSelector = this.parseVariableTokens(processedSelector);
     const dynamicKey = Object.keys(this.actionItems).find((key) =>
       processedSelector.startsWith(`#${key}`),
     );
@@ -129,6 +129,19 @@ export class ConfigurableActionComponent
     if (selector === `#${dynamicKey}`) return this.actionItems[dynamicKey];
     const path = selector.slice(dynamicKey.length + 2);
     return _.get(this.actionItems[dynamicKey], path);
+  }
+
+  private parseVariableTokens(selector: string): string {
+    if (!selector.includes("#date_format")) return selector;
+
+    return selector.replace(
+      /#date_format\(([^,]+),\s*([^)]+)\)/g,
+      (_, dateInput, format) => {
+        const date = new Date(dateInput.trim());
+        if (isNaN(date.getTime())) return "";
+        return this.datePipe.transform(date, format.trim()) || "";
+      },
+    );
   }
 
   private fieldMatch(selector: string): unknown {
@@ -223,17 +236,6 @@ export class ConfigurableActionComponent
       /#MaxDownloadableSize\((.*?)\)/g,
       "$1 <= context.maxSize",
     );
-
-    if (expr.includes("#date_format")) {
-      expr = expr.replace(
-        /#date_format\(([^,]+),\\s*([^)]+)\)/g,
-        (_, dateInput, format) => {
-          const date = new Date(dateInput.trim());
-          if (isNaN(date.getTime())) return "''";
-          return `'${this.datePipe.transform(date, format.trim())}'`;
-        },
-      );
-    }
 
     return expr;
   }

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -1,25 +1,39 @@
 import {
   Component,
+  EventEmitter,
   Input,
   OnChanges,
   OnInit,
+  Output,
   SimpleChanges,
+  OnDestroy,
 } from "@angular/core";
 import { DatePipe } from "@angular/common";
-
-import { UsersService } from "@scicatproject/scicat-sdk-ts-angular";
-import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
+import {
+  DatasetClass,
+  UsersService,
+} from "@scicatproject/scicat-sdk-ts-angular";
+import {
+  ActionButtonStyle,
+  ActionConfig,
+  ActionItemDataset,
+  ActionItems,
+  ActionType,
+  DialogField,
+} from "./configurable-action.interfaces";
 import { AuthService } from "shared/services/auth/auth.service";
-import { v4 } from "uuid";
+import { v4 as uuidv4 } from "uuid";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { Store } from "@ngrx/store";
-import { Router } from "@angular/router";
 import { AppConfigService } from "app-config.service";
 import {
   selectIsAdmin,
   selectProfile,
 } from "state-management/selectors/user.selectors";
 import { Subscription } from "rxjs";
+import { DialogComponent, DynamicDialogData } from "../dialog/dialog.component";
+import { MatDialog } from "@angular/material/dialog";
+import _ from "lodash";
 
 @Component({
   selector: "configurable-action",
@@ -27,25 +41,41 @@ import { Subscription } from "rxjs";
   styleUrls: ["./configurable-action.component.scss"],
   standalone: false,
 })
-export class ConfigurableActionComponent implements OnInit, OnChanges {
+export class ConfigurableActionComponent
+  implements OnInit, OnChanges, OnDestroy
+{
+  private authorizationTokens = {
+    "#jwt": () => this.jwt,
+    "#token": () => this.authService.getToken()?.id,
+    "#tokenSimple": () => this.authService.getToken()?.id,
+    "#tokenBearer": () => `Bearer ${this.authService.getToken()?.id}`,
+    "#uuid": () => uuidv4(),
+  };
+
   @Input({ required: true }) actionConfig: ActionConfig;
   @Input({ required: true }) actionItems: ActionItems;
-  //@Input() files?: DataFiles_File[];
+  @Input({ required: false }) buttonStyle: ActionButtonStyle = {
+    raised: true,
+    color: "accent",
+  };
+  @Output() actionFinished = new EventEmitter<{
+    success: boolean;
+    result?: unknown;
+    error?: Error;
+  }>();
+
   userProfile$ = this.store.select(selectProfile);
   isAdmin$ = this.store.select(selectIsAdmin);
 
   jwt = "";
-  use_mat_icon = false;
-  use_icon = false;
-  disabled_condition = "false";
-  variables: Record<string, any> = {};
+  useMatIcon = false;
+  useIcon = false;
 
-  form: HTMLFormElement = null;
-
-  subscriptions: Subscription[] = [];
-
-  userProfile: any = {};
+  variables: Record<string, unknown> = {};
+  userProfile: Record<string, unknown> = {};
   isAdmin = false;
+  subscriptions: Subscription[] = [];
+  form: HTMLFormElement | null = null;
 
   constructor(
     private usersService: UsersService,
@@ -53,263 +83,429 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
     private configService: AppConfigService,
     private snackBar: MatSnackBar,
     private store: Store,
-    private router: Router,
     private datePipe: DatePipe,
+    public dialog: MatDialog,
   ) {
     this.usersService.usersControllerGetUserJWTV3().subscribe((jwt) => {
       this.jwt = jwt.jwt;
     });
   }
 
-  private evaluate_hidden_condition(condition: string) {
-    return condition
-      .replaceAll(
-        "#isPublished",
-        String(this.actionItems[0].isPublished === true),
-      )
-      .replaceAll(
-        "#!isPublished",
-        String(this.actionItems[0].isPublished === false),
-      );
+  private interpolateCrossReferences(selector: string): string {
+    if (!selector.includes("@")) return selector;
+
+    // Matches @variableName or @variableName[0] or @variableName.path
+    return selector.replace(/@([\w.[\]]+)/g, (__, path) => {
+      const value = _.get(this.variables, path);
+      return value !== undefined ? String(value) : "";
+    });
   }
 
-  private prepare_action_condition(condition: string) {
-    // Define replacements for specific functions and variables
-    return (
-      condition
-        // Handle #Length({{ files }})
-        .replace(
-          // eslint-disable-next-line no-useless-escape
-          /\#Length\(\s*\@(\w+)\s*\)/g,
-          (_, variableName) => `(variables.${variableName}?.length ?? 0)`,
-        )
-        // Handle #MaxDownloadableSize({{ totalSize }})
-        .replace(
-          ///#MaxDownloadableSize\(\{\{\s(\w+)\s\}\}\)/g,
-          // eslint-disable-next-line no-useless-escape
-          /\#MaxDownloadableSize\(@*(\w+)\)/g,
-          (_, variableName) =>
-            `variables.${variableName} <= maxDownloadableSize`,
-        )
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\#datasetOwner/g, (_) => `datasetOwner`)
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\#userIsAdmin/g, (_) => `isAdmin`)
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\#uuid/g, (_) => v4())
-        // eslint-disable-next-line no-useless-escape
-        .replace(/\@(\w+)/g, (_, variableName) => `variables.${variableName}`)
+  private variableHandler(selector: unknown): unknown {
+    if (typeof selector !== "string") return selector;
+
+    const processedSelector = this.interpolateCrossReferences(selector);
+
+    const dynamicKey = Object.keys(this.actionItems).find((key) =>
+      processedSelector.startsWith(`#${key}`),
+    );
+
+    if (dynamicKey)
+      return this.dynamicVariableHandler(processedSelector, dynamicKey);
+
+    const staticMap = this.buildDatasetStaticMap();
+    if (processedSelector in staticMap) return staticMap[processedSelector]();
+
+    if (processedSelector.includes("Field["))
+      return this.fieldMatch(processedSelector);
+
+    return processedSelector;
+  }
+
+  private dynamicVariableHandler(
+    selector: string,
+    dynamicKey: string,
+  ): unknown {
+    if (selector === `#${dynamicKey}`) return this.actionItems[dynamicKey];
+    const path = selector.slice(dynamicKey.length + 2);
+    return _.get(this.actionItems[dynamicKey], path);
+  }
+
+  private fieldMatch(selector: string): unknown {
+    const datasets = _.get(
+      this.actionItems,
+      "datasets",
+      [],
+    ) as ActionItemDataset[];
+    const allFieldMatch = selector.match(/^#DatasetsField\[(\w+)\]$/);
+    if (allFieldMatch) return _.map(datasets, allFieldMatch[1]);
+    const datasetFieldMatch = selector.match(
+      /^#Dataset\[(\d+)\]Field\[(\w+)\]$/,
+    );
+    if (datasetFieldMatch) {
+      const index = Number(datasetFieldMatch[1]);
+      const field = datasetFieldMatch[2];
+      return _.get(datasets, `[${index}].${field}`);
+    }
+
+    const instrumentFieldMatch = selector.match(
+      /^#Instruments\[(\d+)\]Field\[(\w+)\]$/,
+    );
+    if (instrumentFieldMatch) {
+      const index = Number(instrumentFieldMatch[1]);
+      const field = instrumentFieldMatch[2];
+      return _.get(this.actionItems, `instruments[${index}].${field}`);
+    }
+
+    return undefined;
+  }
+
+  private buildDatasetStaticMap() {
+    const datasets = _.get(
+      this.actionItems,
+      "datasets",
+      [],
+    ) as ActionItemDataset[];
+    const ds0 = _.get(datasets, "[0]");
+
+    const staticMap: Record<string, () => unknown> = {
+      "#Dataset0Pid": () => ds0?.pid,
+      "#Dataset0SourceFolder": () => ds0?.sourceFolder,
+      "#Dataset0FilesPath": () => _.map(ds0?.files, "path"),
+      "#Dataset0FilesTotalSize": () =>
+        _.sumBy(ds0?.files, (f) => Number(f.size || 0)),
+      "#Dataset0SelectedFilesPath": () =>
+        _(ds0?.files).filter("selected").map("path").value(),
+      "#Dataset0SelectedFilesCount": () =>
+        _(ds0?.files).filter("selected").size(),
+      "#Dataset0SelectedFilesTotalSize": () =>
+        _(ds0?.files)
+          .filter("selected")
+          .sumBy((f) => Number(f.size || 0)),
+      "#DatasetsPid": () => _.map(datasets, "pid"),
+      "#DatasetsSourceFolder": () => _.map(datasets, "sourceFolder"),
+      "#DatasetsFilesPath": () =>
+        _(datasets).flatMap("files").map("path").value(),
+      "#DatasetsFilesTotalSize": () =>
+        _(datasets)
+          .flatMap("files")
+          .sumBy((f) => Number(f.size || 0)),
+      "#DatasetsSelectedFilesPath": () =>
+        _(datasets).flatMap("files").filter("selected").map("path").value(),
+      "#DatasetsSelectedFilesCount": () =>
+        _(datasets).flatMap("files").filter("selected").size(),
+      "#DatasetsSelectedFilesTotalSize": () =>
+        _(datasets)
+          .flatMap("files")
+          .filter("selected")
+          .sumBy((f) => Number(f.size || 0)),
+    };
+    return staticMap;
+  }
+
+  private viewHandlers(condition: string): string {
+    let expr = condition;
+    const symbols: Record<string, string> = {
+      "#datasetOwner": "context.isOwner",
+      "#userIsAdmin": "context.isAdmin",
+      "#isPublished": String(
+        this.actionItems.datasets?.[0]?.isPublished === true,
+      ),
+      "#!isPublished": String(
+        this.actionItems.datasets?.[0]?.isPublished === false,
+      ),
+    };
+
+    Object.entries(symbols).forEach(([k, v]) => (expr = expr.replaceAll(k, v)));
+    expr = expr.replace(/@([\w.]+)/g, "variables.$1");
+    expr = expr.replace(/#Length\((.*?)\)/g, "($1?.length ?? 0)");
+    expr = expr.replace(
+      /#MaxDownloadableSize\((.*?)\)/g,
+      "$1 <= context.maxSize",
+    );
+
+    if (expr.includes("#date_format")) {
+      expr = expr.replace(
+        /#date_format\(([^,]+),\\s*([^)]+)\)/g,
+        (_, dateInput, format) => {
+          const date = new Date(dateInput.trim());
+          if (isNaN(date.getTime())) return "''";
+          return `'${this.datePipe.transform(date, format.trim())}'`;
+        },
+      );
+    }
+
+    return expr;
+  }
+
+  private authorizationHandlers(definition: string): string {
+    return this.authorizationTokens[definition]?.() ?? definition;
+  }
+
+  private resolve(definition: string): unknown {
+    if (definition.startsWith("@"))
+      return _.get(this.variables, definition.slice(1));
+    if (definition in this.authorizationTokens)
+      return this.authorizationHandlers(definition);
+    return definition;
+  }
+
+  private interpolate(template: string): string {
+    if (!template) return "";
+    return template.replace(
+      /\{\{\s*([@#][\w.]+(\[\])?)\s*\}\}/g,
+      (fullMatch, match) => {
+        const isArray = match.endsWith("[]");
+        const clean = match.replace("[]", "");
+
+        const value = this.resolve(clean);
+        return isArray
+          ? JSON.stringify(_.castArray(value ?? []))
+          : String(value ?? "");
+      },
     );
   }
 
-  private prepare_disabled_condition() {
-    if (this.actionConfig.enabled) {
-      this.disabled_condition =
-        "!(" + this.prepare_action_condition(this.actionConfig.enabled) + ")";
-    } else if (this.actionConfig.disabled) {
-      this.disabled_condition = this.prepare_action_condition(
-        this.actionConfig.disabled,
-      );
-    } else {
-      this.disabled_condition = "false";
-    }
-  }
-
-  private prepare_hidden_condition() {
-    if (this.actionConfig.hidden) {
-      return (
-        "!(" + this.evaluate_hidden_condition(this.actionConfig.hidden) + ")"
-      );
-    } else {
-      return "false";
-    }
-  }
-
-  private processSelector(
-    jsonObject: ActionItems,
-    selector: string,
-  ): string | string[] | number | number[] {
-    if (!jsonObject.datasets?.length) {
-      console.warn("No datasets available");
-      return undefined;
-    }
-    // Map of static patterns to processing functions
-    const keywordMap: { [pattern: string]: (RegExpMatchArray) => any } = {
-      "#Dataset0Pid": (m) => jsonObject.datasets[0]?.pid,
-      "#Dataset0FilesPath": (m) =>
-        jsonObject.datasets[0]?.files?.map((i) => i.path),
-      "#Dataset0FilesTotalSize": (m) =>
-        jsonObject.datasets[0]?.files
-          ?.map((i) => Number(i.size))
-          .reduce((acc, val) => acc + val, 0),
-      "#Dataset0SourceFolder": (m) => jsonObject.datasets[0]?.sourceFolder,
-      "#Dataset0SelectedFilesPath": (m) =>
-        jsonObject.datasets[0]?.files
-          ?.filter((i) => i.selected)
-          .map((i) => i.path),
-      "#Dataset0SelectedFilesCount": (m) =>
-        jsonObject.datasets[0]?.files?.filter((i) => i.selected).length,
-      "#Dataset0SelectedFilesTotalSize": (m) =>
-        jsonObject.datasets[0]?.files
-          ?.filter((i) => i.selected)
-          .map((i) => Number(i.size))
-          .reduce((acc, val) => acc + val, 0),
-      // eslint-disable-next-line no-useless-escape
-      "#Dataset\\[(\\d+)\\]Field\\[(\\w+)\\]": (m) => {
-        if (jsonObject.datasets?.[Number(m[1])]) {
-          return jsonObject.datasets?.[Number(m[1])][m[2]];
-        }
-      },
-      "#DatasetsPid": (m) => jsonObject.datasets?.map((i) => i.pid),
-      "#DatasetsFilesPath": (m) =>
-        jsonObject.datasets
-          ?.map((i) => i.files)
-          .flat()
-          .map((i) => i.path),
-      "#DatasetsFilesTotalSize": (m) =>
-        jsonObject.datasets
-          ?.map((i) => i.files)
-          .flat()
-          .map((i) => Number(i.size))
-          .reduce((acc, val) => acc + val, 0),
-      "#DatasetsSourceFolder": (m) =>
-        jsonObject.datasets?.map((i) => i.sourceFolder),
-      "#DatasetsSelectedFilesPath": (m) =>
-        jsonObject.datasets
-          ?.map((i) => i.files)
-          .flat()
-          .filter((i) => i.selected)
-          .map((i) => i.path),
-      "#DatasetsSelectedFilesCount": (m) =>
-        jsonObject.datasets
-          ?.map((i) => i.files)
-          .flat()
-          .filter((i) => i.selected).length,
-      "#DatasetsSelectedFilesTotalSize": (m) =>
-        jsonObject.datasets
-          ?.map((i) => i.files)
-          .flat()
-          .filter((i) => i.selected)
-          .map((i) => Number(i.size))
-          .reduce((acc, val) => acc + val, 0),
-      // eslint-disable-next-line no-useless-escape
-      "#DatasetsField\\[(\\w+)\\]": (m) =>
-        jsonObject.datasets?.map((i) => i[m[1]]),
-      "#Instruments\\[(\\d+)\\]Field\\[(\\w+)\\]": (m) => {
-        if (jsonObject.instruments?.[Number(m[1])]) {
-          return jsonObject.instruments?.[Number(m[1])][m[2]];
-        }
-      },
-      "#date_format\\(([^,]+),\\s*([^)]+)\\)": (m) => {
-        const dateInput = m[1].trim();
-        const format = m[2].trim();
-        const date = new Date(dateInput);
-
-        console.log(`Date: ${date} Format: ${format}`);
-        if (isNaN(date.getTime())) {
-          console.warn("Invalid date:", dateInput);
-          return "";
-        }
-        return this.datePipe.transform(date, format);
-      },
-    };
-    // Check for direct pattern matches
-    for (const [pattern, fn] of Object.entries(keywordMap)) {
-      const match = selector.match(new RegExp(pattern));
-      if (match) {
-        const res = fn(match);
-        return res;
-      }
-    }
-    // No pattern matched, return selector itself
-    return selector;
-  }
-
-  buildDependenciesGraph(variables: Record<string, any>) {
-    /**
-     * Builds a dependency graph for configured variables.
-     *
-     * Each graph entry maps a variable name to the set of other variables it
-     * references with `@variableName` syntax. The graph is later used to resolve
-     * variables in dependency order.
-     */
-    const graph: Record<string, Set<string>> = {};
-    Object.entries(variables).forEach(([key, value]) => {
-      const deps: string[] = [];
-      if (typeof value === "string") {
-        const matches = value.matchAll(/@(\w+)/g);
-        for (const match of matches) {
-          deps.push(match[1]);
-        }
-      }
-      graph[key] = new Set(deps);
-    });
-    return graph;
-  }
-
-  update_status() {
-    /**
-     * Resolves all variables declared in the action configuration.
-     *
-     * Variable definitions can reference other variables with `@name` and can
-     * read array entries with `@name[index]`. Dependencies are resolved first,
-     * then the final value is passed through `processSelector` so configured
-     * selectors are converted into values from the current action items.
-     */
-    const depsGraph = this.buildDependenciesGraph(this.actionConfig.variables);
-    const visited: Set<string> = new Set();
-    const resolveVariable = (varKey: string): any => {
-      const deps = depsGraph[varKey] ?? new Set();
-      for (const dep of deps ?? []) {
-        if (!(dep in this.variables)) {
-          if (visited.has(dep)) {
-            console.error(`Cyclic dependency detected in variable ${dep}`);
-            continue;
-          }
-          visited.add(dep);
-          this.variables[dep] = resolveVariable(dep);
-        }
-      }
-      const varDef = this.actionConfig.variables?.[varKey];
-      const resolved = varDef.replace(
-        /@(\w+)(\[(\d+)\])?/g,
-        (_, name, _fullIndex, index) => {
-          let value = this.variables[name];
-          if (value === undefined) return undefined;
-          if (index !== undefined) {
-            value = value?.[Number(index)];
-          }
-          return value;
+  private evaluate(expr: string): boolean {
+    try {
+      const context = {
+        variables: this.variables,
+        context: {
+          isAdmin: this.isAdmin,
+          isOwner: this.isDatasetOwner,
+          maxSize: this.configService.getConfig().maxDirectDownloadSize,
         },
-      );
-      return this.processSelector(this.actionItems, resolved);
+      };
+      const fn = new Function("ctx", `with(ctx){ return ${expr}; }`);
+      return fn(context);
+    } catch (e) {
+      console.error("Evaluation error:", expr, e);
+      return false;
+    }
+  }
+
+  private get isDatasetOwner(): boolean {
+    const datasets = _.get(this.actionItems, "datasets", []) as DatasetClass[];
+    const userGroups = _.get(this.userProfile, "accessGroups", []) as string[];
+    return _.some(datasets, (d) => userGroups.includes(d.ownerGroup));
+  }
+
+  private resolveVariableContext() {
+    Object.entries(this.actionConfig.variables ?? {}).forEach(
+      ([key, selector]) => {
+        this.variables[key] = this.variableHandler(selector);
+      },
+    );
+  }
+
+  private typeXhr() {
+    const url = this.interpolate(this.actionConfig.url);
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
     };
 
-    for (const key of Object.keys(this.actionConfig.variables ?? {})) {
-      this.variables[key] = resolveVariable(key);
+    Object.entries(this.actionConfig.headers || {}).forEach(([k, v]) => {
+      headers[k] = String(this.resolve(v));
+    });
+
+    fetch(url, {
+      method: this.actionConfig.method || "POST",
+      headers,
+      body: this.preparePayload(),
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const data = await r.json().catch(() => ({}));
+
+        this.actionFinishedEmit(true, data);
+      })
+      .catch((err: Error) => {
+        this.snackBar.open("Action failed", "Close", { duration: 2000 });
+        this.actionFinishedEmit(false, err);
+      });
+    return true;
+  }
+
+  private typeForm() {
+    if (this.form) document.body.removeChild(this.form);
+    this.form = document.createElement("form");
+    this.form.target = this.actionConfig.target || "_self";
+    this.form.method = this.actionConfig.method || "POST";
+    this.form.action = this.actionConfig.url;
+    this.form.style.display = "none";
+
+    Object.entries(this.actionConfig.inputs || {}).forEach(([input, def]) => {
+      const value = this.resolve(def);
+
+      if (input.endsWith("[]")) {
+        const name = input.slice(0, -2);
+        _.castArray(value).forEach((v, i) =>
+          this.form!.appendChild(
+            this.addInputElement(`${name}[${i}]`, String(v)),
+          ),
+        );
+      } else {
+        this.form!.appendChild(this.addInputElement(input, String(value)));
+      }
+    });
+
+    document.body.appendChild(this.form);
+    this.form.submit();
+    return true;
+  }
+
+  private preparePayload(): string {
+    const { payload } = this.actionConfig;
+    if (payload === "#dump") return JSON.stringify(this.variables);
+    if (!payload || payload === "#empty") return "{}";
+    return this.interpolate(payload);
+  }
+
+  private typeJsonToDownload() {
+    const filename = this.interpolate(
+      this.actionConfig.filename || "download.json",
+    );
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    Object.entries(this.actionConfig.headers || {}).forEach(([k, v]) => {
+      headers[k] = String(this.resolve(v));
+    });
+
+    fetch(this.actionConfig.url, {
+      method: this.actionConfig.method || "POST",
+      headers,
+      body: this.preparePayload(),
+    })
+      .then((r) => (r.ok ? r.blob() : Promise.reject()))
+      .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+      })
+      .catch(() =>
+        this.snackBar.open("Download failed", "Close", { duration: 2000 }),
+      );
+    return true;
+  }
+
+  private typeLink() {
+    window.open(this.actionConfig.url, this.actionConfig.target || "_self");
+  }
+
+  private typeDialog() {
+    const dialogRef = this.dialog.open(DialogComponent, {
+      width: this.actionConfig.dialog?.width || "450px",
+      data: this.prepareDialogData(),
+    });
+
+    dialogRef
+      .afterClosed()
+      .subscribe((result: Record<string, unknown> | undefined) => {
+        if (!result) return;
+        const dialogRes: Record<string, unknown> = {};
+        this.actionConfig.dialog?.fields?.forEach((f) => {
+          const v = result[f.key];
+          dialogRes[f.key] =
+            v && typeof v === "object" && "option" in v
+              ? (v as Record<string, unknown>).option
+              : v;
+        });
+        this.variables["dialog"] = dialogRes;
+        if (this.actionConfig.onSuccess)
+          this.executeNextStep(this.actionConfig.onSuccess);
+      });
+  }
+
+  private executeNextStep(nextStep: ActionType) {
+    if (nextStep === "xhr") this.typeXhr();
+    if (nextStep === "form") this.typeForm();
+    if (nextStep === "json-download") this.typeJsonToDownload();
+  }
+
+  private addInputElement(name: string, value: string): HTMLInputElement {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    return input;
+  }
+
+  private prepareDialogData(): DynamicDialogData {
+    const conf = this.actionConfig.dialog!;
+    const data: DynamicDialogData = {
+      title: conf.title || "Confirm",
+      question: conf.description || "",
+      additionalFields: {},
+    };
+
+    conf.fields?.forEach((f: DialogField) => {
+      data.additionalFields![f.key] = {
+        label: f.label,
+        type: f.type,
+        required: f.required,
+        options: f.options?.map((opt) => {
+          if (typeof opt === "string") return { option: opt };
+          return {
+            option: opt.option,
+            tooltip: opt.tooltip,
+          };
+        }),
+      };
+    });
+
+    return data;
+  }
+
+  private actionFinishedEmit(success: boolean, payload?: unknown) {
+    this.actionFinished.emit({
+      success,
+      result: success ? payload : undefined,
+      error: !success ? (payload as Error) : undefined,
+    });
+  }
+
+  get visible(): boolean {
+    try {
+      this.resolveVariableContext();
+      if (!this.actionConfig.hidden) return true;
+      return !this.evaluate(this.viewHandlers(this.actionConfig.hidden));
+    } catch (error) {
+      console.error("Configurable action error on get visible", error);
+      return false;
+    }
+  }
+
+  get disabled(): boolean {
+    try {
+      this.resolveVariableContext();
+      const raw = this.actionConfig.enabled
+        ? `!(${this.actionConfig.enabled})`
+        : this.actionConfig.disabled || "false";
+      return this.evaluate(this.viewHandlers(raw));
+    } catch (error) {
+      console.error("Configurable action error on get disabled", error);
+      return true;
     }
   }
 
   ngOnInit() {
     this.subscriptions.push(
-      this.userProfile$.subscribe((userProfile) => {
-        if (userProfile) {
-          this.userProfile = userProfile;
-        }
-      }),
+      this.userProfile$.subscribe(
+        (up) => up && (this.userProfile = up as Record<string, unknown>),
+      ),
     );
     this.subscriptions.push(
-      this.isAdmin$.subscribe((isAdmin) => {
-        if (isAdmin) {
-          this.isAdmin = isAdmin;
-        }
-      }),
+      this.isAdmin$.subscribe((ia) => (this.isAdmin = ia)),
     );
-    this.use_mat_icon = !!this.actionConfig.mat_icon;
-    this.use_icon = this.actionConfig.icon !== undefined;
+    this.useMatIcon = !!this.actionConfig.mat_icon;
+    this.useIcon = this.actionConfig.icon !== undefined;
     try {
-      this.prepare_disabled_condition();
-      this.update_status();
+      this.resolveVariableContext();
     } catch (error) {
       console.error("Configurable action error on init", error);
     }
@@ -318,313 +514,32 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes["actionItems"]) {
       try {
-        this.update_status();
+        this.resolveVariableContext();
       } catch (error) {
         console.error("Configurable action error on changes", error);
       }
     }
   }
 
-  get context() {
-    return {
-      variables: this.variables,
-      maxDownloadableSize: this.configService.getConfig().maxDirectDownloadSize,
-      datasetOwner: (
-        this.actionItems.datasets.map((d): boolean => {
-          return this.userProfile.accessGroups?.includes(d.ownerGroup) || false;
-        }) as Array<boolean>
-      ).some(Boolean),
-      isAdmin: this.isAdmin,
-    };
-  }
-
-  get disabled() {
-    let res = false;
-    try {
-      this.update_status();
-
-      const expr = this.disabled_condition;
-      const fn = new Function("ctx", `with (ctx) { return (${expr}); }`);
-      const { context } = this;
-      res = fn(context);
-    } catch (error) {
-      console.error("Configurable action error on get disabled", error);
-    }
-    return res;
-  }
-
-  get visible() {
-    if (!this.actionConfig.hidden) {
-      return true;
-    } else {
-      const expr = this.prepare_hidden_condition();
-      const fn = new Function("ctx", `with (ctx) { return (${expr}); }`);
-
-      return fn({
-        variables: this.variables,
-        maxDownloadableSize:
-          this.configService.getConfig().maxDirectDownloadSize,
-      });
-    }
-  }
-
-  add_input(name: string, value: string) {
-    const input = document.createElement("input");
-    input.type = "hidden";
-    input.name = name;
-    input.value = value;
-    return input;
-  }
-
-  perform_action() {
-    const action_type = this.actionConfig.type || "form";
-    switch (action_type) {
-      case "json-download":
-        return this.type_json_to_download();
-      case "xhr":
-        return this.type_xhr();
-      case "link":
-        return this.type_link();
-      case "form":
-      default:
-        return this.type_form();
-    }
-  }
-
-  get_value_from_definition(definition: string) {
-    if (definition == "#token" || definition == "#tokenSimple") {
-      return this.authService.getToken().id;
-    } else if (definition == "#tokenBearer") {
-      return `Bearer ${this.authService.getToken().id}`;
-    } else if (definition == "#jwt") {
-      return this.jwt;
-    } else if (definition == "#uuid") {
-      return v4();
-    } else if (definition.startsWith("@")) {
-      return this.variables[definition.slice(1)];
-    }
-    return definition;
-  }
-
-  get_auth_headers(headers: Record<string, string>) {
-    const headerKey = "Authorization";
-    if (headerKey in headers) {
-      const currentValue = headers[headerKey];
-      const updatedValue = this.get_value_from_definition(currentValue);
-
-      headers[headerKey] = updatedValue;
-    }
-    return headers;
-  }
-
-  prepare_url() {
-    if (this.actionConfig.url) {
-      return (
-        this.actionConfig.url
-          // eslint-disable-next-line no-useless-escape
-          .replace(
-            /\{\{\s*([@#]\w+(?:\[\d+\])?)\s*\}\}/g,
-            (_, variableName) => {
-              // Handle array indexing like @files[0]
-              const arrayMatch = variableName.match(/^([@#]\w+)\[(\d+)\]$/);
-              if (arrayMatch) {
-                const baseVariable = arrayMatch[1];
-                const index = parseInt(arrayMatch[2], 10);
-                const value = this.get_value_from_definition(baseVariable);
-
-                if (Array.isArray(value) && index < value.length) {
-                  return value[index];
-                }
-                console.error(
-                  `Could not resolve array ${variableName} at index ${index}`,
-                );
-                return "";
-              }
-              // Handle normal variables
-              return this.get_value_from_definition(variableName);
-            },
-          )
-      );
-    } else {
-      console.error("No URL provided for configurable action");
-      return "";
-    }
-  }
-
-  type_form() {
-    if (this.form !== null) {
-      document.body.removeChild(this.form);
-    }
-
-    this.form = document.createElement("form");
-    this.form.target = this.actionConfig.target || "_self";
-    this.form.method = this.actionConfig.method || "POST";
-    this.form.action = this.actionConfig.url;
-    this.form.style.display = "none";
-
-    // use the configuration under inputs to create the form
-    Object.entries(this.actionConfig.inputs).forEach(([input, definition]) => {
-      const value = this.get_value_from_definition(definition);
-
-      if (input.endsWith("[]")) {
-        const itemInput = input.slice(0, -2);
-
-        const iteratable = Array.isArray(value) ? value : [value];
-        iteratable.forEach((itemValue, itemIndex) => {
-          this.form.appendChild(
-            this.add_input(`${itemInput}[${itemIndex}]`, itemValue),
-          );
-        });
-      } else {
-        this.form.appendChild(this.add_input(input, value));
-      }
-    });
-
-    document.body.appendChild(this.form);
-    this.form.submit();
-
-    return true;
-  }
-
-  get_payload() {
-    let payload = "";
-    if (this.actionConfig.payload == "#dump") {
-      payload = JSON.stringify(this.variables);
-    } else if (
-      this.actionConfig.payload != "#empty" &&
-      this.actionConfig.payload
-    ) {
-      payload = this.actionConfig.payload;
-    }
-
-    const readyPayload = payload.replace(
-      /\{\{\s*([@#]\w+(\[\])?)\s*\}\}/g,
-      (_, variableName) => {
-        if (variableName.endsWith("[]")) {
-          const variableNameClean = variableName.slice(0, -2);
-          const value = this.get_value_from_definition(variableNameClean);
-
-          const iteratable = !value
-            ? []
-            : Array.isArray(value)
-              ? value
-              : [value];
-          return JSON.stringify(iteratable);
-        } else {
-          return this.get_value_from_definition(variableName);
-        }
-      },
-    );
-
-    return readyPayload;
-  }
-
-  type_json_to_download() {
-    const filename = this.actionConfig.filename.replace(
-      /\{\{\s*([@#]\w+)\s*\}\}/g,
-      (_, variableName) => this.get_value_from_definition(variableName),
-    );
-
-    const method = this.actionConfig.method || "POST";
-    const payload = this.get_payload();
-    const headers = this.get_auth_headers(this.actionConfig.headers || {});
-    fetch(this.actionConfig.url, {
-      method: method,
-      headers: {
-        ...{
-          "Content-Type": "application/json",
-        },
-        ...(headers || {}),
-      },
-      body: payload,
-    })
-      .then((response) => {
-        if (response.ok) {
-          return response.blob();
-        } else {
-          // http error
-          return Promise.reject(
-            new Error(`HTTP Error code: ${response.status}`),
-          );
-        }
-      })
-      .then((blob) => URL.createObjectURL(blob))
-      .then((url) => {
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = filename;
-        a.click();
-        URL.revokeObjectURL(url);
-      })
-      .catch((error) => {
-        this.snackBar.open(
-          "There has been an error performing the action",
-          "Close",
-          {
-            duration: 2000,
-          },
-        );
-      });
-
-    return true;
-  }
-
-  type_xhr() {
-    const url = this.actionConfig.url.replace(
-      /{{\s*(\w+)\s*}}/g,
-      (_, variableName) =>
-        encodeURIComponent(this.get_value_from_definition(variableName)),
-    );
-    const headers = this.get_auth_headers(this.actionConfig.headers || {});
-
-    fetch(url, {
-      method: this.actionConfig.method || "POST",
-      headers: {
-        ...{
-          "Content-Type": "application/json",
-        },
-        ...(headers || {}),
-      },
-      body: this.get_payload(),
-    })
-      .then((response) => {
-        if (!response.ok) {
-          return Promise.reject(
-            new Error(`HTTP Error code: ${response.status}`),
-          );
-        }
-
-        // specific only for datasets
-        // cannot be used
-        // this.store.dispatch(
-        //   updatePropertyAction({
-        //     method: this.actionConfig.method,
-        //     pid: element.pid,
-        //     property: JSON.parse(this.actionConfig.payload),
-        //   }),
-        // );
-
-        return response;
-      })
-      .catch((error) => {
-        this.snackBar.open(
-          "There has been an error performing the action",
-          "Close",
-          {
-            duration: 2000,
-          },
-        );
-      });
-
-    return true;
-  }
-
-  type_link() {
-    const url = this.prepare_url();
-    window.open(url, this.actionConfig.target || "_self");
-  }
-
   ngOnDestroy() {
     this.subscriptions.forEach((s) => s.unsubscribe());
+  }
+
+  performAction() {
+    this.resolveVariableContext();
+    const type = this.actionConfig.type || "form";
+    switch (type) {
+      case "json-download":
+        return this.typeJsonToDownload();
+      case "xhr":
+        return this.typeXhr();
+      case "link":
+        return this.typeLink();
+      case "dialog":
+        return this.typeDialog();
+      case "form":
+      default:
+        return this.typeForm();
+    }
   }
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -292,12 +292,66 @@ export class ConfigurableActionComponent
     return _.some(datasets, (d) => userGroups.includes(d.ownerGroup));
   }
 
-  private resolveVariableContext() {
-    Object.entries(this.actionConfig.variables ?? {}).forEach(
-      ([key, selector]) => {
-        this.variables[key] = this.variableHandler(selector);
-      },
-    );
+  buildDependenciesGraph(
+    variables: Record<string, unknown>,
+  ): Record<string, Set<string>> {
+    /**
+     * Builds a dependency graph for configured variables.
+     *
+     * Each graph entry maps a variable name to the set of other variables it
+     * references with `@variableName` syntax. The graph is later used to resolve
+     * variables in dependency order.
+     */
+    const graph: Record<string, Set<string>> = {};
+    Object.entries(variables).forEach(([key, value]) => {
+      const deps: string[] = [];
+      if (typeof value === "string") {
+        const matches = value.matchAll(/@(\w+)/g);
+        for (const match of matches) {
+          deps.push(match[1]);
+        }
+      }
+      graph[key] = new Set(deps);
+    });
+    return graph;
+  }
+
+  private resolveVariableContext(): void {
+    /**
+     * Resolves all variables declared in the action configuration.
+     *
+     * Variable definitions can reference other variables with `@name` and can
+     * read array entries with `@name[index]`. Dependencies are resolved first,
+     * then the final value is passed through variableHandler so configured
+     * selectors are converted cleanly.
+     */
+    const variablesConfig = this.actionConfig.variables ?? {};
+    const depsGraph = this.buildDependenciesGraph(variablesConfig);
+    const visited: Set<string> = new Set();
+
+    const resolveVariable = (varKey: string): unknown => {
+      const deps = depsGraph[varKey] ?? new Set<string>();
+
+      for (const dep of deps) {
+        if (!(dep in this.variables)) {
+          if (visited.has(dep)) {
+            console.error(`Cyclic dependency detected in variable ${dep}`);
+            continue;
+          }
+          visited.add(dep);
+          this.variables[dep] = resolveVariable(dep);
+        }
+      }
+
+      const varDef = variablesConfig[varKey];
+      return this.variableHandler(varDef);
+    };
+
+    Object.keys(variablesConfig).forEach((key) => {
+      if (!(key in this.variables)) {
+        this.variables[key] = resolveVariable(key);
+      }
+    });
   }
 
   private typeXhr() {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -327,31 +327,28 @@ export class ConfigurableActionComponent
      */
     const variablesConfig = this.actionConfig.variables ?? {};
     const depsGraph = this.buildDependenciesGraph(variablesConfig);
-    const visited: Set<string> = new Set();
+    const resolvedConfig: Record<string, unknown> = {};
 
-    const resolveVariable = (varKey: string): unknown => {
-      const deps = depsGraph[varKey] ?? new Set<string>();
-
-      for (const dep of deps) {
-        if (!(dep in this.variables)) {
-          if (visited.has(dep)) {
-            console.error(`Cyclic dependency detected in variable ${dep}`);
-            continue;
-          }
-          visited.add(dep);
-          this.variables[dep] = resolveVariable(dep);
-        }
+    const resolve = (key: string, currentPath: string[] = []): unknown => {
+      if (key in resolvedConfig) return resolvedConfig[key];
+      if (currentPath.includes(key)) {
+        console.error(`Cyclic dependency detected in variable ${key}`);
+        return undefined;
       }
 
-      const varDef = variablesConfig[varKey];
-      return this.variableHandler(varDef);
+      const deps = depsGraph[key] ?? new Set<string>();
+      deps.forEach((dep) => {
+        resolvedConfig[dep] = resolve(dep, [...currentPath, key]);
+      });
+
+      return this.variableHandler(variablesConfig[key]);
     };
 
     Object.keys(variablesConfig).forEach((key) => {
-      if (!(key in this.variables)) {
-        this.variables[key] = resolveVariable(key);
-      }
+      resolvedConfig[key] = resolve(key);
     });
+
+    this.variables = { ...this.variables, ...resolvedConfig };
   }
 
   private typeXhr() {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -337,17 +337,14 @@ export class ConfigurableActionComponent
       }
 
       const deps = depsGraph[key] ?? new Set<string>();
-      deps.forEach((dep) => {
-        resolvedConfig[dep] = resolve(dep, [...currentPath, key]);
-      });
-
-      return this.variableHandler(variablesConfig[key]);
+      deps.forEach((dep) => resolve(dep, [...currentPath, key]));
+      const finalValue = this.variableHandler(variablesConfig[key]);
+      resolvedConfig[key] = finalValue;
+      this.variables[key] = finalValue;
+      return finalValue;
     };
 
-    Object.keys(variablesConfig).forEach((key) => {
-      resolvedConfig[key] = resolve(key);
-    });
-
+    Object.keys(variablesConfig).forEach((key) => resolve(key));
     this.variables = { ...this.variables, ...resolvedConfig };
   }
 

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -1,18 +1,31 @@
 import { DataFiles_File } from "datasets/datafiles/datafiles.interfaces";
+import { DynamicField } from "../dialog/dialog.component";
+import { DatasetClass } from "@scicatproject/scicat-sdk-ts-angular";
+
+export type DialogField = { key: string } & DynamicField;
+
+export interface DialogConfig {
+  title?: string;
+  description?: string;
+  width?: string;
+  fields: DialogField[];
+}
+
+export type ActionType = "form" | "link" | "json-download" | "xhr" | "dialog";
 
 export interface ActionConfig {
   id: string;
   description?: string;
   order: number;
   label: string;
-  files?: string;
+  files?: "all" | "selected";
   mat_icon?: string;
   icon?: string;
-  type?: string;
+  type?: ActionType;
   url: string;
-  target: string;
+  target?: "_blank" | "_self" | "_parent" | "_top";
   authorization: string[];
-  method?: string;
+  method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
   enabled?: string;
   disabled?: string;
   payload?: string;
@@ -21,22 +34,20 @@ export interface ActionConfig {
   variables?: Record<string, string>;
   inputs?: Record<string, string>;
   headers?: Record<string, string>;
+  onSuccess?: ActionType;
+  dialog?: DialogConfig;
 }
 
-// export interface ActionItem {
-//   pid: string;
-//   sourceFolder?: string;
-//   isPublished?: boolean;
-// }
-
-export interface ActionItemDataset {
-  ownerGroup: string;
-  pid: string;
-  sourceFolder?: string;
-  isPublished?: boolean;
+export type ActionItemDataset = DatasetClass & {
   files?: DataFiles_File[];
-}
+};
 
 export interface ActionItems {
   datasets: ActionItemDataset[];
+  [key: string]: unknown;
+}
+
+export interface ActionButtonStyle {
+  raised?: boolean;
+  color?: "primary" | "accent" | "warn";
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -32,8 +32,8 @@ export interface ActionConfig {
   payload?: string;
   filename?: string;
   hidden?: string;
-  variables?: Record<string, string>;
   inputs?: Record<string, string>;
+  variables?: Record<string, unknown>;
   headers?: Record<string, string>;
   onSuccess?: ActionType;
   dialog?: DialogConfig;

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -1,19 +1,32 @@
 import { DataFiles_File } from "datasets/datafiles/datafiles.interfaces";
 import { Instrument } from "@scicatproject/scicat-sdk-ts-angular";
+import { DynamicField } from "../dialog/dialog.component";
+import { DatasetClass } from "@scicatproject/scicat-sdk-ts-angular";
+
+export type DialogField = { key: string } & DynamicField;
+
+export interface DialogConfig {
+  title?: string;
+  description?: string;
+  width?: string;
+  fields: DialogField[];
+}
+
+export type ActionType = "form" | "link" | "json-download" | "xhr" | "dialog";
 
 export interface ActionConfig {
   id: string;
   description?: string;
   order: number;
   label: string;
-  files?: string;
+  files?: "all" | "selected";
   mat_icon?: string;
   icon?: string;
-  type?: string;
+  type?: ActionType;
   url: string;
-  target: string;
+  target?: "_blank" | "_self" | "_parent" | "_top";
   authorization: string[];
-  method?: string;
+  method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
   enabled?: string;
   disabled?: string;
   payload?: string;
@@ -22,23 +35,21 @@ export interface ActionConfig {
   variables?: Record<string, string>;
   inputs?: Record<string, string>;
   headers?: Record<string, string>;
+  onSuccess?: ActionType;
+  dialog?: DialogConfig;
 }
 
-// export interface ActionItem {
-//   pid: string;
-//   sourceFolder?: string;
-//   isPublished?: boolean;
-// }
-
-export interface ActionItemDataset {
-  ownerGroup: string;
-  pid: string;
-  sourceFolder?: string;
-  isPublished?: boolean;
+export type ActionItemDataset = DatasetClass & {
   files?: DataFiles_File[];
-}
+};
 
 export interface ActionItems {
   datasets: ActionItemDataset[];
   instruments?: Instrument[];
+  [key: string]: unknown;
+}
+
+export interface ActionButtonStyle {
+  raised?: boolean;
+  color?: "primary" | "accent" | "warn";
 }

--- a/src/app/shared/modules/configurable-actions/configurable-actions.component.html
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.component.html
@@ -4,6 +4,8 @@
       *ngFor="let actionConfig of sortedActionsConfig"
       [actionConfig]="actionConfig"
       [actionItems]="actionItems"
+      [buttonStyle]="buttonsStyle"
+      (actionFinished)="actionFinished.emit($event)"
     >
     </configurable-action>
   </div>

--- a/src/app/shared/modules/configurable-actions/configurable-actions.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.component.spec.ts
@@ -107,6 +107,16 @@ describe("1010: ConfigurableActionsComponent", () => {
     expect(component.maxFileSize).toEqual(lowerMaxFileSizeLimit);
   });
 
+  it("0055: max file size should fallback to zero when not configured", () => {
+    const config = mockAppConfigService.appConfig as {
+      maxDirectDownloadSize?: number;
+      datafilesActionsEnabled: boolean;
+    };
+    config.maxDirectDownloadSize = undefined;
+
+    expect(component.maxFileSize).toEqual(0);
+  });
+
   it("0060: there should be as many actions as defined in default configuration", async () => {
     component.actionsConfig = mockActionsConfig;
 

--- a/src/app/shared/modules/configurable-actions/configurable-actions.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.component.ts
@@ -1,5 +1,9 @@
-import { Component, Input } from "@angular/core";
-import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import {
+  ActionButtonStyle,
+  ActionConfig,
+  ActionItems,
+} from "./configurable-action.interfaces";
 
 import { AppConfigService } from "app-config.service";
 
@@ -12,6 +16,15 @@ import { AppConfigService } from "app-config.service";
 export class ConfigurableActionsComponent {
   @Input({ required: true }) actionsConfig: ActionConfig[] = [];
   @Input({ required: true }) actionItems: ActionItems;
+  @Input({ required: false }) buttonsStyle: ActionButtonStyle = {
+    raised: true,
+    color: "accent",
+  };
+  @Output() actionFinished = new EventEmitter<{
+    success: boolean;
+    result?: unknown;
+    error?: Error;
+  }>();
 
   constructor(public appConfigService: AppConfigService) {}
 

--- a/src/app/shared/modules/configurable-actions/configurable-actions.documentation.md
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.documentation.md
@@ -120,7 +120,14 @@ Please review the offical documentation for this attribute https://www.w3schools
   - _Example_: "{{ uuid }}.ipynb"
   - _Keywords_: The string can contain any of the following keywords. They are substituted with the value indicated.
     - {{ uuid }}: random uuid v4 generated for each request.
-
+- __dialog__: configuration for a confirmation or parameters dialog modal to be prompted to the user before the action is executed.
+  - _Type_: object
+  - _Optional_: true
+  - _Fields_:
+    - `title` (string): Header text displayed at the top of the dialog modal.
+    - `description` (string): Explanatory prompt message shown below the title.
+    - `width` (string): CSS width dimension value for formatting the window layout container bounds.
+    - `fields` (object[]): Form element configurations layout array mapping user selections to context variables.
 
 ## Variable and selector resolution
 Configurable actions can define a `variables` object. Each entry is resolved before the action condition and request data are evaluated. This makes it possible to extract values from datasets, reuse them in other variables, and inject them into action configuration fields.
@@ -191,7 +198,9 @@ The configuration below will create the following 5 buttons under the "Datafiles
 5. Donwload ASll  
    Triggers the download of a zip file containing all the dataset files
    The zip file is created by an external service, which needs to be properly configured.
-
+6. Custom Action with Dialog  
+   Triggers a custom processing workflow by showing a UI configuration modal window first. The captured values from user selection elements and configuration inputs are then processed dynamically when executing the command pipeline sequence.
+  
 Configuration
 ```
 {
@@ -255,6 +264,38 @@ Configuration
       "target": "_blank",
       "enabled": "#Selected",
       "authorization": ["#datasetAccess", "#datasetPublic"]
+    },
+    {
+      "id": "b18274d0-bfd8-4a5c-89a1-026859336ab2",
+      "order": 6,
+      "label": "Custom Action with Dialog",
+      "files": "selected",
+      "mat_icon": "settings",
+      "type": "json-download",
+      "url": "https://api.scicatproject.org/actions/process",
+      "target": "_blank",
+      "enabled": "#Selected",
+      "authorization": ["#datasetAccess"],
+      "dialog": {
+        "title": "Configure Download Parameters",
+        "description": "Please select the processing cluster and format options for your download.",
+        "width": "500px",
+        "fields": [
+          {
+            "id": "cluster",
+            "label": "Target Cluster",
+            "type": "select",
+            "required": true,
+            "options": ["Cluster-A", "Cluster-B", "Cluster-C"]
+          },
+          {
+            "id": "compress",
+            "label": "Enable Compression",
+            "type": "boolean",
+            "default": true
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/app/shared/modules/configurable-actions/configurable-actions.test.data.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.test.data.ts
@@ -223,6 +223,43 @@ export const mockActionsConfig: ActionConfig[] = [
   },
 ];
 
+mockActionsConfig.push({
+  ...mockActionsConfig[0],
+  order: 9,
+  id: "6a4d5226-1cf8-4dbf-a7db-9a4a16b1f523",
+  label: "Dialog Action",
+  type: "dialog",
+  dialog: {
+    title: "Confirm",
+    description: "Why?",
+    width: "500px",
+    fields: [{ key: "reason", label: "Reason", type: "text" }],
+  },
+});
+
+mockActionsConfig.push({
+  ...mockActionsConfig[0],
+  order: 10,
+  id: "4fcf5658-95f4-4fbd-99fd-8df4bb4bf0d0",
+  label: "Dialog XHR",
+  type: "dialog",
+  method: "POST",
+  url: "https://example.org/action",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  variables: {
+    pid: "#Dataset0Pid",
+  },
+  payload: '{"dataset":"{{ @pid }}","reason":"{{ @dialog.reason }}"}',
+  onSuccess: "xhr",
+  dialog: {
+    title: "Confirm",
+    description: "Why?",
+    fields: [{ key: "reason", label: "Reason", type: "text" }],
+  },
+});
+
 export const mockActionItems: ActionItems = {
   datasets: [
     {
@@ -250,7 +287,7 @@ export const mockActionItems: ActionItems = {
           time: "2019-09-06T13:11:37.102Z",
         },
       ],
-    },
+    } as ActionItemDataset,
     {
       pid: "48217db2-bee2-11f0-ace4-b7a1618f0eba",
       sourceFolder: "/source/folder/2",
@@ -264,7 +301,7 @@ export const mockActionItems: ActionItems = {
           time: "2019-09-06T13:11:37.102Z",
         },
       ],
-    },
+    } as ActionItemDataset,
   ],
 };
 

--- a/src/app/shared/modules/configurable-actions/doc/configurable-actions-configuration-reference-table.md
+++ b/src/app/shared/modules/configurable-actions/doc/configurable-actions-configuration-reference-table.md
@@ -1,25 +1,27 @@
-| Option        | Type      | Required | Description                                            |
-| ------------- | --------- | -------- | ------------------------------------------------------ |
-| id            | string    | Yes      | Unique identifier for action                           |
-| order         | number    | Yes      | UI display order                                       |
-| label         | string    | Yes      | Button label text                                      |
-| description   | string    | No       | Tooltip/extra info                                     |
-| type          | string    | Yes      | "form", "link", "json-download", or "xhr"              |
-| method        | string    | No       | HTTP method for requests                               |
-| url           | string    | Yes      | Target URL (templated)                                 |
-| target        | string    | No       | Browser tab/window target                              |
-| icon          | string    | No       | Display icon (path to image asset)                     |
-| mat_icon      | string    | No       | Material icon name                                     |
-| files         | string    | No       | "all" or "selected" (file context)                     |
-| enabled       | string    | No       | Expression for enabling action                         |
-| disabled      | string    | No       | Expression for disabling action                        |
-| hidden        | string    | No       | Expression for hiding action                           |
-| authorization | string[]  | No       | Expressions for user/group authorization               |
-| variables     | object    | No       | Variable definitions and selectors                     |
-| inputs        | object    | No       | Form input mappings (for `"form"` type)                |
-| headers       | object    | No       | HTTP headers (for `"xhr"`, `"json-download"`)          |
-| payload       | string    | No       | Request body (`"xhr"`/`"json-download"` only)          |
-| filename      | string    | No       | Download filename (`"json-download"` only)             |
+| Option        | Type      | Required | Description                                                                         |
+| ------------- | --------- | -------- | ----------------------------------------------------------------------------------- |
+| id            | string    | Yes      | Unique identifier for action                                                        |
+| order         | number    | Yes      | UI display order                                                                    |
+| label         | string    | Yes      | Button label text                                                                   |
+| description   | string    | No       | Tooltip/extra info                                                                  |
+| type          | string    | Yes      | "form", "link", "json-download", "xhr", or "dialog"                                 |
+| method        | string    | No       | HTTP method for requests                                                            |
+| url           | string    | Yes      | Target URL (templated)                                                              |
+| target        | string    | No       | Browser tab/window target                                                           |
+| icon          | string    | No       | Display icon (path to image asset)                                                  |
+| mat_icon      | string    | No       | Material icon name                                                                  |
+| files         | string    | No       | "all" or "selected" (file context)                                                  |
+| enabled       | string    | No       | Expression for enabling action                                                      |
+| disabled      | string    | No       | Expression for disabling action                                                     |
+| hidden        | string    | No       | Expression for hiding action                                                        |
+| authorization | string[]  | No       | Expressions for user/group authorization                                            |
+| variables     | object    | No       | Variable definitions and selectors                                                  |
+| inputs        | object    | No       | Form input mappings (for `"form"` type)                                             |
+| headers       | object    | No       | HTTP headers (for `"xhr"`, `"json-download"`)                                       |
+| payload       | string    | No       | Request body (`"xhr"`/`"json-download"` only)                                       |
+| filename      | string    | No       | Download filename (`"json-download"` only)                                          |
+| onSuccess     | string    | No       | Next action type after dialog close (`"xhr"`, `"form"`, `"json-download"`)          |
+| dialog        | object    | No       | Dialog definition (`title`, `description`, `width`, `fields[]`) for `"dialog"` type |
 
 ---
 > **Note:** This document has been generated with the help of AI using Neutro, the ESS dedicated AI app.

--- a/src/app/shared/modules/configurable-actions/doc/configurable-actions-non-technical.md
+++ b/src/app/shared/modules/configurable-actions/doc/configurable-actions-non-technical.md
@@ -14,6 +14,7 @@ Configurable actions are special buttons in the ESS user interface that help you
 - **Generate notebooks** (for Jupyter or SciWyrm)
 - **Create download links**
 - **Change dataset status** (publish/unpublish)
+- **Ask for extra input in a dialog** before running an action
 - And more, as new options are added
 
 ## Common Button Types
@@ -25,6 +26,7 @@ Configurable actions are special buttons in the ESS user interface that help you
 | "Publish"               | Make your dataset publicly available        |
 | "Unpublish"             | Make your dataset private again             |
 | "ESS"                   | Link to an ESS webpage                      |
+| "Dialog"-based actions  | Ask for confirmation or user input first    |
 
 *(Note: The actual icon may look different in your UI.)*
 

--- a/src/app/shared/modules/configurable-actions/doc/configurable-actions-technical.md
+++ b/src/app/shared/modules/configurable-actions/doc/configurable-actions-technical.md
@@ -32,12 +32,13 @@ Below are supported configuration properties, their types, and descriptions.
 
 ### 5. `type`
 - **Type:** `string`
-- **Accepted values:** `form`, `link`, `json-download`, `xhr`
+- **Accepted values:** `form`, `link`, `json-download`, `xhr`, `dialog`
 - **Description:** Action execution mode:
     - `form`: Submits a hidden HTML form to `url`.
     - `link`: Opens URL in new tab/window.
     - `json-download`: Fetches data and starts file download.
     - `xhr`: Makes an XHR/fetch API call, optionally updating local state.
+    - `dialog`: Opens a configurable dialog before running a follow-up action.
 
 ### 6. `method`
 - **Type:** `string`
@@ -114,6 +115,21 @@ Below are supported configuration properties, their types, and descriptions.
 - **Type:** `string`
 - **Description:** *(json-download only)*. Name for downloaded file (can use template, eg: `{{ #uuid }}.ipynb`).
 
+### 21. `onSuccess`
+- **Type:** `string`
+- **Accepted values:** `xhr`, `form`, `json-download`
+- **Description:** *(dialog only)*. Action to execute after the dialog closes with valid user input.
+
+### 22. `dialog`
+- **Type:** `object`
+- **Description:** *(dialog only)* Defines dialog UI.
+
+  Typical shape:
+  - `title`: dialog title
+  - `description`: helper text/question
+  - `width`: dialog width (e.g. `"450px"`)
+  - `fields`: array of field definitions (`key`, `label`, `type`, `required`, `options`)
+
 ---
 
 ## Supported Selectors in `variables`
@@ -139,6 +155,14 @@ Below are supported configuration properties, their types, and descriptions.
 **Other runtime keywords:**
 - `#token`, `#tokenBearer`, `#jwt`, `#uuid`: Various tokens and a random UUID.
 - `@<variable>`: Variable defined in `variables` mapping.
+
+**Expression helper keywords (enabled/disabled/hidden):**
+- `#datasetOwner`: True if user belongs to owner group of at least one dataset
+- `#userIsAdmin`: True if user has admin role
+- `#isPublished`: True if first dataset is published
+- `#!isPublished`: True if first dataset is not published
+- `#Length(<expr>)`: Resolves to expression length (`0` if null/undefined)
+- `#MaxDownloadableSize(<expr>)`: Compares value against configured max direct download size
 
 ---
 

--- a/src/app/shared/modules/configurable-actions/doc/configurable-actions-technical.md
+++ b/src/app/shared/modules/configurable-actions/doc/configurable-actions-technical.md
@@ -116,19 +116,31 @@ Below are supported configuration properties, their types, and descriptions.
 - **Description:** *(json-download only)*. Name for downloaded file (can use template, eg: `{{ #uuid }}.ipynb`).
 
 ### 21. `onSuccess`
-- **Type:** `string`
-- **Accepted values:** `xhr`, `form`, `json-download`
-- **Description:** *(dialog only)*. Action to execute after the dialog closes with valid user input.
+- **Type:** `object` (ActionConfig)
+- **Description:** *(dialog only)*. A nested, secondary execution action object evaluated immediately after the dialog closes with valid user inputs.
+- **Safety Interceptor:** If the child configuration contains an unsupported or unmapped action execution type (e.g., misspelled), the engine handles the issue via an explicit `default` fallback catch to prevent sequential pipeline stalls.
 
 ### 22. `dialog`
 - **Type:** `object`
-- **Description:** *(dialog only)* Defines dialog UI.
+- **Description:** *(dialog only)* Defines dialog UI properties.
+  
+  **Supported Properties:**
+  - `title`: Dialog modal header title (Defaults to `"Confirm"`).
+  - `description`: Secondary instruction text or question.
+  - `width`: Structural modal width (e.g., `"450px"`).
+  - `fields`: Array of form field definitions (`key`, `label`, `type`, `required`, `options[]`).
+    - *Note on `options`*: Supports both primitive flat string arrays and complex metadata option objects containing optional helper configurations:
+      ```json
+      { 
+        "option": "value", 
+        "tooltip": "Optional contextual helper tip", 
+        "thumbnail": "/path/to/img.png" 
+      }
+      ```
 
-  Typical shape:
-  - `title`: dialog title
-  - `description`: helper text/question
-  - `width`: dialog width (e.g. `"450px"`)
-  - `fields`: array of field definitions (`key`, `label`, `type`, `required`, `options`)
+### 23. `actionFinished`
+- **Type:** `EventEmitter<unknown>`
+- **Description:** Component Output Event. Dispatched instantly when a running action completes its terminal step or downstream `onSuccess` pipeline loop to allow parent wrappers to refresh views.
 
 ---
 
@@ -151,18 +163,17 @@ Below are supported configuration properties, their types, and descriptions.
 - `#DatasetsSelectedFilesCount`: Total number selected files
 - `#DatasetsSelectedFilesTotalSize`: Total selected files size
 - `#DatasetsField[fieldName]`: Array; `fieldName` in all datasets
+- `#Instruments[n]Field[fieldName]`: Arbitrary field `fieldName` from instrument[n]
+- `#date_format(value, format)`: Formatted date string using format template
 
 **Other runtime keywords:**
 - `#token`, `#tokenBearer`, `#jwt`, `#uuid`: Various tokens and a random UUID.
 - `@<variable>`: Variable defined in `variables` mapping.
 
-**Expression helper keywords (enabled/disabled/hidden):**
-- `#datasetOwner`: True if user belongs to owner group of at least one dataset
-- `#userIsAdmin`: True if user has admin role
-- `#isPublished`: True if first dataset is published
-- `#!isPublished`: True if first dataset is not published
-- `#Length(<expr>)`: Resolves to expression length (`0` if null/undefined)
-- `#MaxDownloadableSize(<expr>)`: Compares value against configured max direct download size
+### Variable Dependency Engine Constraints
+Variables support multi-tier evaluation chains via cross-reference pointers (e.g., `"first": "@files[0]"`). Before evaluation begins, the engine passes configurations through a dedicated topological sorter (`buildDependenciesGraph`) to evaluate keys in sequential dependency order.
+
+* **Circular Reference Guard:** If an infinite circular reference path is identified (e.g., `a` references `@b` while `b` references `@a`), the execution engine breaks out of the loop instantly to avoid browser thread lockups, logs a clear `Cyclic dependency detected` trace to the console, and alerts the UI with an error message boundary.
 
 ---
 

--- a/src/app/shared/modules/dialog/dialog.component.html
+++ b/src/app/shared/modules/dialog/dialog.component.html
@@ -1,32 +1,54 @@
 <h1 mat-dialog-title>{{ data.title }}</h1>
+
 <div mat-dialog-content>
-  <p>{{ data.question }}</p>
-  <mat-form-field *ngIf="data.input">
-    <input matInput tabindex="1" [(ngModel)]="data.input" />
-  </mat-form-field>
-</div>
+  <p *ngIf="data.question">{{ data.question }}</p>
 
-<div *ngIf="data.choice?.options?.length > 0">
-  <mat-form-field>
-    <mat-select [(ngModel)]="data.option">
-      <mat-option
-        *ngFor="let choice of data.choice.options"
-        [value]="choice.option"
-        [matTooltip]="choice.tooltip"
-        >{{ choice.option }}</mat-option
-      >
-    </mat-select>
-  </mat-form-field>
-
-  <span *ngFor="let choice of data.choice.options">
-    <mat-form-field *ngIf="choice.option === data.option && choice.location">
-      <span matPrefix>{{ choice.location }}&nbsp;</span>
-      <input [(ngModel)]="data.location" matInput placeholder="Relative path" />
+  <form #dynamicForm="ngForm">
+    <mat-form-field appearance="outline" class="full-width" *ngIf="data.choice">
+      <mat-label>{{ data.label ?? data.title }}</mat-label>
+      <mat-select [(ngModel)]="data.selectedOption" name="primaryReason"
+        required>
+        <mat-option *ngFor="let opt of data.choice.options"
+          [matTooltip]="opt.tooltip" 
+          [value]="opt.option">
+          {{ opt.option }}
+        </mat-option>
+      </mat-select>
     </mat-form-field>
-  </span>
+
+    <div *ngFor="let field of data.additionalFields | keyvalue">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ field.value.label }}</mat-label>
+
+        <textarea *ngIf="field.value.type === 'textarea'" matInput
+          [(ngModel)]="data[field.key]" [name]="field.key"
+          [required]="field.value.required">
+        </textarea>
+
+        <mat-select *ngIf="field.value.type === 'select'"
+          [(ngModel)]="data[field.key]" [name]="field.key"
+          [required]="field.value.required">
+          <mat-option *ngFor="let opt of field.value.options"
+            [matTooltip]="opt.tooltip" 
+            [value]="opt.option">
+            {{ opt.option }}
+          </mat-option>
+        </mat-select>
+
+        <input *ngIf="field.value.type === 'text'" matInput
+          [(ngModel)]="data[field.key]" [name]="field.key"
+          [required]="field.value.required">
+
+        <mat-error>This field is required</mat-error>
+      </mat-form-field>
+    </div>
+  </form>
 </div>
 
-<div mat-dialog-actions>
-  <button mat-button [mat-dialog-close]="data" tabindex="2">Ok</button>
-  <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onNoClick()">Cancel</button>
+  <button mat-raised-button color="primary" [mat-dialog-close]="data"
+    [disabled]="dynamicForm.invalid">
+    Ok
+  </button>
 </div>

--- a/src/app/shared/modules/dialog/dialog.component.html
+++ b/src/app/shared/modules/dialog/dialog.component.html
@@ -39,7 +39,7 @@
           [(ngModel)]="data[field.key]" [name]="field.key"
           [required]="field.value.required">
 
-        <mat-error>This field is required</mat-error>
+        <mat-error>The field {{ field.value.label }} is required</mat-error>
       </mat-form-field>
     </div>
   </form>

--- a/src/app/shared/modules/dialog/dialog.component.spec.ts
+++ b/src/app/shared/modules/dialog/dialog.component.spec.ts
@@ -4,9 +4,11 @@ import { DialogComponent } from "./dialog.component";
 import { MockMatDialogRef, MockMatDialogData } from "shared/MockStubs";
 import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { SharedScicatFrontendModule } from "shared/shared.module";
+
 describe("DialogComponent", () => {
   let component: DialogComponent;
   let fixture: ComponentFixture<DialogComponent>;
+  let dialogRef: MatDialogRef<DialogComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -22,10 +24,46 @@ describe("DialogComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DialogComponent);
     component = fixture.componentInstance;
+    dialogRef = TestBed.inject(MatDialogRef);
     fixture.detectChanges();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should close the dialog when cancelling", () => {
+    const closeSpy = spyOn(dialogRef, "close");
+
+    component.onNoClick();
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render dynamic additional fields and disable submit when required data is missing", () => {
+    component.data = {
+      title: "Mark for deletion reason",
+      additionalFields: {
+        deletiionCode: {
+          label: "Deletion code",
+          type: "select",
+          required: true,
+          options: [{ option: "MARKED_FOR_DELETION" }],
+        },
+        explanation: {
+          label: "Explanation for deletion",
+          type: "textarea",
+          required: true,
+        },
+      },
+    };
+
+    fixture.detectChanges();
+
+    const compiled = fixture.debugElement.nativeElement;
+
+    expect(compiled.textContent).toContain("Deletion code");
+    expect(compiled.textContent).toContain("Explanation for deletion");
+    expect(compiled.querySelector("textarea")).toBeTruthy();
   });
 });

--- a/src/app/shared/modules/dialog/dialog.component.ts
+++ b/src/app/shared/modules/dialog/dialog.component.ts
@@ -1,5 +1,29 @@
 import { Component, Inject } from "@angular/core";
+import { FormGroup } from "@angular/forms";
 import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
+
+export interface DialogOptionData {
+  option: string;
+  tooltip?: string;
+}
+
+export interface DynamicField {
+  label: string;
+  type: "text" | "textarea" | "select";
+  required?: boolean;
+  options?: DialogOptionData[];
+}
+
+export interface DynamicDialogData {
+  title: string;
+  label?: string;
+  question?: string;
+  choice?: {
+    options: DialogOptionData[];
+  };
+  additionalFields?: { [key: string]: DynamicField };
+  [key: string]: any;
+}
 
 @Component({
   selector: "app-dialog",
@@ -8,9 +32,12 @@ import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
   standalone: false,
 })
 export class DialogComponent {
+  form: FormGroup = new FormGroup({});
+  fieldKeys: string[] = [];
+
   constructor(
     public dialogRef: MatDialogRef<DialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(MAT_DIALOG_DATA) public data: DynamicDialogData,
   ) {}
 
   onNoClick(): void {

--- a/src/app/shared/modules/dialog/dialog.component.ts
+++ b/src/app/shared/modules/dialog/dialog.component.ts
@@ -1,5 +1,4 @@
 import { Component, Inject } from "@angular/core";
-import { FormGroup } from "@angular/forms";
 import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 
 export interface DialogOptionData {
@@ -32,9 +31,6 @@ export interface DynamicDialogData {
   standalone: false,
 })
 export class DialogComponent {
-  form: FormGroup = new FormGroup({});
-  fieldKeys: string[] = [];
-
   constructor(
     public dialogRef: MatDialogRef<DialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: DynamicDialogData,

--- a/src/app/shared/modules/dialog/dialog.component.ts
+++ b/src/app/shared/modules/dialog/dialog.component.ts
@@ -21,7 +21,7 @@ export interface DynamicDialogData {
     options: DialogOptionData[];
   };
   additionalFields?: { [key: string]: DynamicField };
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 @Component({


### PR DESCRIPTION
## Description
It adds a new action called dialog which can be configured in config.json allowing to set the shape of the dialog (fields, type of fields and required properties) and selecting a follow-up action.

## Motivation
This will later make the cart and the overview datasets actions configurable, effectively replacing the hardcoded job submissions and enabling easy extensions to published data

dialog configuration:
<img width="1103" height="817" alt="image" src="https://github.com/user-attachments/assets/55c4e8aa-57f4-484e-97bf-6804405a79e3" />

generated form

<img width="296" height="317" alt="image" src="https://github.com/user-attachments/assets/73167cff-25d1-4886-a9b4-4cb72d4bb74d" />


## Changes:
Please provide a list of the changes implemented by this PR

* Extend dialog component with an "additionalFields" property where one can set additional user filled fields. This keeps the old "data" fields to avoid changing upstream
* add support for dialog action in configurable actions
* refactor actions for better maintainability
* add tests for new actions and missing tests for registered functions
* adds an output to actions enabling to control from the component which uses the action what to do on component end (e.g. clearBatch on dialog submission)
* adds inputs for button type (raised or not) and color which can be configured from the component
* adds a generic function to access data from actionItems

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Introduce a configurable dialog-based action type and richer action evaluation to the configurable actions framework, along with button styling controls and expanded configuration typing.

New Features:
- Add a new "dialog" action type that opens a configurable dialog and can trigger follow-up actions such as XHR, form submit, or JSON download.
- Allow configurable actions and dialogs to define dynamic additional fields and options, with dialog input fed back into action variables and payloads.
- Expose button style configuration (raised/flat and color) for configurable action buttons and propagate it through the actions container component.
- Type configurable action definitions and action items more strictly, including strongly typed dataset-based items and support for batch actions in app configuration.

Enhancements:
- Refactor the configurable action component to centralize variable resolution, authorization token handling, expression evaluation, and dataset selector support.
- Extend visibility and enable/disable expressions with higher-level keywords like dataset ownership, admin status, publication flags, and helper functions for list length and maximum downloadable size checks.
- Improve the generic dialog component to support dynamic field rendering, validation, and better-structured data passing.
- Adjust configurable action button markup to use standard Angular Material buttons and align tests with the new structure.

Documentation:
- Update technical and reference documentation to describe the new "dialog" action type, onSuccess chaining, dialog configuration structure, and extended selector and expression keywords.
- Update non-technical documentation to mention dialog-based actions as a user-facing capability.

Tests:
- Add and extend unit tests for configurable actions to cover dialog flow, selector resolution, visibility/enabled expressions, and edge cases like missing max download size configuration.
- Add dialog component tests for cancel behavior and dynamic field rendering and validation.
- Add test configurations and fixtures for new dialog actions and stricter action typing.