### PR TITLE
fix: remove horizontal overflow on the table page

### DIFF
--- a/src/app/_layout/app-header/app-header.component.html
+++ b/src/app/_layout/app-header/app-header.component.html
@@ -204,7 +204,6 @@
           data-cy="login-button"
         >
           <mat-icon color="primary"> account_circle </mat-icon>
-          <span class="large-screen-text">Sign in</span>
         </button>
       </h6>
     </ng-template>

--- a/src/app/_layout/app-header/app-header.component.html
+++ b/src/app/_layout/app-header/app-header.component.html
@@ -141,7 +141,6 @@
           [routerLink]="['/help']"
         >
           <mat-icon color="primary"> help </mat-icon>
-          <span class="large-screen-text">Help</span>
         </button>
       </h6>
     </span>
@@ -188,9 +187,6 @@
           [matMenuTriggerFor]="userMenu"
         >
           <img class="user-image" src="{{ profileImage$ | async }}" />
-          <div color="primary" class="large-screen-text">
-            {{ username$ | async }}
-          </div>
         </button>
       </span>
     </span>

--- a/src/app/_layout/app-header/app-header.component.html
+++ b/src/app/_layout/app-header/app-header.component.html
@@ -187,6 +187,9 @@
           [matMenuTriggerFor]="userMenu"
         >
           <img class="user-image" src="{{ profileImage$ | async }}" />
+          <div color="primary" class="large-screen-text">
+            {{ username$ | async }}
+          </div>
         </button>
       </span>
     </span>
@@ -194,8 +197,8 @@
       <h6>
         <button
           mat-icon-button
-          (click)="login()"
           aria-label="Sign in to your account"
+          (click)="login()"
           [matTooltip]="'Sign in to your account'"
           [matTooltipShowDelay]="500"
           data-cy="login-button"

--- a/src/app/_layout/app-header/app-header.component.html
+++ b/src/app/_layout/app-header/app-header.component.html
@@ -199,6 +199,7 @@
         <button
           mat-icon-button
           (click)="login()"
+          aria-label="Sign in to your account"
           [matTooltip]="'Sign in to your account'"
           [matTooltipShowDelay]="500"
           data-cy="login-button"

--- a/src/app/_layout/app-header/app-header.component.scss
+++ b/src/app/_layout/app-header/app-header.component.scss
@@ -3,6 +3,9 @@
   position: -webkit-sticky;
   top: 0;
   z-index: 1000;
+  overflow: hidden;
+  padding-bottom: 0.5rem;
+  margin-bottom: -0.5rem;
 
   mat-toolbar {
     height: 3.5rem;
@@ -60,6 +63,12 @@
   font-size: 0.75rem;
   margin-left: 0.5rem;
   background-color: var(--theme-header-3-default);
+}
+
+@media only screen and (max-width: 1279px) {
+  .large-screen-text {
+    display: none;
+  }
 }
 
 ::ng-deep .custom-menu .mat-mdc-menu-content:not(:empty) {

--- a/src/app/_layout/app-header/app-header.component.scss
+++ b/src/app/_layout/app-header/app-header.component.scss
@@ -62,12 +62,6 @@
   background-color: var(--theme-header-3-default);
 }
 
-@media only screen and (max-width: 1279px) {
-  .large-screen-text {
-    display: none;
-  }
-}
-
 ::ng-deep .custom-menu .mat-mdc-menu-content:not(:empty) {
   padding-top: 1px;
   padding-bottom: 1px;


### PR DESCRIPTION
## Description

<img width="588" height="336" alt="image" src="https://github.com/user-attachments/assets/6f28114c-5d42-452b-b81d-ee7ee9f765c2" />


## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Remove unnecessary responsive styles and sign-in label text from the app header login button to prevent horizontal overflow on smaller viewports.

Bug Fixes:
- Eliminate horizontal overflow in the app header caused by the login button text on smaller screens.

Enhancements:
- Simplify app header styling by removing an unused media query tied to the sign-in label.