### PR TITLE
fix(UI): hide disabled dataset filters

### DIFF
--- a/cypress/e2e/datasets/datasets-general.cy.js
+++ b/cypress/e2e/datasets/datasets-general.cy.js
@@ -477,6 +477,11 @@ describe("Datasets general", () => {
 
       cy.contains("Location").should("not.exist");
     });
+
+    it("should hide disabled filters in the list", () => {
+      cy.contains("Keyword").should("not.exist");
+      cy.contains("Type").should("exist");
+    });
   });
 
   describe("Pre-configured conditions test", () => {

--- a/cypress/e2e/datasets/datasets-general.cy.js
+++ b/cypress/e2e/datasets/datasets-general.cy.js
@@ -473,14 +473,16 @@ describe("Datasets general", () => {
     });
 
     it("should automatically apply pre-configured filters from config", () => {
-      cy.contains("Type").should("exist");
-
-      cy.contains("Location").should("not.exist");
+      cy.get('[data-cy="shared-filter-form"]').should("contain", "Type");
+      cy.get('[data-cy="shared-filter-form"]').should(
+        "not.contain",
+        "Location",
+      );
     });
 
     it("should hide disabled filters in the list", () => {
-      cy.contains("Keyword").should("not.exist");
-      cy.contains("Type").should("exist");
+      cy.get('[data-cy="shared-filter-form"]').should("not.contain", "Keyword");
+      cy.get('[data-cy="shared-filter-form"]').should("contain", "Type");
     });
   });
 
@@ -782,7 +784,7 @@ describe("Datasets general", () => {
       cy.get('[data-cy="remove-condition-button"]').click();
     });
   });
-  
+
   describe("Auto apply filters", () => {
     beforeEach(() => {
       cy.clearLocalStorage();
@@ -858,7 +860,7 @@ describe("Datasets general", () => {
         .type("{enter}");
     });
   });
-  
+
   describe("Sorting datasets by a column from config", () => {
     beforeEach(() => {
       cy.createDataset({
@@ -900,7 +902,9 @@ describe("Datasets general", () => {
     });
 
     it("should sort datasets by datasetName in asc order from config", () => {
-      cy.get(".dataset-table mat-row").first().should("contain", "A DatasetName");
+      cy.get(".dataset-table mat-row")
+        .first()
+        .should("contain", "A DatasetName");
     });
   });
 });

--- a/src/app/datasets/datasets-filter/datasets-filter.component.html
+++ b/src/app/datasets/datasets-filter/datasets-filter.component.html
@@ -36,6 +36,7 @@
     </ng-template>
     <ng-container *ngFor="let filter of filtersList">
       <shared-filter
+        *ngIf="filter.enabled"
         [key]="filter.key"
         [label]="filter.label"
         [clear]="clearSearchBar"

--- a/src/app/shared/modules/shared-filter/shared-filter.component.html
+++ b/src/app/shared/modules/shared-filter/shared-filter.component.html
@@ -1,5 +1,5 @@
 <!-- shared-filter.component.html -->
-<form [formGroup]="filterForm">
+<form [formGroup]="filterForm" data-cy="shared-filter-form">
   <ng-container [ngSwitch]="filterType">
     <ng-container *ngSwitchDefault>
       <mat-form-field [id]="key">


### PR DESCRIPTION
## Description
This PR hides disabled filters in Datasets Filters section

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Tests:
- Add Cypress test to verify that disabled dataset filters are not rendered while enabled ones remain visible.