### PR TITLE
feat: add metadata as colum from tree-view

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
@@ -183,6 +183,8 @@
                       <tree-view
                         *ngSwitchCase="'tree'"
                         [metadata]="metadata"
+                        [allowAddAsColumn]="true"
+                        [metadataPath]="section.source || 'scientificMetadata'"
                       ></tree-view>
                       <metadata-view
                         *ngSwitchDefault

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
@@ -375,6 +375,7 @@
                   <tree-view
                     *ngSwitchCase="'tree'"
                     [metadata]="dataset['scientificMetadata']"
+                    [allowAddAsColumn]="true"
                   ></tree-view>
                   <metadata-view
                     *ngSwitchDefault

--- a/src/app/shared/modules/scientific-metadata-tree/base-classes/tree-base.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/base-classes/tree-base.ts
@@ -11,11 +11,16 @@ import { DateTimeService } from "shared/services/date-time.service";
 import { UnitsService } from "shared/services/units.service";
 import { AppConfigService } from "app-config.service";
 
+export const DEFAULT_METADATA_PATH = "scientificMetadata";
+
 export class TreeNode {
   children: TreeNode[];
   key: string;
   value: any;
   unit: string;
+  path: string;
+  columnName: string;
+  human_name?: string;
 }
 export class FlatNode {
   key: string;
@@ -24,6 +29,9 @@ export class FlatNode {
   level: number;
   expandable: boolean;
   visible: boolean;
+  path: string;
+  columnName: string;
+  human_name?: string;
 }
 @Component({
   template: "",
@@ -50,20 +58,34 @@ export class TreeBaseComponent {
     this.formatNumberPipe = new FormatNumberPipe(this.configService);
     this.dateTimeService = new DateTimeService();
   }
-  buildDataTree(obj: { [key: string]: any }, level: number): TreeNode[] {
+  buildDataTree(
+    obj: { [key: string]: any },
+    level: number,
+    parentPath = DEFAULT_METADATA_PATH,
+  ): TreeNode[] {
     return Object.keys(obj).reduce<TreeNode[]>((accumulator, key) => {
       const value = obj[key];
       const node = new TreeNode();
+      const path = parentPath ? `${parentPath}.${key}` : key;
       node.key = key;
+      node.path = path;
+      node.columnName = path;
+      node.human_name =
+        value !== null && typeof value === "object"
+          ? value["human_name"]
+          : undefined;
       // suport both {value: any, unit: string} and {v: any , u: string}
       if (value?.unit || value?.unit === "" || value?.u || value?.u === "") {
         node.unit = value.unit || value.u || undefined;
         node.value = value.value ?? value.v;
+        if ("value" in value) {
+          node.columnName = `${path}.value`;
+        }
       } else {
         node.value = value;
       }
       if (node.value && typeof node.value === "object") {
-        node.children = this.buildDataTree(node.value, level + 1);
+        node.children = this.buildDataTree(node.value, level + 1, path);
         if (!Array.isArray(node.value)) {
           node.value = undefined;
         }

--- a/src/app/shared/modules/scientific-metadata-tree/scientific-metadata-tree.module.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/scientific-metadata-tree.module.ts
@@ -25,6 +25,7 @@ import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { PrettyUnitPipe } from "shared/pipes/pretty-unit.pipe";
 import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
 import { MatDatepickerModule } from "@angular/material/datepicker";
+import { RowMenuModule } from "shared/modules/dynamic-material-table/table/extensions/row-menu/row-menu.module";
 import {
   NgxMatDatepickerActions,
   NgxMatDatepickerApply,
@@ -65,6 +66,7 @@ import {
     MatMenuModule,
     MatSnackBarModule,
     MatDatepickerModule,
+    RowMenuModule,
     NgxMatDatetimepicker,
     NgxMatDatepickerInput,
     NgxMatDatepickerActions,

--- a/src/app/shared/modules/scientific-metadata-tree/tree-edit/tree-edit.component.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/tree-edit/tree-edit.component.ts
@@ -38,6 +38,9 @@ export class FlatNodeEdit implements FlatNode {
   level: number;
   expandable: boolean;
   visible: boolean;
+  path: string;
+  columnName: string;
+  human_name?: string;
   editing: boolean;
   editable: boolean;
 }
@@ -114,6 +117,9 @@ export class TreeEditComponent
     flatNode.value = node.value;
     flatNode.expandable = node.children?.length > 0;
     flatNode.unit = node.unit;
+    flatNode.path = node.path;
+    flatNode.columnName = node.columnName;
+    flatNode.human_name = node.human_name;
     if (!existingNode) {
       // Important only set for new node
       flatNode.editing = node.key === "" ? true : false;

--- a/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.html
+++ b/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.html
@@ -27,7 +27,14 @@
   </mat-button-toggle-group>
 </div>
 
-<mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+<mat-tree
+  class="treeView"
+  [class.treeView-add-column-enabled]="
+    allowAddAsColumn && rowContextMenuItems.length > 0
+  "
+  [dataSource]="dataSource"
+  [treeControl]="treeControl"
+>
   <!-- Key - Value -->
   <mat-tree-node
     *matTreeNodeDef="let node"
@@ -35,10 +42,24 @@
     [style.display]="isVisible(0, node) ? 'flex' : 'none'"
   >
     <section>
+      <div class="menu-cell">
+        <row-menu
+          *ngIf="canShowAddAsColumn(node)"
+          [actionMenus]="rowContextMenuItems"
+          [tableSetting]="tableSetting"
+          (rowActionChange)="onRowActionChange(node, $event)"
+        ></row-menu>
+        <span
+          class="menu-spacer"
+          *ngIf="allowAddAsColumn && rowContextMenuItems.length > 0 && !canShowAddAsColumn(node)"
+        ></span>
+      </div>
       <div class="key-cell" [style.padding-left.px]="getPadding(node)">
         <label class="label-cell">{{ node.key }}</label>
       </div>
-      <div class="value-cell">{{ getValueRepresentation(node) | formatNumber }}</div>
+      <div class="value-cell">
+        {{ getValueRepresentation(node) | formatNumber }}
+      </div>
     </section>
   </mat-tree-node>
   <!-- Only Key -->
@@ -47,6 +68,12 @@
     [style.display]="isVisible(0, node) ? 'flex' : 'none'"
   >
     <section>
+      <div class="menu-cell">
+        <span
+          class="menu-spacer"
+          *ngIf="allowAddAsColumn && rowContextMenuItems.length > 0"
+        ></span>
+      </div>
       <div class="key-cell" [style.padding-left.px]="getPadding(node)">
         <button
           mat-icon-button

--- a/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.scss
+++ b/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.scss
@@ -1,3 +1,39 @@
+.treeView {
+  &-add-column-enabled {
+    .menu-cell {
+      padding-right: 0;
+      box-sizing: border-box;
+    }
+
+    section {
+      margin: 0;
+    }
+
+    .menu-cell row-menu {
+      justify-content: flex-start;
+      width: 24px;
+      min-width: 24px;
+    }
+
+    .menu-cell .menu-spacer {
+      width: 24px;
+      min-width: 24px;
+      height: 24px;
+      display: inline-block;
+    }
+
+    .menu-cell ::ng-deep row-menu .clear {
+      width: 24px;
+      height: 24px;
+      padding: 0;
+    }
+
+    .menu-cell ::ng-deep row-menu .clear mat-icon {
+      color: rgba(0, 0, 0, 0.25);
+    }
+  }
+}
+
 .container {
   margin: 1em;
 
@@ -61,18 +97,25 @@ mat-form-field {
 }
 section {
   display: grid;
-  grid-template-columns: 40% 60%;
+  grid-template-columns: auto minmax(0, 40%) minmax(0, 1fr);
   gap: 1em;
   width: 100%;
   margin: 0 2em;
+  align-items: center;
+}
+
+.menu-cell {
+  grid-column: 1;
+  display: flex;
+  justify-content: flex-start;
 }
 
 .key-cell {
-  grid-column: 1;
+  grid-column: 2;
   word-wrap: break-word;
 }
 
 .value-cell {
-  grid-column: 2;
+  grid-column: 3;
   word-wrap: break-word;
 }

--- a/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.spec.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.spec.ts
@@ -1,4 +1,5 @@
 import { DatePipe } from "@angular/common";
+import { SimpleChange } from "@angular/core";
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormatNumberPipe } from "shared/pipes/format-number.pipe";
 import { PrettyUnitPipe } from "shared/pipes/pretty-unit.pipe";
@@ -7,13 +8,42 @@ import { TreeViewComponent } from "./tree-view.component";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { AppConfigService } from "app-config.service";
 import { provideHttpClient } from "@angular/common/http";
+import { ScientificMetadataColumnsService } from "shared/services/scientific-metadata-columns.service";
+
+const metadataFloatFormatConfig = {
+  metadataFloatFormatEnabled: true,
+  metadataFloatFormat: {
+    significantDigits: 3,
+    minCutoff: 0.001,
+    maxCutoff: 1000,
+  },
+};
+
+const addAsColumnEnabledConfig = {
+  ...metadataFloatFormatConfig,
+  addScientificMetadataKeysAsColumn: true,
+};
 
 describe("TreeViewComponent", () => {
   let component: TreeViewComponent;
   let fixture: ComponentFixture<TreeViewComponent>;
+  let scientificMetadataColumnsService: jasmine.SpyObj<ScientificMetadataColumnsService>;
+  let appConfigService: jasmine.SpyObj<AppConfigService>;
 
   beforeEach(waitForAsync(() => {
     TestBed.resetTestingModule();
+    scientificMetadataColumnsService =
+      jasmine.createSpyObj<ScientificMetadataColumnsService>(
+        "ScientificMetadataColumnsService",
+        ["addMetadataColumn"],
+      );
+    appConfigService = jasmine.createSpyObj<AppConfigService>(
+      "AppConfigService",
+      ["getConfig"],
+    );
+    appConfigService.getConfig.and.returnValue(
+      metadataFloatFormatConfig as any,
+    );
     TestBed.configureTestingModule({
       declarations: [TreeViewComponent],
       imports: [ScientificMetadataTreeModule, BrowserAnimationsModule],
@@ -21,22 +51,20 @@ describe("TreeViewComponent", () => {
         DatePipe,
         PrettyUnitPipe,
         FormatNumberPipe,
-        AppConfigService,
+        {
+          provide: AppConfigService,
+          useValue: appConfigService,
+        },
+        {
+          provide: ScientificMetadataColumnsService,
+          useValue: scientificMetadataColumnsService,
+        },
         provideHttpClient(),
       ],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    const appConfigService = TestBed.inject(AppConfigService);
-    (appConfigService as any).appConfig = {
-      metadataFloatFormatEnabled: true,
-      metadataFloatFormat: {
-        significantDigits: 3,
-        minCutoff: 0.001,
-        maxCutoff: 1000,
-      },
-    };
     fixture = TestBed.createComponent(TreeViewComponent);
     component = fixture.componentInstance;
     component.metadata = {
@@ -55,5 +83,131 @@ describe("TreeViewComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should hide add-as-column actions by default", () => {
+    const leafNode = component.treeControl.dataNodes.find(
+      (node) => node.key === "sampx",
+    );
+
+    expect(component.canShowAddAsColumn(leafNode)).toBeFalse();
+  });
+
+  it("should expose add-as-column actions for scientific metadata leaves when enabled", () => {
+    appConfigService.getConfig.and.returnValue(addAsColumnEnabledConfig as any);
+
+    const enabledFixture = TestBed.createComponent(TreeViewComponent);
+    const enabledComponent = enabledFixture.componentInstance;
+    enabledComponent.allowAddAsColumn = true;
+    enabledComponent.metadata = {
+      beam_size: {
+        value: 2.4,
+        unit: "mm",
+        human_name: "Beam Size",
+      },
+    };
+    enabledFixture.detectChanges();
+
+    const leafNode = enabledComponent.treeControl.dataNodes.find(
+      (node) => node.key === "beam_size",
+    );
+
+    expect(enabledComponent.canShowAddAsColumn(leafNode)).toBeTrue();
+    expect(leafNode.columnName).toBe("scientificMetadata.beam_size.value");
+    expect(enabledComponent.rowContextMenuItems).toEqual([
+      scientificMetadataColumnsService.addAsColumnAction,
+    ]);
+  });
+
+  it("should delegate nested scientific metadata leaves to the saved-column service", async () => {
+    appConfigService.getConfig.and.returnValue(addAsColumnEnabledConfig as any);
+
+    const enabledFixture = TestBed.createComponent(TreeViewComponent);
+    const enabledComponent = enabledFixture.componentInstance;
+    enabledComponent.allowAddAsColumn = true;
+    enabledComponent.metadata = {
+      sample: {
+        beam_size: {
+          value: 2.4,
+          unit: "mm",
+          human_name: "Beam Size",
+        },
+      },
+    };
+    enabledFixture.detectChanges();
+
+    const leafNode = enabledComponent.treeControl.dataNodes.find(
+      (node) => node.key === "beam_size",
+    );
+
+    await enabledComponent.addAsColumn(leafNode);
+
+    expect(
+      scientificMetadataColumnsService.addMetadataColumn,
+    ).toHaveBeenCalledWith({
+      name: "sample.beam_size",
+      human_name: "Beam Size",
+      columnName: "scientificMetadata.sample.beam_size.value",
+    });
+  });
+
+  it("should derive the column entry name from the configured metadata path", async () => {
+    appConfigService.getConfig.and.returnValue(addAsColumnEnabledConfig as any);
+
+    const enabledFixture = TestBed.createComponent(TreeViewComponent);
+    const enabledComponent = enabledFixture.componentInstance;
+    enabledComponent.allowAddAsColumn = true;
+    enabledComponent.metadataPath = "scientificMetadata.sample";
+    enabledComponent.metadata = {
+      beam_size: {
+        value: 2.4,
+        unit: "mm",
+      },
+    };
+    enabledFixture.detectChanges();
+
+    const leafNode = enabledComponent.treeControl.dataNodes.find(
+      (node) => node.key === "beam_size",
+    );
+
+    await enabledComponent.addAsColumn(leafNode);
+
+    expect(
+      scientificMetadataColumnsService.addMetadataColumn,
+    ).toHaveBeenCalledWith({
+      name: "beam_size",
+      human_name: undefined,
+      columnName: "scientificMetadata.sample.beam_size.value",
+    });
+  });
+
+  it("should rebuild the tree once when metadata and metadataPath change together", () => {
+    spyOn(component, "buildDataTree").and.callThrough();
+
+    const metadata = {
+      beam_size: {
+        value: 2.4,
+        unit: "mm",
+      },
+    };
+
+    component.ngOnChanges({
+      metadata: new SimpleChange(component.metadata, metadata, false),
+      metadataPath: new SimpleChange(
+        component.metadataPath,
+        "scientificMetadata.sample",
+        false,
+      ),
+    });
+
+    expect(component.buildDataTree).toHaveBeenCalledTimes(1);
+    expect(component.buildDataTree).toHaveBeenCalledWith(
+      metadata,
+      0,
+      "scientificMetadata.sample",
+    );
+    expect(component.dataSource.data[0].columnName).toBe(
+      "scientificMetadata.sample.beam_size.value",
+    );
   });
 });

--- a/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.ts
+++ b/src/app/shared/modules/scientific-metadata-tree/tree-view/tree-view.component.ts
@@ -11,12 +11,16 @@ import {
   MatTreeFlattener,
 } from "@angular/material/tree";
 import {
+  DEFAULT_METADATA_PATH,
   FlatNode,
   TreeBaseComponent,
   TreeNode,
 } from "shared/modules/scientific-metadata-tree/base-classes/tree-base";
 import { DatePipe } from "@angular/common";
 import { AppConfigService } from "app-config.service";
+import { ContextMenuItem } from "shared/modules/dynamic-material-table/models/context-menu.model";
+import { TableSetting } from "shared/modules/dynamic-material-table/models/table-setting.model";
+import { ScientificMetadataColumnsService } from "shared/services/scientific-metadata-columns.service";
 @Component({
   selector: "tree-view",
   templateUrl: "./tree-view.component.html",
@@ -28,11 +32,23 @@ export class TreeViewComponent
   implements OnInit, OnChanges
 {
   @Input() metadata: any;
+  @Input() allowAddAsColumn = false;
+  @Input() metadataPath = DEFAULT_METADATA_PATH;
+
+  canAddScientificMetadataKeysAsColumn = false;
+  rowContextMenuItems: ContextMenuItem[] = [];
+  tableSetting = new TableSetting();
   constructor(
     public datePipe: DatePipe,
     configService: AppConfigService,
+    private scientificMetadataColumnsService: ScientificMetadataColumnsService,
   ) {
     super(configService);
+    this.canAddScientificMetadataKeysAsColumn =
+      configService.getConfig().addScientificMetadataKeysAsColumn === true;
+    this.rowContextMenuItems = this.canAddScientificMetadataKeysAsColumn
+      ? [this.scientificMetadataColumnsService.addAsColumnAction]
+      : [];
     this.treeFlattener = new MatTreeFlattener(
       this.transformer,
       this.getLevel,
@@ -50,19 +66,39 @@ export class TreeViewComponent
     this.nestNodeMap = new Map<TreeNode, FlatNode>();
     this.flatNodeMap = new Map<FlatNode, TreeNode>();
   }
+
+  private getMetadataColumnName(path: string): string {
+    const metadataPathPrefix = `${this.metadataPath}.`;
+
+    return path.startsWith(metadataPathPrefix)
+      ? path.slice(metadataPathPrefix.length)
+      : path;
+  }
+
   ngOnInit() {
-    this.dataTree = this.buildDataTree(this.metadata, 0);
+    this.dataTree = this.buildDataTree(this.metadata, 0, this.metadataPath);
     this.dataSource.data = this.dataTree;
   }
   ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
-    for (const propName in changes) {
-      if (propName === "metadata") {
-        this.metadata = changes[propName].currentValue;
-        this.dataTree = this.buildDataTree(this.metadata, 0);
-        this.dataSource.data = this.dataTree;
-        this.filterText = this._filterText;
-      }
+    const shouldRebuildTree = !!changes.metadata || !!changes.metadataPath;
+
+    if (changes.metadata) {
+      this.metadata = changes.metadata.currentValue;
     }
+
+    if (changes.metadataPath) {
+      // Used for saved column paths when a dynamic section renders a nested metadata source.
+      this.metadataPath =
+        changes.metadataPath.currentValue || DEFAULT_METADATA_PATH;
+    }
+
+    if (!shouldRebuildTree) {
+      return;
+    }
+
+    this.dataTree = this.buildDataTree(this.metadata, 0, this.metadataPath);
+    this.dataSource.data = this.dataTree;
+    this.filterText = this._filterText;
   }
   transformer = (node: TreeNode, level: number) => {
     const existingNode = this.nestNodeMap.get(node);
@@ -76,8 +112,46 @@ export class TreeViewComponent
     flatNode.unit = node.unit;
     flatNode.expandable = node.children?.length > 0;
     flatNode.visible = true;
+    flatNode.path = node.path;
+    flatNode.columnName = node.columnName;
+    flatNode.human_name = node.human_name;
     this.flatNodeMap.set(flatNode, node);
     this.nestNodeMap.set(node, flatNode);
     return flatNode;
   };
+
+  canShowAddAsColumn(node: FlatNode): boolean {
+    return (
+      this.allowAddAsColumn &&
+      this.rowContextMenuItems.length > 0 &&
+      !node.expandable &&
+      !!node.columnName
+    );
+  }
+
+  async onRowActionChange(
+    node: FlatNode,
+    action: ContextMenuItem,
+  ): Promise<void> {
+    if (
+      action.name !==
+      this.scientificMetadataColumnsService.addAsColumnAction.name
+    ) {
+      return;
+    }
+
+    await this.addAsColumn(node);
+  }
+
+  async addAsColumn(node: FlatNode): Promise<void> {
+    if (!this.canShowAddAsColumn(node)) {
+      return;
+    }
+
+    await this.scientificMetadataColumnsService.addMetadataColumn({
+      name: this.getMetadataColumnName(node.path),
+      human_name: node.human_name,
+      columnName: node.columnName,
+    });
+  }
 }

--- a/src/app/shared/services/scientific-metadata-columns.service.spec.ts
+++ b/src/app/shared/services/scientific-metadata-columns.service.spec.ts
@@ -5,6 +5,7 @@ import {
   showMessageAction,
   updateUserSettingsAction,
 } from "state-management/actions/user.actions";
+import { getSettingKey } from "state-management/models";
 import {
   selectColumnsWithHasFetchedSettings,
   selectCurrentUser,
@@ -131,7 +132,7 @@ describe("ScientificMetadataColumnsService", () => {
     expect(store.dispatch.calls.argsFor(0)[0]).toEqual(
       updateUserSettingsAction({
         property: {
-          columns: [
+          [getSettingKey("dataset", "columns")]: [
             {
               name: "datasetName",
               order: 0,

--- a/src/app/shared/services/scientific-metadata-columns.service.ts
+++ b/src/app/shared/services/scientific-metadata-columns.service.ts
@@ -6,7 +6,12 @@ import {
   showMessageAction,
   updateUserSettingsAction,
 } from "state-management/actions/user.actions";
-import { Message, MessageType, TableColumn } from "state-management/models";
+import {
+  getSettingKey,
+  Message,
+  MessageType,
+  TableColumn,
+} from "state-management/models";
 import {
   selectColumnsWithHasFetchedSettings,
   selectCurrentUser,
@@ -104,7 +109,7 @@ export class ScientificMetadataColumnsService {
     this.store.dispatch(
       updateUserSettingsAction({
         property: {
-          columns: nextColumns,
+          [getSettingKey("dataset", "columns")]: nextColumns,
         },
       }),
     );


### PR DESCRIPTION
## Description
Continuation of #2333. Same configuration now also works for the scientific metadata tree view.

<img width="845" height="511" alt="image" src="https://github.com/user-attachments/assets/d6927637-a2db-41fb-8828-68fd70ae660f" />


## Motivation
Users should be able to configure the dataset table with columns from scientific metadata.


## Changes:
- Added “Add as column” row menu support to the scientific metadata tree view, reusing the shared row-menu component used by metadata tables.
  - Added metadata path tracking in tree nodes so saved columns get correct paths like scientificMetadata.sample.temperature.value.
  - Enabled the feature for dataset scientific metadata tree views, including dynamic detail sections with nested section.source.
  - Adjusted tree row layout so the left-side menu aligns with existing metadata table


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)

## Summary by Sourcery

Enable adding scientific metadata keys as configurable dataset table columns from the tree view.

New Features:
- Allow scientific metadata tree views to expose an 'add as column' action for leaf nodes when enabled in configuration.
- Support dynamic metadata path tracking so added scientific metadata columns use correct nested paths in saved column definitions.

Enhancements:
- Align scientific metadata tree view layout with metadata tables when row menus are enabled for adding columns.

Tests:
- Extend scientific metadata tree view tests to cover add-as-column visibility, path generation, and delegation to the saved-column service.