### PR TITLE
fix(shared-table): call unsubscribe() instead of referencing it

### DIFF
--- a/src/app/shared/modules/shared-table/shared-table.component.spec.ts
+++ b/src/app/shared/modules/shared-table/shared-table.component.spec.ts
@@ -200,4 +200,18 @@ describe("SharedTableComponent", () => {
   describe("#getFilterColumns()", () => {
     xit("should ...", () => {});
   });
+
+  describe("#ngOnDestroy()", () => {
+    it("should call unsubscribe() on every tracked subscription", () => {
+      const spy = jasmine.createSpy("unsubscribe");
+      (component as any).subscriptions = [
+        { unsubscribe: spy },
+        { unsubscribe: spy },
+      ];
+
+      component.ngOnDestroy();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/app/shared/modules/shared-table/shared-table.component.ts
+++ b/src/app/shared/modules/shared-table/shared-table.component.ts
@@ -269,7 +269,7 @@ export class SharedTableComponent
   }
 
   ngOnDestroy() {
-    this.subscriptions.forEach((sub) => sub.unsubscribe);
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
   }
 
   onRowClick(event: any) {


### PR DESCRIPTION
## Description
Fix memory leak in `SharedTableComponent` where `ngOnDestroy` passed a function reference instead of calling it, meaning no subscription was ever cleaned up.

## Motivation
`ngOnDestroy` iterated the tracked subscriptions array but used `sub.unsubscribe` (a reference) rather than `sub.unsubscribe()` (a call). As `SharedTableComponent` is used by every list view in the application, subscriptions accumulated on every navigation without bound.

## Fixes:

* `sub.unsubscribe` → `sub.unsubscribe()` in `ngOnDestroy`

## Changes:

* One-character fix in `shared-table.component.ts`
* Regression test added in `shared-table.component.spec.ts`

## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)

## Summary by Sourcery

Fix subscription cleanup in SharedTableComponent to prevent memory leaks on destroy.

Bug Fixes:
- Ensure SharedTableComponent calls unsubscribe() on all tracked subscriptions during ngOnDestroy to properly clean up subscriptions.

Tests:
- Add a unit test verifying ngOnDestroy invokes unsubscribe() on each tracked subscription.