### PR TITLE
fix: account for non visible columns when dropping

### DIFF
--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
@@ -129,7 +129,7 @@
         cdkDragBoundary="mat-header-row"
         cdkDropListLockAxis="x"
         [ngClass]="headerClass(column)"
-        [cdkDragData]="{ name: column.name, columnIndex: i }"
+        [cdkDragData]="{ name: column.name }"
         [ngStyle]="column.style"
         [class.active-resize]="resizeColumn.columnIndex === i"
         [class.active-sort]="sort.direction && sort.active === column.name"

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.ts
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.ts
@@ -1101,12 +1101,18 @@ export class DynamicMatTableComponent<T extends TableRow>
   dragStarted(event: Event) {}
 
   dropListDropped(event: CdkDragDrop<string[]>) {
-    const columnPreviousIndex = event.item.data.columnIndex;
+    const displayedColumnIndexMap = this.columns
+      .map((column, index) => ({ column, index }))
+      .filter(({ column }) => column.display !== "hidden");
+    const from = displayedColumnIndexMap[event.previousIndex];
+    const to = displayedColumnIndexMap[event.currentIndex];
 
-    if (event) {
-      this.dragDropData.dropColumnIndex = event.currentIndex;
-      this.moveColumn(columnPreviousIndex, event.currentIndex);
+    if (!from || !to || from.index === to.index) {
+      return;
     }
+
+    this.dragDropData.dropColumnIndex = to.index;
+    this.moveColumn(from.index, to.index);
   }
 
   drop(event: CdkDragDrop<string[]>) {


### PR DESCRIPTION
## Description
Fix an issue where moving columns does not work correctly when hidden columns are present.

## Motivation
 Dragging and dropping a column while hidden columns are present could place the dragged column in the wrong position, or  make it disappear from the rendered table.

This happened because drag-and-drop reports indices based on the rendered columns, while the table reorders the internal full column list. When hidden columns exist, those index positions no longer match.

## Fixes:
  * Build a mapping from rendered column indices to internal `columns` indices.
  * Use the resolved internal source and target indices when moving columns.



## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked)

## Summary by Sourcery

Fix column drag-and-drop reordering to correctly handle hidden columns in the dynamic material table.

Bug Fixes:
- Resolve incorrect column reordering and disappearance when dragging columns while some columns are hidden by mapping drag indices from displayed to internal columns.

Enhancements:
- Add a helper to determine which columns are considered displayed and use it to derive drag source and target columns instead of relying on raw indices.