### PR TITLE
fix: include sampleName in e2e test sample

### DIFF
--- a/cypress/fixtures/testData.js
+++ b/cypress/fixtures/testData.js
@@ -73,6 +73,7 @@ export const testData = {
     },
   },
   sample: {
+    sampleName: "Cypress Sample",
     ownerGroup: "ess",
     accessGroups: ["string"],
     instrumentGroup: "string",
@@ -366,7 +367,7 @@ export const defaultDatasetsColumnsList = [
   "Size",
   "Creation Time",
   "Image",
-  "Proposal Id"
+  "Proposal Id",
 ];
 
 export const personalizedDatasetsColumnsList = [
@@ -377,5 +378,5 @@ export const personalizedDatasetsColumnsList = [
   "Creation Time",
   "Proposal Id",
   "Start Time",
-  "End Time"
+  "End Time",
 ];


### PR DESCRIPTION
## Description
sampleName is a mandatory field now when creating a sample, which was missing from the e2e test setup and causing test failures.


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Ensure Cypress e2e test data complies with updated sample requirements and tidy dataset column configurations.

Bug Fixes:
- Add the mandatory sampleName field to the e2e test sample fixture to prevent sample creation failures.

Enhancements:
- Normalize dataset column list definitions in Cypress fixtures by adding trailing commas for consistency.