### PR TITLE
fix(proposal-metadata-view): separate table-widget and view-type config flags

### DIFF
--- a/cypress/e2e/proposals/proposals-general.cy.js
+++ b/cypress/e2e/proposals/proposals-general.cy.js
@@ -9,7 +9,10 @@ describe("Proposals general", () => {
   const proposalLabelsConfig = testConfig.proposalViewCustomLabels;
   beforeEach(() => {
     cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
-      const mergedConfig = mergeConfig(baseConfig, proposalLabelsConfig);
+      const mergedConfig = mergeConfig(baseConfig, {
+        ...proposalLabelsConfig,
+        jsonMetadataEnabled: false,
+      });
       cy.intercept("GET", "**/admin/config", mergedConfig).as(
         "getFrontendConfig",
       );
@@ -156,9 +159,10 @@ describe("Proposals general", () => {
 
       cy.get('[data-cy="proposal-metadata-card"]').should("exist");
 
-      cy.contains('[data-cy="proposal-metadata-card"] [role="tab"]', "Edit", {
-        timeout: 20000,
-      }).click();
+      cy.contains(
+        '[data-cy="proposal-metadata-card"] [role="tab"]',
+        "Edit",
+      ).click();
 
       cy.get('[data-cy="add-new-row"]').click();
 
@@ -487,7 +491,6 @@ describe("Proposals general", () => {
       cy.get('[role="menu"] button').contains("Default setting").click();
 
       cy.get("body").type("{esc}");
-      
       cy.get("dynamic-mat-table table-menu button").click();
       cy.get('[role="menu"] button').contains("Save table setting").click();
 

--- a/cypress/e2e/proposals/proposals-general.cy.js
+++ b/cypress/e2e/proposals/proposals-general.cy.js
@@ -156,9 +156,9 @@ describe("Proposals general", () => {
 
       cy.get('[data-cy="proposal-metadata-card"]').should("exist");
 
-      cy.get('[data-cy="proposal-metadata-card"] [role="tab"]')
-        .contains("Edit")
-        .click();
+      cy.contains('[data-cy="proposal-metadata-card"] [role="tab"]', "Edit", {
+        timeout: 20000,
+      }).click();
 
       cy.get('[data-cy="add-new-row"]').click();
 

--- a/src/app/admin/schema/frontend.config.jsonforms.json
+++ b/src/app/admin/schema/frontend.config.jsonforms.json
@@ -453,6 +453,7 @@
           { "type": "Control", "scope": "#/properties/statusBannerMessage" },
           { "type": "Control", "scope": "#/properties/statusBannerCode" },
           { "type": "Control", "scope": "#/properties/addDatasetEnabled" },
+          { "type": "Control", "scope": "#/properties/tableSciDataEnabled" },
           {
             "type": "Control",
             "scope": "#/properties/skipSciCatLoginPageEnabled"

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/_dataset-detail-dynamic-theme.scss
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/_dataset-detail-dynamic-theme.scss
@@ -10,7 +10,7 @@
   $header-3: map.get($color-config, "header-3");
   $header-4: map.get($color-config, "header-4");
   $warn: map.get($color-config, "warn");
-
+  $warn-2: map.get($color-config, "warn-2");
   .dynamic-template-general-header {
     background-color: mat.m2-get-color-from-palette($primary, "lighter");
   }
@@ -23,7 +23,7 @@
   }
 
   .general-warning {
-    color: mat.m2-get-color-from-palette($warn, "default");
+    color: mat.m2-get-color-from-palette($warn-2, "darker");
     font-weight: bold;
   }
 }

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -119,7 +119,10 @@
   </mat-card>
 
   <ng-container *ngIf="emptyMetadataTable()">
-    <mat-card data-cy="proposal-metadata-card">
+    <mat-card
+      *ngIf="appConfig.tableSciDataEnabled"
+      data-cy="proposal-metadata-card"
+    >
       <mat-card-header class="scientific-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> science </mat-icon>
@@ -128,7 +131,7 @@
       </mat-card-header>
       <mat-card-content>
         <ng-template
-          [ngIf]="appConfig.tableSciDataEnabled"
+          [ngIf]="!appConfig.jsonMetadataEnabled"
           [ngIfElse]="jsonView"
         >
           <ng-template #metadataView>

--- a/src/app/proposals/proposal-detail/proposal-detail.component.html
+++ b/src/app/proposals/proposal-detail/proposal-detail.component.html
@@ -119,10 +119,7 @@
   </mat-card>
 
   <ng-container *ngIf="emptyMetadataTable()">
-    <mat-card
-      *ngIf="appConfig.jsonMetadataEnabled"
-      data-cy="proposal-metadata-card"
-    >
+    <mat-card data-cy="proposal-metadata-card">
       <mat-card-header class="scientific-header">
         <div mat-card-avatar class="section-icon">
           <mat-icon> science </mat-icon>

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
@@ -303,7 +303,7 @@ cdk-virtual-scroll-viewport {
   cursor: pointer;
   display: flex;
   align-items: center;
-  padding-left: 4px;
+  padding-left: 8px;
   font-size: 18px;
 }
 

--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.scss
@@ -301,7 +301,10 @@ cdk-virtual-scroll-viewport {
 
 .general-warning {
   cursor: pointer;
-  padding-right: 0.5em;
+  display: flex;
+  align-items: center;
+  padding-left: 4px;
+  font-size: 18px;
 }
 
 ::ng-deep .active-sort .mat-sort-header-arrow svg {

--- a/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
+++ b/src/app/shared/modules/scientific-metadata/metadata-view/metadata-view.component.ts
@@ -167,7 +167,9 @@ export class MetadataViewComponent implements OnInit, OnChanges {
               return row.unit ? this.prettyUnit.transform(row.unit) : "--";
             },
             renderContentIcon: (column, row) => {
-              return row.validUnit === false ? "error" : "";
+              return row.type === "quantity" && row.validUnit === false
+                ? "error"
+                : "";
             },
             contentIconTooltip: "Unrecognized unit, conversion disabled",
             contentIconClass: "general-warning",


### PR DESCRIPTION
## Description
The two metadata config flags in the proposal detail view had overlapping/incorrect responsibilities.
Give each a single clear job:

- tableSciDataEnabled now controls whether the scientific data table
  widget is rendered at all.
- jsonMetadataEnabled now controls the view type, toggling between the
  table and JSON representations.

Additionally, reduced the size of unit cversion warning icon and changed color from red to yellowish 
<img width="726" height="334" alt="image" src="https://github.com/user-attachments/assets/70c5adde-6614-4f74-a4e9-3fa3e8e70aff" />



## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Adjust proposal metadata view configuration and warning display styling in the dataset detail table.

Bug Fixes:
- Correctly separate configuration flags so one controls rendering of the scientific data table and the other controls the metadata view type (table vs JSON).

Enhancements:
- Restrict the invalid-unit warning icon to quantity-type metadata fields only.
- Update general warning icon layout and typography in the dynamic material table.
- Change the general warning color to use a secondary warning palette for a less aggressive appearance.