### PR TITLE
feat(configurable-actions): add userinfo in configurable-actions

### DIFF
--- a/docs/contributors/configurable_actions_technical.md
+++ b/docs/contributors/configurable_actions_technical.md
@@ -148,6 +148,8 @@ This section list all the default values and operators that are available when c
 | #datasetOwner | boolean | True if the user is part of the owner group of the dataset(s) |
 | #userIsAdmin | boolean | True if the user is an admin |
 | #uuid | string | A v4 uuid generated on the fly |
+| #Username | string | The currently logged in user's username |
+| #UserEmail | string | email address of the user |
 | @variable | any | replace the string with the valu eof the variable defined in the action variable |
 
 ## How to Configure

--- a/docs/contributors/configurable_actions_technical.md
+++ b/docs/contributors/configurable_actions_technical.md
@@ -48,7 +48,7 @@ Variables (defined in the `variables` object) are user-defined values which use 
 - System information, like user authentication token (`#jwt`, `#tokenBearer`) or auto generated uuid and more.
 
 Entries under the `inputs` field define the form fields that are dynamically created on the form that it is than submitted when the action is triggered.
-The `payload` field contains what is sent as body of the POST request when an XHR or json-download action is triggered. 
+The `payload` field contains what is sent as body of the POST request when an XHR or json-download action is triggered.
 User defined variables can be injected in the inputs and payload by including the variable name enclosed in double curly braces `{{ ... }}`.
 __Example__:
 Given the following configuration:
@@ -99,7 +99,7 @@ Both configuration support logical operators and variables injection. More infor
 }
 ```
 
-This example action configures a button with label "Download All" and icon mat-icon `download`. The action is of type `form` which by default will submit a form with method POST. Internally, it defines 4 variables with name `pid`, `files`, `totalSize`, and `folder` with their values depending from the dataset fields. The variables are used to define the fields of the form.  
+This example action configures a button with label "Download All" and icon mat-icon `download`. The action is of type `form` which by default will submit a form with method POST. Internally, it defines 4 variables with name `pid`, `files`, `totalSize`, and `folder` with their values depending from the dataset fields. The variables are used to define the fields of the form.
 When the user clicks the button, the FE creates a form with the listed fields and submits it to the specified URL as a POST, then shows the reply in a new browser tab.
 
 ## Configuration Options Reference
@@ -127,9 +127,9 @@ When the user clicks the button, the FE creates a form with the listed fields an
 ## Available operators and system variables
 This section list all the default values and operators that are available when configuring the configurable actions.
 
-| Operator | Type | Description | 
+| Operator | Type | Description |
 |----------|------|-------------|
-| #Dataset0Pid | string | The pid of the first dataset passed to the action | 
+| #Dataset0Pid | string | The pid of the first dataset passed to the action |
 | #Dataset0FilesPath | [string] | The list of all the path for all the files in the first dataset passed to the action |
 | #Dataset0FilesTotalSize | integer | The total size of all the files of the first dataset passed to the action |
 | #Dataset0SourceFolder | string | The source folder indicated in the related field of the first dataset passed to the action |
@@ -137,7 +137,7 @@ This section list all the default values and operators that are available when c
 | #Dataset0SelectedFilesCount | integer | The number of selected files of the first dataset passed to the action |
 | #Dataset0SelectedFilesTotalSize | integer | The total size of all the selected files of the first dataset passed to the action |
 | #Dataset[i]Field[f] | any | The value of field `f` of the `i`-th dataset passed to the action |
-| #DatasetsPid | [string] | The list of pids of the all datasets passed to the action | 
+| #DatasetsPid | [string] | The list of pids of the all datasets passed to the action |
 | #DatasetsFilesPath | [string] | The list of all the paths for all the files of all the datasets passed to the action |
 | #DatasetsFilesTotalSize | integer | The total size of all the files of all the datasets passed to the action |
 | #DatasetsSourceFolder | [string] | The list of source folders indicated in the related field of all the datasets passed to the action |
@@ -150,7 +150,7 @@ This section list all the default values and operators that are available when c
 | #uuid | string | A v4 uuid generated on the fly |
 | #Username | string | The currently logged in user's username |
 | #UserEmail | string | email address of the user |
-| @variable | any | replace the string with the valu eof the variable defined in the action variable |
+| @variable | any | replace the string with the value of the variable defined in the action variable |
 
 ## How to Configure
 

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -7,7 +7,7 @@ import {
 } from "@angular/core";
 import { DatePipe } from "@angular/common";
 
-import { UsersService } from "@scicatproject/scicat-sdk-ts-angular";
+import { UsersService, UserProfile } from "@scicatproject/scicat-sdk-ts-angular";
 import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 import { AuthService } from "shared/services/auth/auth.service";
 import { v4 } from "uuid";
@@ -44,7 +44,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
 
   subscriptions: Subscription[] = [];
 
-  userProfile: any = {};
+  userProfile: UserProfile | null = null;
   isAdmin = false;
 
   constructor(
@@ -127,7 +127,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
 
   private processSelector(
     jsonObject: ActionItems,
-    userObject: any,
+    userObject: UserProfile,
     selector: string,
   ): string | string[] | number | number[] {
     if (!jsonObject.datasets?.length) {
@@ -285,7 +285,11 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
           return value;
         },
       );
-      return this.processSelector(this.actionItems, this.userProfile, resolved);
+      return this.processSelector(
+        this.actionItems,
+        this.userProfile ?? { email: "", username: "", accessGroups: [] },
+        resolved,
+      );
     };
 
     for (const key of Object.keys(this.actionConfig.variables ?? {})) {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -127,6 +127,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
 
   private processSelector(
     jsonObject: ActionItems,
+    userObject: any,
     selector: string,
   ): string | string[] | number | number[] {
     if (!jsonObject.datasets?.length) {
@@ -200,6 +201,8 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
           return jsonObject.instruments?.[Number(m[1])][m[2]];
         }
       },
+      "#Username": (m) => userObject.username,
+      "#UserEmail": (m) => userObject.email,
       "#date_format\\(([^,]+),\\s*([^)]+)\\)": (m) => {
         const dateInput = m[1].trim();
         const format = m[2].trim();
@@ -282,7 +285,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
           return value;
         },
       );
-      return this.processSelector(this.actionItems, resolved);
+      return this.processSelector(this.actionItems, this.userProfile, resolved);
     };
 
     for (const key of Object.keys(this.actionConfig.variables ?? {})) {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -7,7 +7,10 @@ import {
 } from "@angular/core";
 import { DatePipe } from "@angular/common";
 
-import { UsersService, UserProfile } from "@scicatproject/scicat-sdk-ts-angular";
+import {
+  UsersService,
+  UserProfile,
+} from "@scicatproject/scicat-sdk-ts-angular";
 import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 import { AuthService } from "shared/services/auth/auth.service";
 import { v4 } from "uuid";


### PR DESCRIPTION
## Description

We want to create Jobs via configurable-actions and the email field needs to be populated by the current user's email address.
This PR adds this functionality.

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Summary by Sourcery

Expose current user information as variables in configurable actions and document the new placeholders.

New Features:
- Allow configurable actions to resolve #Username and #UserEmail placeholders using the currently logged-in user's profile.

Documentation:
- Document the new #Username and #UserEmail placeholders in the configurable actions technical guide.