### PR TITLE
refactor(Sample-Datasets): replace old table with dynamic-mat-table and fix pagination bugs

### DIFF
--- a/src/app/samples/sample-detail/sample-detail.component.html
+++ b/src/app/samples/sample-detail/sample-detail.component.html
@@ -164,20 +164,23 @@
 
     <mat-tab>
       <ng-template mat-tab-label>
-        <mat-icon> folder </mat-icon> Datasets
+        <mat-icon> folder </mat-icon> Related Datasets
       </ng-template>
 
       <div class="datasets-table">
-        <app-table
-          [data]="tableData"
+        <dynamic-mat-table
           [columns]="tableColumns"
-          [paginate]="tablePaginate"
-          [currentPage]="vm.datasetsPage"
-          [dataCount]="vm.datasetsCount"
-          [dataPerPage]="vm.datasetsPerPage"
-          (pageChange)="onPageChange($event)"
-          (rowClick)="onRowClick($event)"
-        ></app-table>
+          [dataSource]="dataSource"
+          [setting]="setting"
+          [pagingMode]="paginationMode"
+          [pagination]="pagination"
+          [rowSelectionMode]="rowSelectionMode"
+          [showGlobalTextSearch]="false"
+          [emptyMessage]="'No datasets available'"
+          [emptyIcon]="'folder'"
+          (paginationChange)="onPaginationChange($event)"
+          (onRowEvent)="onRowEvent($event)"
+        ></dynamic-mat-table>
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/src/app/samples/sample-detail/sample-detail.component.html
+++ b/src/app/samples/sample-detail/sample-detail.component.html
@@ -169,7 +169,7 @@
 
       <div class="datasets-table">
         <dynamic-mat-table
-          [columns]="tableColumns"
+          [columns]="columns"
           [dataSource]="dataSource"
           [setting]="setting"
           [pagingMode]="paginationMode"

--- a/src/app/samples/sample-detail/sample-detail.component.spec.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.spec.ts
@@ -37,6 +37,7 @@ import { FlexLayoutModule } from "@ngbracket/ngx-layout";
 import { AppConfigService } from "app-config.service";
 import { ReturnedUserDto } from "@scicatproject/scicat-sdk-ts-angular";
 import { RowEventType } from "shared/modules/dynamic-material-table/models/table-row.model";
