### PR TITLE
fix(shared-table): track sort/paginator merge subscription for cleanup

### DIFF
--- a/src/app/shared/modules/shared-table/shared-table.component.spec.ts
+++ b/src/app/shared/modules/shared-table/shared-table.component.spec.ts
@@ -203,13 +203,15 @@ describe("SharedTableComponent", () => {
 
   describe("#ngAfterViewInit()", () => {
     it("should add the sort/paginator merge subscription to the tracked list", () => {
-      (component as any).subscriptions = [];
+      const pushSpy = spyOn(
+        (component as any).subscriptions,
+        "push",
+      ).and.callThrough();
+
       component.ngAfterViewInit();
 
-      // Expects at least: sort-reset subscription + merge subscription
-      expect((component as any).subscriptions.length).toBeGreaterThanOrEqualTo(
-        2,
-      );
+      // sort-reset subscription + merge subscription
+      expect(pushSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/app/shared/modules/shared-table/shared-table.component.spec.ts
+++ b/src/app/shared/modules/shared-table/shared-table.component.spec.ts
@@ -200,4 +200,16 @@ describe("SharedTableComponent", () => {
   describe("#getFilterColumns()", () => {
     xit("should ...", () => {});
   });
+
+  describe("#ngAfterViewInit()", () => {
+    it("should add the sort/paginator merge subscription to the tracked list", () => {
+      (component as any).subscriptions = [];
+      component.ngAfterViewInit();
+
+      // Expects at least: sort-reset subscription + merge subscription
+      expect((component as any).subscriptions.length).toBeGreaterThanOrEqualTo(
+        2,
+      );
+    });
+  });
 });

--- a/src/app/shared/modules/shared-table/shared-table.component.ts
+++ b/src/app/shared/modules/shared-table/shared-table.component.ts
@@ -207,22 +207,24 @@ export class SharedTableComponent
     );
 
     this.setDefaultFilters();
-    merge(this.sort.sortChange, this.paginator.page)
-      .pipe(
-        tap(() => {
-          this.router.navigate([], {
-            queryParams: {
-              sortActive: this.sort.active,
-              sortDirection: this.sort.direction,
-              pageIndex: this.paginator.pageIndex,
-              pageSize: this.paginator.pageSize,
-            },
-            queryParamsHandling: "merge",
-          });
-          this.loadDataPage();
-        }),
-      )
-      .subscribe();
+    this.subscriptions.push(
+      merge(this.sort.sortChange, this.paginator.page)
+        .pipe(
+          tap(() => {
+            this.router.navigate([], {
+              queryParams: {
+                sortActive: this.sort.active,
+                sortDirection: this.sort.direction,
+                pageIndex: this.paginator.pageIndex,
+                pageSize: this.paginator.pageSize,
+              },
+              queryParamsHandling: "merge",
+            });
+            this.loadDataPage();
+          }),
+        )
+        .subscribe(),
+    );
 
     // copy changes in URL parameters to corresponding GUI fields
     // Important: Do only once


### PR DESCRIPTION
## Description
Fix memory leak in `SharedTableComponent` where the `merge(sort.sortChange, paginator.page)` subscription created in `ngAfterViewInit` was not added to the tracked subscriptions array, so it was never cleaned up on component destruction.

## Motivation
The subscription was created with `.subscribe()` but the returned `Subscription` object was discarded rather than pushed to `this.subscriptions`. On every navigation away from and back to a list view, another copy of the subscription was created and kept alive indefinitely. This complements the fix in #2367, which corrected `ngOnDestroy` actually invoking `unsubscribe()`.

## Fixes:

* Wrap `merge(...).subscribe()` in `this.subscriptions.push(...)` so it is cleaned up by `ngOnDestroy`

## Changes:

* `shared-table.component.ts` — subscription is now tracked
* `shared-table.component.spec.ts` — regression test verifies `ngAfterViewInit` registers at least two subscriptions (sort-reset + merge)

## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)

## Summary by Sourcery

Track the merged sort/paginator subscription in SharedTableComponent so it is cleaned up on destroy and covered by tests.

Bug Fixes:
- Ensure the sort/paginator merge subscription in SharedTableComponent is tracked for proper cleanup to prevent memory leaks.

Tests:
- Add a regression test confirming ngAfterViewInit registers the sort/paginator merge subscription in the tracked subscriptions list.