### PR TITLE
fix: format-number pipe should not convert 0 to 0e+0

### DIFF
--- a/src/app/shared/pipes/format-number.pipe.ts
+++ b/src/app/shared/pipes/format-number.pipe.ts
@@ -79,6 +79,7 @@ export class FormatNumberPipe implements PipeTransform {
     if (!this.enabled) {
       if (
         typeof innerValue === "number" &&
+        innerValue !== 0 &&
         (innerValue >= 1e5 || innerValue <= 1e-5)
       ) {
         return innerValue.toExponential();
@@ -88,11 +89,6 @@ export class FormatNumberPipe implements PipeTransform {
 
     if (typeof innerValue !== "number" || !Number.isFinite(innerValue)) {
       // value is not a finite number
-      return String(innerValue);
-    }
-
-    // Do not format integers
-    if (Number.isInteger(innerValue)) {
       return String(innerValue);
     }
 

--- a/src/app/shared/pipes/format-number.pipe.ts
+++ b/src/app/shared/pipes/format-number.pipe.ts
@@ -92,6 +92,11 @@ export class FormatNumberPipe implements PipeTransform {
       return String(innerValue);
     }
 
+    // Do not format integers
+    if (Number.isInteger(innerValue)) {
+      return String(innerValue);
+    }
+
     // use scientific notation if float value is large or small
     const absoluteValue = Math.abs(innerValue);
     if (absoluteValue < this.minCutoff || absoluteValue > this.maxCutoff) {


### PR DESCRIPTION
## Description

Before the change, the following condition converts `0` to `0e+0` because `0` satisfies all the conditions.
After the change, 0 remains as 0

```js
    if (!this.enabled) {
      if (
        typeof innerValue === "number" &&
        (innerValue >= 1e5 || innerValue <= 1e-5)
      ) {
        return innerValue.toExponential();
      }
      return String(innerValue);
    }
```
## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Adjust numeric formatting behavior in the shared format-number pipe.

Bug Fixes:
- Prevent the format-number pipe from converting a numeric value of 0 to scientific notation when formatting is disabled.

Enhancements:
- Remove the special-case bypass that returned integers unformatted so they now follow the standard formatting logic.