### PR TITLE
fix: format-number pipe should format booleans

### DIFF
--- a/src/app/shared/pipes/format-number.pipe.spec.ts
+++ b/src/app/shared/pipes/format-number.pipe.spec.ts
@@ -96,9 +96,7 @@ describe("FormatNumberPipe", () => {
       setConfig({ enabled: false });
       const pipe = new FormatNumberPipe(mockConfigService);
       const value = [1, 2, 3];
-      const formatted = pipe.transform(
-        value as unknown as string | number | null | undefined,
-      );
+      const formatted = pipe.transform(value);
       expect(formatted).toEqual("1,2,3");
     });
 
@@ -106,9 +104,7 @@ describe("FormatNumberPipe", () => {
       setConfig({ enabled: false });
       const pipe = new FormatNumberPipe(mockConfigService);
       const value = [1, 2, "4", null, 3];
-      const formatted = pipe.transform(
-        value as unknown as string | number | null | undefined,
-      );
+      const formatted = pipe.transform(value as unknown as (string | number)[]);
       expect(formatted).toEqual("1,2,4,3");
     });
 
@@ -116,19 +112,22 @@ describe("FormatNumberPipe", () => {
       setConfig({ enabled: false });
       const pipe = new FormatNumberPipe(mockConfigService);
       const value = BigInt(123);
-      const formatted = pipe.transform(
-        value as unknown as string | number | null | undefined,
-      );
+      const formatted = pipe.transform(value);
       expect(formatted).toEqual("123");
     });
 
-    it("returns empty string when value is a boolean", () => {
+    it("returns string when value is true", () => {
       setConfig({ enabled: false });
       const pipe = new FormatNumberPipe(mockConfigService);
-      const formatted = pipe.transform(
-        true as unknown as string | number | null | undefined,
-      );
-      expect(formatted).toEqual("");
+      const formatted = pipe.transform(true);
+      expect(formatted).toEqual("true");
+    });
+
+    it("returns string when value is false", () => {
+      setConfig({ enabled: false });
+      const pipe = new FormatNumberPipe(mockConfigService);
+      const formatted = pipe.transform(false);
+      expect(formatted).toEqual("false");
     });
 
     it("returns string when number is a string", () => {
@@ -151,10 +150,16 @@ describe("FormatNumberPipe", () => {
       setConfig({ enabled: false });
       const pipe = new FormatNumberPipe(mockConfigService);
       const value = [1, 2, { value: "4", unit: "unit" }, 3];
-      const formatted = pipe.transform(
-        value as unknown as string | number | null | undefined,
-      );
+      const formatted = pipe.transform(value);
       expect(formatted).toEqual("1,2,4 unit,3");
+    });
+
+    it("returns concatenated string when value is an array with booleans", () => {
+      setConfig({ enabled: false });
+      const pipe = new FormatNumberPipe(mockConfigService);
+      const value = [true, false, { value: true, unit: "" }];
+      const formatted = pipe.transform(value);
+      expect(formatted).toEqual("true,false,true ");
     });
   });
 
@@ -179,6 +184,13 @@ describe("FormatNumberPipe", () => {
       const pipe = new FormatNumberPipe(mockConfigService);
       expect(pipe.transform("abc")).toBe("abc");
       expect(pipe.transform("")).toBe("");
+    });
+
+    it("should return string representation for boolean values", () => {
+      setConfig();
+      const pipe = new FormatNumberPipe(mockConfigService);
+      expect(pipe.transform(true)).toBe("true");
+      expect(pipe.transform(false)).toBe("false");
     });
 
     it("should return string representation for non-finite numbers", () => {

--- a/src/app/shared/pipes/format-number.pipe.ts
+++ b/src/app/shared/pipes/format-number.pipe.ts
@@ -1,7 +1,8 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import { AppConfigService } from "app-config.service";
 
-type ValueWithUnit = { value: number | string | bigint; unit?: string };
+type FormattableScalar = string | number | bigint | boolean;
+type ValueWithUnit = { value: FormattableScalar; unit?: string };
 
 @Pipe({
   name: "formatNumber",
@@ -31,15 +32,22 @@ export class FormatNumberPipe implements PipeTransform {
       typeof value === "object" &&
       value !== null &&
       "value" in value &&
-      (typeof value.value === "number" ||
-        typeof value.value === "string" ||
-        typeof value.value === "bigint")
+      this.isFormattableScalar(value.value)
+    );
+  }
+
+  private isFormattableScalar(value: unknown): value is FormattableScalar {
+    return (
+      typeof value === "number" ||
+      typeof value === "bigint" ||
+      typeof value === "string" ||
+      typeof value === "boolean"
     );
   }
 
   private formatValueUnitObj(
-    value: string | number | bigint | ValueWithUnit,
-  ): string | number | bigint {
+    value: FormattableScalar | ValueWithUnit,
+  ): FormattableScalar {
     return this.isValueWithUnit(value)
       ? `${value.value} ${value.unit ?? ""}`
       : value;
@@ -47,33 +55,20 @@ export class FormatNumberPipe implements PipeTransform {
 
   transform(
     value:
-      | string
-      | number
+      | FormattableScalar
       | null
       | undefined
-      | bigint
       | ValueWithUnit
-      | (string | number | bigint | ValueWithUnit)[],
+      | (FormattableScalar | ValueWithUnit)[],
   ): string {
     if (Array.isArray(value))
       return String(
         value
-          .filter(
-            (v) =>
-              typeof v === "number" ||
-              typeof v === "bigint" ||
-              typeof v === "string" ||
-              this.isValueWithUnit(v),
-          )
+          .filter((v) => this.isFormattableScalar(v) || this.isValueWithUnit(v))
           .map((v) => this.formatValueUnitObj(v)),
       );
     const innerValue = this.formatValueUnitObj(value);
-    if (
-      typeof innerValue !== "string" &&
-      typeof innerValue !== "number" &&
-      typeof innerValue !== "bigint"
-    )
-      return "";
+    if (!this.isFormattableScalar(innerValue)) return "";
 
     // use old way if not enabled
     if (!this.enabled) {


### PR DESCRIPTION
## Description
Currently booleans are rendered as empty strings. This PR changes that so that booleans are converted to strings ("true" or "false")


## Motivation
It should be possible to see boolean values


## Tests included
- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked)

## Summary by Sourcery

Handle boolean values in the formatNumber pipe and extend type guards to treat them as formattable scalars.

Bug Fixes:
- Ensure boolean values are rendered as their string representations instead of empty strings in the formatNumber pipe.

Tests:
- Add and update unit tests to verify boolean handling in both scalar and array inputs for the formatNumber pipe.