### PR TITLE
feat: session expired interceptor with login redirection

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { LayoutModule } from "_layout/layout.module";
 import { AppConfigService } from "app-config.service";
 import { AppThemeService } from "app-theme.service";
 import { SnackbarInterceptor } from "shared/interceptors/snackbar.interceptor";
+import { AuthInterceptor } from "shared/interceptors/auth.interceptor";
 import { AuthService } from "shared/services/auth/auth.service";
 import { InternalStorage, SDKStorage } from "shared/services/auth/base.storage";
 import { CookieService } from "ngx-cookie-service";
@@ -110,6 +111,11 @@ const apiConfigurationFn = (
     {
       provide: HTTP_INTERCEPTORS,
       useClass: SnackbarInterceptor,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
       multi: true,
     },
     {

--- a/src/app/shared/interceptors/auth.interceptor.ts
+++ b/src/app/shared/interceptors/auth.interceptor.ts
@@ -1,0 +1,45 @@
+import { Injectable } from "@angular/core";
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+  HttpErrorResponse,
+} from "@angular/common/http";
+import { Observable, throwError } from "rxjs";
+import { catchError } from "rxjs/operators";
+import { Router } from "@angular/router";
+import { NgZone } from "@angular/core";
+import { Subscription } from "rxjs";
+import { sessionTimeoutAction } from "state-management/actions/user.actions";
+import { Store } from "@ngrx/store";
+import { selectProfile } from "state-management/selectors/user.selectors";
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(
+    private router: Router,
+    private store: Store,
+    private zone: NgZone,
+  ) {}
+
+  intercept(
+    request: HttpRequest<unknown>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<unknown>> {
+    return next.handle(request).pipe(
+      catchError((error: HttpErrorResponse) => {
+        const isSessionExpired =
+          error.status === 401 && error.error?.message === "SESSION_EXPIRED";
+
+        if (isSessionExpired) {
+          const currentUrl = this.router.url;
+          sessionStorage.setItem("postLoginRedirect", currentUrl);
+          this.store.dispatch(sessionTimeoutAction());
+        }
+
+        return throwError(() => error);
+      }),
+    );
+  }
+}

--- a/src/app/state-management/actions/user.actions.ts
+++ b/src/app/state-management/actions/user.actions.ts
@@ -140,6 +140,8 @@ export const logoutCompleteAction = createAction(
 );
 export const logoutFailedAction = createAction("[User] Logout Failed");
 
+export const sessionTimeoutAction = createAction("[User] Session Timeout");
+
 export const addCustomColumnsAction = createAction(
   "[User] Add Custom Columns",
   props<{ names: string[]; scope: "dataset" | "sample" }>(),

--- a/src/app/state-management/effects/user.effects.ts
+++ b/src/app/state-management/effects/user.effects.ts
@@ -246,6 +246,27 @@ export class UserEffects {
     );
   });
 
+  sessionTimeout$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(fromActions.sessionTimeoutAction),
+      filter(() => this.authService.isAuthenticated()),
+      switchMap(() => {
+        this.authService.clear();
+        return of(
+          clearDatasetsStateAction(),
+          clearInstrumentsStateAction(),
+          clearJobsStateAction(),
+          clearLogbooksStateAction(),
+          clearPoliciesStateAction(),
+          clearProposalsStateAction(),
+          clearPublishedDataStateAction(),
+          clearSamplesStateAction(),
+          fromActions.logoutCompleteAction({ logoutURL: "/login" }),
+        );
+      }),
+    );
+  });
+
   logoutNavigate$ = createEffect(
     () => {
       return this.actions$.pipe(

--- a/src/app/state-management/reducers/user.reducer.ts
+++ b/src/app/state-management/reducers/user.reducer.ts
@@ -128,6 +128,13 @@ const reducer = createReducer(
   ),
 
   on(
+    fromActions.sessionTimeoutAction,
+    (): UserState => ({
+      ...initialUserState,
+    }),
+  ),
+
+  on(
     fromActions.addCustomColumnsAction,
     (state, { names, scope }): UserState => {
       const key = getSettingKey(scope, "columns");

--- a/src/app/users/login/login.component.ts
+++ b/src/app/users/login/login.component.ts
@@ -125,6 +125,12 @@ export class LoginComponent implements OnInit, OnDestroy {
     this.loginLocalEnabled = this.appConfig.loginLocalEnabled;
     this.oAuth2Endpoints = this.appConfig.oAuth2Endpoints;
 
+    const storedRedirect = sessionStorage.getItem("postLoginRedirect");
+    if (storedRedirect) {
+      this.returnUrl = storedRedirect;
+      sessionStorage.removeItem("postLoginRedirect");
+    }
+
     this.proceedSubscription = this.vm$
       .pipe(filter((vm) => vm.isLoggedIn))
       .subscribe(() => {


### PR DESCRIPTION
## Description
Redirect to login page at session expiration if an authentication with an expired token is attempted. then redirect back in case of successful login.

## Motivation
- Informs the user of session expiration by redirecting to login page, avoiding silent `403` failures returning empty results (e.i: empty `datafiles`, no datasets at filtering, ...)

- Also Adresses #1822 

## Changes:
- new interceptor: `auth.interceptor.ts`
- new `sessionTimeout` user action 
- update the returnUrl for login in case of `session timeout`

## Backend changes:
- Requires `401` HTTP status errors with `SESSION_EXPIRED` message to be thrown from the backend yo perform the redirection.
- See Backend PR [2737](https://github.com/SciCatProject/backend/pull/2737)


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Summary by Sourcery

Handle expired authentication sessions by redirecting users to the login page and back to their original route after successful re-authentication.

New Features:
- Add an HTTP auth interceptor that detects SESSION_EXPIRED 401 responses and triggers a session-timeout flow with post-login redirection.
- Introduce a session timeout user action and effect to clear user-related state and complete logout with a redirect to the login page.
- Restore a stored post-login redirect URL in the login component so users return to the page they were on before session expiration.

Enhancements:
- Register the new auth interceptor in the application module HTTP interceptor chain.