### PR TITLE
fix(breadcrumb): fall back to router navigation when mode is empty

### DIFF
--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
@@ -6,11 +6,29 @@ import {
 import { MockStore } from "shared/MockStubs";
 import { BreadcrumbComponent } from "./breadcrumb.component";
 import { Store } from "@ngrx/store";
-import { provideRouter } from "@angular/router";
+import { provideRouter, Router } from "@angular/router";
+import { Location } from "@angular/common";
+import {
+  selectArchiveViewMode,
+  selectFilters,
+} from "state-management/selectors/datasets.selectors";
+import { of } from "rxjs/internal/observable/of";
+import { ArchViewMode } from "state-management/models";
 
 describe("BreadcrumbComponent", () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
+  let router: Router;
+  let location: Location;
+  let store: Store;
+
+  const datasetsCrumb = {
+    label: "Datasets",
+    path: "datasets",
+    params: {},
+    url: "/datasets",
+    fallback: "/datasets",
+  };
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -27,6 +45,9 @@ describe("BreadcrumbComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(BreadcrumbComponent);
     component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
+    store = TestBed.inject(Store);
     fixture.detectChanges();
   });
 
@@ -36,5 +57,32 @@ describe("BreadcrumbComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should navigateByUrl to fallback when mode is empty", () => {
+    spyOn(store, "select").and.callFake((selector) => {
+      if (selector === selectFilters) return of({});
+      if (selector === selectArchiveViewMode) return of(ArchViewMode.all);
+      return of(null);
+    });
+    spyOn(router, "navigateByUrl").and.returnValue(Promise.resolve(true));
+
+    component.crumbClick(0, datasetsCrumb);
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith("/datasets");
+  });
+
+  it("should call location.back() when mode is not empty", () => {
+    spyOn(store, "select").and.callFake((selector) => {
+      if (selector === selectFilters) return of({});
+      if (selector === selectArchiveViewMode)
+        return of(ArchViewMode.archivable);
+      return of(null);
+    });
+    spyOn(location, "back");
+
+    component.crumbClick(0, datasetsCrumb);
+
+    expect(location.back).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.spec.ts
@@ -1,3 +1,4 @@
+/// <reference types="jasmine" />
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import {
   provideHttpClient,

--- a/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/modules/breadcrumb/breadcrumb.component.ts
@@ -10,6 +10,7 @@ import { take, filter } from "rxjs/operators";
 import { TitleCasePipe } from "shared/pipes/title-case.pipe";
 import { ArchViewMode } from "state-management/models";
 import { Location } from "@angular/common";
+import { isEmpty } from "lodash-es";
 
 interface Breadcrumb {
   label: string;
@@ -123,8 +124,13 @@ export class BreadcrumbComponent implements OnInit {
             .select(selectArchiveViewMode)
             .pipe(take(1))
             .subscribe((currentMode) => {
-              filters["mode"] = setMode(currentMode);
-              this.location.back();
+              const mode = setMode(currentMode);
+              if (isEmpty(mode)) {
+                this.router.navigateByUrl(url + crumb.fallback);
+              } else {
+                filters["mode"] = mode;
+                this.location.back();
+              }
             });
         });
     } else {


### PR DESCRIPTION
## Description
`location.back()` relies on browser history, which causes unexpected redirects (e.g. to google.com) when the page is opened in a new tab or accessed directly via URL.

- **Before:** clicking a breadcrumb in a new tab could redirect to an external URL (browser history fallback)
- **After:** always navigates to the correct fallback route regardless of browser history state

## Fixes:
- Add a guard to check if `mode` is empty before applying it to filters
- If `mode` is empty, navigate directly to the fallback URL without appending mode to filters

## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Bug Fixes:
- Prevent incorrect breadcrumb redirects by skipping history.back navigation when the computed view mode is empty and routing directly to the fallback URL.