+import { TablePagination } from "shared/modules/dynamic-material-table/models/table-pagination.model";
 
 const getConfig = () => ({
   editMetadataEnabled: true,

--- a/src/app/samples/sample-detail/sample-detail.component.spec.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.spec.ts
@@ -16,7 +16,6 @@ import {
   waitForAsync,
 } from "@angular/core/testing";
 import { NgxJsonViewerModule } from "ngx-json-viewer";
-import { PageChangeEvent } from "shared/modules/table/table.component";
 import {
   changeDatasetsPageAction,
   fetchSampleDatasetsAction,
@@ -36,10 +35,8 @@ import { MatIconModule } from "@angular/material/icon";
 import { MatTabsModule } from "@angular/material/tabs";
 import { FlexLayoutModule } from "@ngbracket/ngx-layout";
 import { AppConfigService } from "app-config.service";
-import {
-  DatasetClass,
-  ReturnedUserDto,
-} from "@scicatproject/scicat-sdk-ts-angular";
+import { ReturnedUserDto } from "@scicatproject/scicat-sdk-ts-angular";
+import { RowEventType } from "shared/modules/dynamic-material-table/models/table-row.model";
 
 const getConfig = () => ({
   editMetadataEnabled: true,
@@ -204,20 +201,20 @@ describe("SampleDetailComponent", () => {
     });
   });
 
-  describe("#onPageChange()", () => {
+  describe("#onPaginationChange()", () => {
     it("should dispatch a changeDatasetsPageAction and a fetchSampleDatasetsAction", () => {
       dispatchSpy = spyOn(store, "dispatch");
 
       const sample = mockSample;
       sample.sampleId = "testId";
       component.sample = sample;
-      const event: PageChangeEvent = {
+      const event: TablePagination = {
         pageIndex: 1,
         pageSize: 25,
         length: 25,
       };
 
-      component.onPageChange(event);
+      component.onPaginationChange(event);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2);
       expect(dispatchSpy).toHaveBeenCalledWith(
@@ -232,12 +229,15 @@ describe("SampleDetailComponent", () => {
     });
   });
 
-  describe("#onRowClick()", () => {
+  describe("#onRowEvent()", () => {
     it("should navigate to a dataset", () => {
       const dataset = mockDataset;
       dataset.pid = "testId";
 
-      component.onRowClick(dataset as DatasetClass);
+      component.onRowEvent({
+        event: RowEventType.RowClick,
+        sender: { row: dataset },
+      } as any);
 
       expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
       expect(router.navigateByUrl).toHaveBeenCalledWith(

--- a/src/app/samples/sample-detail/sample-detail.component.spec.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.spec.ts
@@ -38,6 +38,12 @@ import { AppConfigService } from "app-config.service";
 import { ReturnedUserDto } from "@scicatproject/scicat-sdk-ts-angular";
 import { RowEventType } from "shared/modules/dynamic-material-table/models/table-row.model";
 import { TablePagination } from "shared/modules/dynamic-material-table/models/table-pagination.model";
+import { JsonHeadPipe } from "shared/pipes/json-head.pipe";
+import { provideMockStore } from "@ngrx/store/testing";
+import { selectSampleDetailPageViewModel } from "state-management/selectors/samples.selectors";
+import { selectColumnsWithHasFetchedSettings } from "state-management/selectors/user.selectors";
+import { DatasetsListService } from "shared/services/datasets-list.service";
+import { MockDatasetsListService } from "shared/MockStubs";
 
 const getConfig = () => ({
   editMetadataEnabled: true,
@@ -67,7 +73,35 @@ describe("SampleDetailComponent", () => {
         SharedScicatFrontendModule,
         StoreModule.forRoot({}),
       ],
-      providers: [DatePipe, FileSizePipe, SlicePipe],
+      providers: [
+        DatePipe,
+        FileSizePipe,
+        SlicePipe,
+        JsonHeadPipe,
+        provideMockStore({
+          selectors: [
+            {
+              selector: selectSampleDetailPageViewModel,
+              value: {
+                sample: mockSample,
+                user: null,
+                attachments: [],
+                datasets: [],
+                datasetsPage: 0,
+                datasetsPerPage: 25,
+                datasetsCount: 0,
+              },
+            },
+            {
+              selector: selectColumnsWithHasFetchedSettings,
+              value: {
+                columns: [],
+                hasFetchedSettings: true,
+              },
+            },
+          ],
+        }),
+      ],
     });
     TestBed.overrideComponent(SampleDetailComponent, {
       set: {
@@ -80,6 +114,7 @@ describe("SampleDetailComponent", () => {
           },
           { provide: Router, useValue: router },
           { provide: ActivatedRoute, useClass: MockActivatedRoute },
+          { provide: DatasetsListService, useClass: MockDatasetsListService },
         ],
       },
     });
@@ -102,21 +137,6 @@ describe("SampleDetailComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
-  });
-
-  describe("#formatTableData()", () => {
-    it("should return empty array if there are no datasets", () => {
-      const data = component.formatTableData(null);
-
-      expect(data).toEqual([]);
-    });
-
-    it("should return an array of data objects if there are datasets", () => {
-      const datasets = [mockDataset];
-      const data = component.formatTableData(datasets);
-
-      expect(data.length).toEqual(1);
-    });
   });
 
   describe("#onSaveCharacteristics()", () => {

--- a/src/app/samples/sample-detail/sample-detail.component.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.ts
@@ -1,6 +1,6 @@
 import { ActivatedRoute, Router } from "@angular/router";
 import { Component, OnDestroy, OnInit } from "@angular/core";
-import { fromEvent, Subscription } from "rxjs";
+import { BehaviorSubject, fromEvent, Subscription } from "rxjs";
 import { selectSampleDetailPageViewModel } from "../../state-management/selectors/samples.selectors";
 import { Store } from "@ngrx/store";
 import {
@@ -16,10 +16,6 @@ import {
 import { DatePipe, SlicePipe } from "@angular/common";
 import { FileSizePipe } from "shared/pipes/filesize.pipe";
 import {
-  TableColumn,
-  PageChangeEvent,
-} from "shared/modules/table/table.component";
-import {
   PickedFile,
   SubmitCaptionEvent,
 } from "shared/modules/file-uploader/file-uploader.component";
@@ -27,12 +23,22 @@ import { EditableComponent } from "app-routing/pending-changes.guard";
 import { AppConfigService } from "app-config.service";
 import {
   CreateAttachmentV3Dto,
-  DatasetClass,
   OutputAttachmentV3Dto,
   OutputDatasetObsoleteDto,
   ReturnedUserDto,
   OutputSampleDto,
 } from "@scicatproject/scicat-sdk-ts-angular";
+import { TableField } from "shared/modules/dynamic-material-table/models/table-field.model";
+import { ITableSetting } from "shared/modules/dynamic-material-table/models/table-setting.model";
+import {
+  TablePagination,
+  TablePaginationMode,
+} from "shared/modules/dynamic-material-table/models/table-pagination.model";
+import {
+  IRowEvent,
+  RowEventType,
+  TableSelectionMode,
+} from "shared/modules/dynamic-material-table/models/table-row.model";
 
 export interface TableData {
   pid: string;
@@ -65,16 +71,35 @@ export class SampleDetailComponent
   show = false;
   subscriptions: Subscription[] = [];
 
-  tableData: TableData[] = [];
-  tablePaginate = true;
-  tableColumns: TableColumn[] = [
-    { name: "name", icon: "portrait", sort: false, inList: true },
-    { name: "sourceFolder", icon: "explore", sort: false, inList: true },
-    { name: "size", icon: "save", sort: false, inList: true },
-    { name: "creationTime", icon: "calendar_today", sort: false, inList: true },
-    { name: "owner", icon: "face", sort: false, inList: true },
-    { name: "location", icon: "explore", sort: false, inList: true },
+  tableColumns: TableField<TableData>[] = [
+    { name: "name", header: "Name" },
+    { name: "sourceFolder", header: "Source Folder" },
+    { name: "size", header: "Size" },
+    { name: "creationTime", header: "Creation Time" },
+    { name: "owner", header: "Owner" },
+    { name: "location", header: "Location" },
   ];
+
+  setting: ITableSetting = {
+    rowStyle: {
+      "border-bottom": "1px solid #d2d2d2",
+    },
+  };
+
+  dataSource: BehaviorSubject<TableData[]> = new BehaviorSubject<TableData[]>(
+    [],
+  );
+
+  paginationMode: TablePaginationMode = "server-side";
+
+  pagination: TablePagination = {
+    pageSizeOptions: [5, 10, 25, 50, 100],
+    pageIndex: 0,
+    pageSize: 25,
+    length: 0,
+  };
+
+  rowSelectionMode: TableSelectionMode = "none";
 
   constructor(
     private appConfigService: AppConfigService,
@@ -143,11 +168,11 @@ export class SampleDetailComponent
     );
   }
 
-  onPageChange(event: PageChangeEvent) {
+  onPaginationChange({ pageIndex, pageSize }: TablePagination) {
     this.store.dispatch(
       changeDatasetsPageAction({
-        page: event.pageIndex,
-        limit: event.pageSize,
+        page: pageIndex,
+        limit: pageSize,
       }),
     );
     this.store.dispatch(
@@ -155,9 +180,11 @@ export class SampleDetailComponent
     );
   }
 
-  onRowClick(dataset: DatasetClass) {
-    const id = encodeURIComponent(dataset.pid);
-    this.router.navigateByUrl("/datasets/" + id);
+  onRowEvent(event: IRowEvent<TableData>) {
+    if (event.event === RowEventType.RowClick) {
+      const id = encodeURIComponent(event.sender.row.pid);
+      this.router.navigateByUrl("/datasets/" + id);
+    }
   }
 
   ngOnInit() {
@@ -174,6 +201,14 @@ export class SampleDetailComponent
         if (vm.attachments) {
           this.attachments = vm.attachments;
         }
+
+        this.dataSource.next(this.formatTableData(vm.datasets));
+        this.pagination = {
+          ...this.pagination,
+          pageIndex: vm.datasetsPage || 0,
+          pageSize: vm.datasetsPerPage || this.pagination.pageSize,
+          length: vm.datasetsCount || 0,
+        };
       }),
     );
     // Prevent user from reloading page if there are unsave changes
@@ -182,11 +217,6 @@ export class SampleDetailComponent
         if (this.hasUnsavedChanges()) {
           event.preventDefault();
         }
-      }),
-    );
-    this.subscriptions.push(
-      this.vm$.subscribe((vm) => {
-        this.tableData = this.formatTableData(vm.datasets);
       }),
     );
 

--- a/src/app/samples/sample-detail/sample-detail.component.ts
+++ b/src/app/samples/sample-detail/sample-detail.component.ts
@@ -1,6 +1,12 @@
 import { ActivatedRoute, Router } from "@angular/router";
 import { Component, OnDestroy, OnInit } from "@angular/core";
-import { BehaviorSubject, fromEvent, Subscription } from "rxjs";
+import {
+  BehaviorSubject,
+  fromEvent,
+  Subscription,
+  take,
+  combineLatest,
+} from "rxjs";
 import { selectSampleDetailPageViewModel } from "../../state-management/selectors/samples.selectors";
 import { Store } from "@ngrx/store";
 import {
@@ -13,8 +19,6 @@ import {
   removeAttachmentAction,
   fetchSampleAttachmentsAction,
 } from "../../state-management/actions/samples.actions";
-import { DatePipe, SlicePipe } from "@angular/common";
-import { FileSizePipe } from "shared/pipes/filesize.pipe";
 import {
   PickedFile,
   SubmitCaptionEvent,
@@ -39,16 +43,11 @@ import {
   RowEventType,
   TableSelectionMode,
 } from "shared/modules/dynamic-material-table/models/table-row.model";
-
-export interface TableData {
-  pid: string;
-  name: string;
-  sourceFolder: string;
-  size: string;
-  creationTime: string | null;
-  owner: string;
-  location: string;
-}
+import { actionMenu } from "shared/modules/dynamic-material-table/utilizes/default-table-settings";
+import { TableConfigService } from "shared/services/table-config.service";
+import { DatasetsListService } from "shared/services/datasets-list.service";
+import { TableColumn } from "state-management/models";
+import { selectColumnsWithHasFetchedSettings } from "state-management/selectors/user.selectors";
 
 @Component({
   selector: "app-sample-detail",
@@ -62,6 +61,16 @@ export class SampleDetailComponent
   private _hasUnsavedChanges = false;
   vm$ = this.store.select(selectSampleDetailPageViewModel);
 
+  selectColumnsWithFetchedSettings$ = this.store.select(
+    selectColumnsWithHasFetchedSettings,
+  );
+
+  tableName = "sampleDatasetsTable";
+
+  columns: TableField<any>[];
+
+  setting: ITableSetting = {};
+
   appConfig = this.appConfigService.getConfig();
 
   sample: OutputSampleDto;
@@ -71,24 +80,26 @@ export class SampleDetailComponent
   show = false;
   subscriptions: Subscription[] = [];
 
-  tableColumns: TableField<TableData>[] = [
-    { name: "name", header: "Name" },
-    { name: "sourceFolder", header: "Source Folder" },
-    { name: "size", header: "Size" },
-    { name: "creationTime", header: "Creation Time" },
-    { name: "owner", header: "Owner" },
-    { name: "location", header: "Location" },
-  ];
-
-  setting: ITableSetting = {
+  tableDefaultSettingsConfig: ITableSetting = {
+    visibleActionMenu: actionMenu,
+    saveSettingMode: "none",
+    settingList: [
+      {
+        visibleActionMenu: actionMenu,
+        saveSettingMode: "none",
+        isDefaultSetting: true,
+        isCurrentSetting: true,
+        columnSetting: [],
+      },
+    ],
     rowStyle: {
       "border-bottom": "1px solid #d2d2d2",
     },
   };
 
-  dataSource: BehaviorSubject<TableData[]> = new BehaviorSubject<TableData[]>(
-    [],
-  );
+  dataSource: BehaviorSubject<OutputDatasetObsoleteDto[]> = new BehaviorSubject<
+    OutputDatasetObsoleteDto[]
+  >([]);
 
   paginationMode: TablePaginationMode = "server-side";
 
@@ -103,32 +114,24 @@ export class SampleDetailComponent
 
   constructor(
     private appConfigService: AppConfigService,
-    private datePipe: DatePipe,
-    private filesizePipe: FileSizePipe,
     private router: Router,
     private route: ActivatedRoute,
-    private slicePipe: SlicePipe,
     private store: Store,
+    private tableConfigService: TableConfigService,
+    private datasetsListService: DatasetsListService,
   ) {}
 
-  formatTableData(datasets: OutputDatasetObsoleteDto[]): TableData[] {
-    let tableData: TableData[] = [];
-    if (datasets) {
-      tableData = datasets.map((dataset: any) => ({
-        pid: dataset.pid,
-        name: dataset.datasetName,
-        sourceFolder:
-          "..." + this.slicePipe.transform(dataset.sourceFolder, -14),
-        size: this.filesizePipe.transform(dataset.size),
-        creationTime: this.datePipe.transform(
-          dataset.creationTime,
-          "yyyy-MM-dd HH:mm",
-        ),
-        owner: dataset.owner,
-        location: dataset.creationLocation,
-      }));
-    }
-    return tableData;
+  initTable(
+    settingConfig: ITableSetting,
+    paginationConfig: TablePagination,
+  ): void {
+    const currentColumnSetting = settingConfig.settingList.find(
+      (s) => s.isCurrentSetting,
+    )?.columnSetting;
+
+    this.columns = currentColumnSetting;
+    this.setting = settingConfig;
+    this.pagination = paginationConfig;
   }
 
   onSaveCharacteristics(characteristics: Record<string, unknown>) {
@@ -180,7 +183,7 @@ export class SampleDetailComponent
     );
   }
 
-  onRowEvent(event: IRowEvent<TableData>) {
+  onRowEvent(event: IRowEvent<OutputDatasetObsoleteDto>) {
     if (event.event === RowEventType.RowClick) {
       const id = encodeURIComponent(event.sender.row.pid);
       this.router.navigateByUrl("/datasets/" + id);
@@ -189,7 +192,10 @@ export class SampleDetailComponent
 
   ngOnInit() {
     this.subscriptions.push(
-      this.vm$.subscribe((vm) => {
+      combineLatest([
+        this.vm$,
+        this.selectColumnsWithFetchedSettings$.pipe(take(1)),
+      ]).subscribe(([vm, defaultTableColumns]) => {
         if (vm.sample) {
           this.sample = vm.sample;
 
@@ -202,7 +208,38 @@ export class SampleDetailComponent
           this.attachments = vm.attachments;
         }
 
-        this.dataSource.next(this.formatTableData(vm.datasets));
+        this.dataSource.next(vm.datasets);
+
+        const defaultConfigColumns =
+          this.appConfig?.defaultDatasetsListSettings?.columns || [];
+
+        const userTableConfigColumns =
+          this.datasetsListService.convertSavedDatasetColumns(
+            defaultTableColumns.columns,
+          );
+
+        this.tableDefaultSettingsConfig.settingList[0].columnSetting =
+          this.datasetsListService.convertSavedDatasetColumns(
+            defaultConfigColumns as TableColumn[],
+          );
+
+        const tableSettingsConfig =
+          this.tableConfigService.getTableSettingsConfig(
+            this.tableName,
+            this.tableDefaultSettingsConfig,
+            userTableConfigColumns,
+          );
+
+        const paginationConfig = {
+          pageSizeOptions: [5, 10, 25, 50, 100],
+          pageIndex: vm.datasetsPage || 0,
+          pageSize: vm.datasetsPerPage || this.pagination.pageSize,
+          length: vm.datasetsCount || 0,
+        };
+
+        if (tableSettingsConfig?.settingList.length) {
+          this.initTable(tableSettingsConfig, paginationConfig);
+        }
         this.pagination = {
           ...this.pagination,
           pageIndex: vm.datasetsPage || 0,

--- a/src/app/samples/samples.module.ts
+++ b/src/app/samples/samples.module.ts
@@ -24,6 +24,7 @@ import { FileSizePipe } from "shared/pipes/filesize.pipe";
 import { MatExpansionModule } from "@angular/material/expansion";
 import { SharedConditionModule } from "shared/modules/shared-condition/shared-condition.module";
 import { JsonHeadPipe } from "shared/pipes/json-head.pipe";
+import { instrumentsReducer } from "state-management/reducers/instruments.reducer";
 
 @NgModule({
   imports: [
@@ -46,6 +47,7 @@ import { JsonHeadPipe } from "shared/pipes/json-head.pipe";
     StoreModule.forFeature("samples", samplesReducer),
     MatExpansionModule,
     SharedConditionModule,
+    StoreModule.forFeature("instruments", instrumentsReducer),
   ],
   exports: [SampleDetailComponent, SampleDialogComponent],
   declarations: [

--- a/src/app/samples/samples.module.ts
+++ b/src/app/samples/samples.module.ts
@@ -23,6 +23,7 @@ import { MatChipsModule } from "@angular/material/chips";
 import { FileSizePipe } from "shared/pipes/filesize.pipe";
 import { MatExpansionModule } from "@angular/material/expansion";
 import { SharedConditionModule } from "shared/modules/shared-condition/shared-condition.module";
+import { JsonHeadPipe } from "shared/pipes/json-head.pipe";
 
 @NgModule({
   imports: [
@@ -52,6 +53,6 @@ import { SharedConditionModule } from "shared/modules/shared-condition/shared-co
     SampleDialogComponent,
     SampleDashboardComponent,
   ],
-  providers: [FileSizePipe],
+  providers: [FileSizePipe, JsonHeadPipe],
 })
 export class SamplesModule {}

--- a/src/app/state-management/effects/samples.effects.spec.ts
+++ b/src/app/state-management/effects/samples.effects.spec.ts
@@ -75,6 +75,7 @@ describe("SampleEffects", () => {
           provide: DatasetsService,
           useValue: jasmine.createSpyObj("datasetApi", [
             "datasetsControllerFindAllV3",
+            "datasetsControllerCountV3",
           ]),
         },
       ],
@@ -285,16 +286,14 @@ describe("SampleEffects", () => {
     const sampleId = "testId";
 
     it("should result in a fetchSampleDatasetsCountCompleteAction", () => {
-      const count = 1;
-      const datasets = [dataset];
       const action = fromActions.fetchSampleDatasetsCountAction({ sampleId });
       const outcome = fromActions.fetchSampleDatasetsCountCompleteAction({
-        count,
+        count: 1,
       });
 
       actions = hot("-a", { a: action });
-      const response = cold("-a|", { a: datasets });
-      datasetApi.datasetsControllerFindAllV3.and.returnValue(response);
+      const response = cold("-a|", { a: { count: 1 } });
+      datasetApi.datasetsControllerCountV3.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchSampleDatasetsCount$).toBeObservable(expected);
@@ -306,7 +305,7 @@ describe("SampleEffects", () => {
 
       actions = hot("-a", { a: action });
       const response = cold("-#", {});
-      datasetApi.datasetsControllerFindAllV3.and.returnValue(response);
+      datasetApi.datasetsControllerCountV3.and.returnValue(response);
 
       const expected = cold("--b", { b: outcome });
       expect(effects.fetchSampleDatasetsCount$).toBeObservable(expected);

--- a/src/app/state-management/effects/samples.effects.ts
+++ b/src/app/state-management/effects/samples.effects.ts
@@ -134,9 +134,11 @@ export class SampleEffects {
           .datasetsControllerFindAllV3(
             JSON.stringify({
               where: { sampleId },
-              order,
-              skip,
-              limit,
+              limits: {
+                order,
+                skip,
+                limit,
+              },
             }),
           )
           .pipe(
@@ -155,11 +157,11 @@ export class SampleEffects {
       ofType(fromActions.fetchSampleDatasetsCountAction),
       switchMap(({ sampleId }) =>
         this.datasetApi
-          .datasetsControllerFindAllV3(JSON.stringify({ where: { sampleId } }))
+          .datasetsControllerCountV3(JSON.stringify({ where: { sampleId } }))
           .pipe(
-            map((datasets) =>
+            map(({ count }) =>
               fromActions.fetchSampleDatasetsCountCompleteAction({
-                count: datasets.length,
+                count,
               }),
             ),
             catchError(() =>


### PR DESCRIPTION
## Description
This PR replaces the old sample datasets table with dynamic-mat-table and fixes pagination bugs.

Before:
<img width="2528" height="945" alt="image" src="https://github.com/user-attachments/assets/663c01d8-be0d-40c8-8450-45cb463b35b6" />


After:
<img width="2538" height="828" alt="image" src="https://github.com/user-attachments/assets/4bf05f0e-97b8-4f59-829d-20bdb0e811c7" />


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Replace the sample detail datasets table with the shared dynamic material table and align dataset fetching and pagination with server-side APIs.

New Features:
- Introduce a dynamic material table for displaying related datasets in the sample detail view, including empty-state messaging and configurable pagination.

Bug Fixes:
- Fix incorrect datasets count retrieval by switching to the dedicated count endpoint.
- Resolve pagination inconsistencies by wiring dynamic table pagination to the NgRx store and backend server-side pagination parameters.
- Fix row navigation by handling dynamic table row click events and using dataset PID from the table row data.

Enhancements:
- Standardize table column definitions and styling using shared dynamic-material-table models.
- Refine related datasets tab labelling and row styling for improved clarity and consistency.