### PR TITLE
feat(configurable-actions): configurable actions in Publisheddata w/ Confirm Screen

### DIFF
--- a/CI/e2e/frontend.config.e2e.json
+++ b/CI/e2e/frontend.config.e2e.json
@@ -299,6 +299,91 @@
   "datasetDetailsActions": [],
   "selectionActionsEnabled": true,
   "selectionActions": [],
+  "publishedDataActionsEnabled": true,
+  "publishedDataActions": [
+    {
+      "id": "private",
+      "description": "This action makes a published data record private.",
+      "order": 1,
+      "label": "Private",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method": "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/private",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
+      "authorization": "#datasetOwner || #userIsAdmin",
+      "variables": {
+        "doi": "#PublishedData0Doi",
+        "status": "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "#tokenBearer"
+      },
+      "alertMessage": "Are you sure you want to make this published data record private?"
+    },
+    {
+      "id": "publish",
+      "description": "This publishes the record locally.",
+      "order": 1,
+      "label": "publish",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method": "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/publish",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'private')",
+      "authorization": "#datasetOwner || #userIsAdmin",
+      "variables": {
+        "doi": "#PublishedData0Doi",
+        "status": "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "#tokenBearer"
+      },
+      "alertMessage": "Are you sure you want to publish this record locally?"
+    },
+    {
+      "id": "register",
+      "description": "This action register the published data record with datacite.",
+      "order": 2,
+      "label": "Register",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method": "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/register",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'published')",
+      "authorization": "#datasetOwner && #userIsAdmin",
+      "variables": {
+        "doi": "#PublishedData0Doi",
+        "status": "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "alertMessage": "Are you sure you want to register this published data with DataCite? No further changes can be made after this action."
+    },
+    {
+      "id": "amend",
+      "description": "This action amend the published data record.",
+      "order": 3,
+      "label": "Amend",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method": "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/amend",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'registered')",
+      "authorization": "true",
+      "variables": {
+        "doi": "#PublishedData0Doi",
+        "status": "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "alertMessage": "Are you sure you want to amend this published data record?"
+    }
+  ],
   "labelMaps": {
     "filters": {
       "LocationFilter": "Location",

--- a/CI/e2e/frontend.config.e2e.json
+++ b/CI/e2e/frontend.config.e2e.json
@@ -310,7 +310,7 @@
       "mat_icon": "publish",
       "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/private",
-      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'public')",
       "authorization": "#datasetOwner || #userIsAdmin",
       "variables": {
         "doi": "#PublishedData0Doi",

--- a/cypress/e2e/published-data/published-data.cy.js
+++ b/cypress/e2e/published-data/published-data.cy.js
@@ -203,9 +203,14 @@ describe("Datasets general", () => {
 
       cy.get('[data-cy="status"]').contains("private");
 
-      cy.get('[data-cy="publishButton"]').click();
+      cy.contains("button", "publish").click();
 
-      cy.get("simple-snack-bar").should("contain", "Publishing Failed.");
+      cy.contains("mat-dialog-container button", "Confirm").click();
+
+      cy.get("simple-snack-bar", { timeout: 10000 }).should(
+        "contain",
+        "Publishing Failed.",
+      );
     });
 
     it("admins should be able to edit their private published data", () => {
@@ -360,9 +365,11 @@ describe("Datasets general", () => {
 
       cy.get('[data-cy="status"]').contains("private");
 
-      cy.get('[data-cy="publishButton"]').click();
+      cy.contains("button", "publish").click();
 
-      cy.get('[data-cy="status"]').contains("public");
+      cy.contains("mat-dialog-container button", "Confirm").click();
+
+      cy.get('[data-cy="status"]').contains("public", { timeout: 15000 });
     });
 
     it("should not be able to edit dataset list on a published data that is public", () => {
@@ -428,7 +435,9 @@ describe("Datasets general", () => {
 
       cy.get('[data-cy="status"]').contains("public");
 
-      cy.get('[data-cy="registerButton"]').click();
+      cy.contains("button", "Register").click();
+
+      cy.contains("mat-dialog-container button", "Confirm").click();
 
       cy.get('[data-cy="status"]').contains("registered");
     });
@@ -517,9 +526,11 @@ describe("Datasets general", () => {
 
       cy.get('[data-cy="status"]').contains("private");
 
-      cy.get('[data-cy="publishButton"]').click();
+      cy.contains("button", "publish").click();
 
-      cy.get('[data-cy="status"]').contains("public");
+      cy.contains("mat-dialog-container button", "Confirm").click();
+
+      cy.get('[data-cy="status"]').contains("public", { timeout: 15000 });
 
       cy.get("#editBtn").should("not.exist");
     });

--- a/src/app/admin/schema/frontend.config.jsonforms.json
+++ b/src/app/admin/schema/frontend.config.jsonforms.json
@@ -350,6 +350,9 @@
             },
             "filename": {
               "type": "string"
+            },
+            "alertMessage": {
+              "type": "string"
             }
           }
         }

--- a/src/app/admin/schema/frontend.config.jsonforms.json
+++ b/src/app/admin/schema/frontend.config.jsonforms.json
@@ -4,74 +4,165 @@
     "properties": {
       "defaultMainPage": {
         "type": "object",
-
         "properties": {
-          "nonAuthenticatedUser": { "type": "string" },
-          "authenticatedUser": { "type": "string" }
+          "nonAuthenticatedUser": {
+            "type": "string"
+          },
+          "authenticatedUser": {
+            "type": "string"
+          }
         }
       },
       "ingestorComponent": {
         "type": "object",
         "properties": {
-          "ingestorEnabled": { "type": "boolean" }
+          "ingestorEnabled": {
+            "type": "boolean"
+          }
         }
       },
-      "skipSciCatLoginPageEnabled": { "type": "boolean" },
-      "addScientificMetadataKeysAsColumn": { "type": "boolean" },
-      "allowConfigOverrides": { "type": "boolean" },
-      "dateFormat": { "type": "string" },
-      "timezone": { "type": "string" },
-      "accessTokenPrefix": { "type": "string" },
-      "addDatasetEnabled": { "type": "boolean" },
-      "archiveWorkflowEnabled": { "type": "boolean" },
-      "datasetReduceEnabled": { "type": "boolean" },
-      "datasetJsonScientificMetadata": { "type": "boolean" },
+      "skipSciCatLoginPageEnabled": {
+        "type": "boolean"
+      },
+      "addScientificMetadataKeysAsColumn": {
+        "type": "boolean"
+      },
+      "allowConfigOverrides": {
+        "type": "boolean"
+      },
+      "dateFormat": {
+        "type": "string"
+      },
+      "timezone": {
+        "type": "string"
+      },
+      "accessTokenPrefix": {
+        "type": "string"
+      },
+      "addDatasetEnabled": {
+        "type": "boolean"
+      },
+      "archiveWorkflowEnabled": {
+        "type": "boolean"
+      },
+      "datasetReduceEnabled": {
+        "type": "boolean"
+      },
+      "datasetJsonScientificMetadata": {
+        "type": "boolean"
+      },
       "datasetPageSizeOptions": {
         "type": "array",
-        "items": { "type": "number" }
+        "items": {
+          "type": "number"
+        }
       },
-      "editDatasetEnabled": { "type": "boolean" },
-      "editDatasetSampleEnabled": { "type": "boolean" },
-      "editMetadataEnabled": { "type": "boolean" },
-      "addSampleEnabled": { "type": "boolean" },
-      "externalAuthEndpoint": { "type": "string" },
-      "facility": { "type": "string" },
-      "siteIcon": { "type": "string" },
-      "siteTitle": { "type": "string" },
-      "siteSciCatLogo": { "type": "string" },
-      "loginFacilityLabel": { "type": "string" },
-      "loginLdapLabel": { "type": "string" },
-      "loginLocalLabel": { "type": "string" },
-      "loginFacilityEnabled": { "type": "boolean" },
-      "loginLdapEnabled": { "type": "boolean" },
-      "loginLocalEnabled": { "type": "boolean" },
-      "fileColorEnabled": { "type": "boolean" },
-      "fileDownloadEnabled": { "type": "boolean" },
+      "editDatasetEnabled": {
+        "type": "boolean"
+      },
+      "editDatasetSampleEnabled": {
+        "type": "boolean"
+      },
+      "editMetadataEnabled": {
+        "type": "boolean"
+      },
+      "addSampleEnabled": {
+        "type": "boolean"
+      },
+      "externalAuthEndpoint": {
+        "type": "string"
+      },
+      "facility": {
+        "type": "string"
+      },
+      "siteIcon": {
+        "type": "string"
+      },
+      "siteTitle": {
+        "type": "string"
+      },
+      "siteSciCatLogo": {
+        "type": "string"
+      },
+      "loginFacilityLabel": {
+        "type": "string"
+      },
+      "loginLdapLabel": {
+        "type": "string"
+      },
+      "loginLocalLabel": {
+        "type": "string"
+      },
+      "loginFacilityEnabled": {
+        "type": "boolean"
+      },
+      "loginLdapEnabled": {
+        "type": "boolean"
+      },
+      "loginLocalEnabled": {
+        "type": "boolean"
+      },
+      "fileColorEnabled": {
+        "type": "boolean"
+      },
+      "fileDownloadEnabled": {
+        "type": "boolean"
+      },
       "gettingStarted": {},
       "ingestManual": {},
-      "jobsEnabled": { "type": "boolean" },
-      "jsonMetadataEnabled": { "type": "boolean" },
-      "jupyterHubUrl": { "type": "string" },
-      "landingPage": { "type": "string" },
-      "lbBaseURL": { "type": "string" },
-      "logbookEnabled": { "type": "boolean" },
-      "loginFormEnabled": { "type": "boolean" },
-      "metadataPreviewEnabled": { "type": "boolean" },
-      "autoApplyFilters": { "type": "boolean" },
-      "metadataStructure": { "type": "string" },
-      "multipleDownloadAction": { "type": "string" },
-      "multipleDownloadEnabled": { "type": "boolean" },
+      "jobsEnabled": {
+        "type": "boolean"
+      },
+      "jsonMetadataEnabled": {
+        "type": "boolean"
+      },
+      "jupyterHubUrl": {
+        "type": "string"
+      },
+      "landingPage": {
+        "type": "string"
+      },
+      "lbBaseURL": {
+        "type": "string"
+      },
+      "logbookEnabled": {
+        "type": "boolean"
+      },
+      "loginFormEnabled": {
+        "type": "boolean"
+      },
+      "metadataPreviewEnabled": {
+        "type": "boolean"
+      },
+      "autoApplyFilters": {
+        "type": "boolean"
+      },
+      "metadataStructure": {
+        "type": "string"
+      },
+      "multipleDownloadAction": {
+        "type": "string"
+      },
+      "multipleDownloadEnabled": {
+        "type": "boolean"
+      },
       "oAuth2Endpoints": {
         "type": "array",
         "items": {
           "type": "object",
           "properties": {
-            "authURL": { "type": "string" },
-            "displayText": { "type": "string" }
+            "authURL": {
+              "type": "string"
+            },
+            "displayText": {
+              "type": "string"
+            }
           }
         }
       },
-      "policiesEnabled": { "type": "boolean" },
+      "policiesEnabled": {
+        "type": "boolean"
+      },
       "retrieveDestinations": {
         "type": "array",
         "items": {
@@ -84,55 +175,126 @@
               "type": "string"
             }
           },
-          "required": ["option", "tooltip"]
+          "required": [
+            "option",
+            "tooltip"
+          ]
         }
       },
-      "riotBaseUrl": { "type": "string" },
-      "scienceSearchEnabled": { "type": "boolean" },
-      "scienceSearchUnitsEnabled": { "type": "boolean" },
-      "searchPublicDataEnabled": { "type": "boolean" },
-      "searchSamples": { "type": "boolean" },
-      "sftpHost": { "type": "string" },
-      "sourceFolder": { "type": "string" },
-      "maxDirectDownloadSize": { "type": "number" },
-      "maxFileSizeWarning": { "type": "string" },
-      "shareEnabled": { "type": "boolean" },
-      "shoppingCartEnabled": { "type": "boolean" },
-      "shoppingCartOnHeader": { "type": "boolean" },
-      "tableSciDataEnabled": { "type": "boolean" },
-      "datasetDetailsShowMissingProposalId": { "type": "boolean" },
-      "notificationInterceptorEnabled": { "type": "boolean" },
-      "metadataEditingUnitListDisabled": { "type": "boolean" },
-      "hideEmptyMetadataTable": { "type": "boolean" },
-      "datafilesActionsEnabled": { "type": "boolean" },
-      "statusBannerMessage": { "type": "string" },
+      "riotBaseUrl": {
+        "type": "string"
+      },
+      "scienceSearchEnabled": {
+        "type": "boolean"
+      },
+      "scienceSearchUnitsEnabled": {
+        "type": "boolean"
+      },
+      "searchPublicDataEnabled": {
+        "type": "boolean"
+      },
+      "searchSamples": {
+        "type": "boolean"
+      },
+      "sftpHost": {
+        "type": "string"
+      },
+      "sourceFolder": {
+        "type": "string"
+      },
+      "maxDirectDownloadSize": {
+        "type": "number"
+      },
+      "maxFileSizeWarning": {
+        "type": "string"
+      },
+      "shareEnabled": {
+        "type": "boolean"
+      },
+      "shoppingCartEnabled": {
+        "type": "boolean"
+      },
+      "shoppingCartOnHeader": {
+        "type": "boolean"
+      },
+      "tableSciDataEnabled": {
+        "type": "boolean"
+      },
+      "datasetDetailsShowMissingProposalId": {
+        "type": "boolean"
+      },
+      "notificationInterceptorEnabled": {
+        "type": "boolean"
+      },
+      "metadataEditingUnitListDisabled": {
+        "type": "boolean"
+      },
+      "hideEmptyMetadataTable": {
+        "type": "boolean"
+      },
+      "statusBannerMessage": {
+        "type": "string"
+      },
       "statusBannerCode": {
         "type": "string",
-        "enum": ["INFO", "WARN"],
+        "enum": [
+          "INFO",
+          "WARN"
+        ],
         "default": "INFO"
+      },
+      "datafilesActionsEnabled": {
+        "type": "boolean"
       },
       "datafilesActions": {
         "type": "array",
         "items": {
           "type": "object",
           "properties": {
-            "label": { "type": "string" },
-            "id": { "type": "string" },
-            "description": { "type": "string" },
-            "order": { "type": "number" },
-            "files": { "type": "string" },
-            "mat_icon": { "type": "string" },
-            "url": { "type": "string" },
-            "target": { "type": "string" },
-            "enabled": { "type": "string" },
-            "authorization": { "type": "array", "items": { "type": "string" } },
+            "label": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "order": {
+              "type": "number"
+            },
+            "files": {
+              "type": "string"
+            },
+            "mat_icon": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "string"
+            },
+            "authorization": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "inputs": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "key": { "type": "string" },
-                  "value": { "type": "string" }
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
                 }
               }
             },
@@ -141,33 +303,168 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "key": { "type": "string" },
-                  "value": { "type": "string" }
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
                 }
               }
             },
             "headers": {
               "type": "object",
               "properties": {
-                "content-type": { "type": "string" },
-                "Authorization": { "type": "string" }
+                "content-type": {
+                  "type": "string"
+                },
+                "Authorization": {
+                  "type": "string"
+                }
               }
             },
             "method": {
               "type": "string",
-              "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"]
+              "enum": [
+                "GET",
+                "POST",
+                "PUT",
+                "DELETE",
+                "PATCH"
+              ]
             },
             "type": {
               "type": "string",
-              "enum": ["form", "xhr", "link", "json-download"]
+              "enum": [
+                "form",
+                "xhr",
+                "link",
+                "json-download"
+              ]
             },
-            "icon": { "type": "string" },
-            "payload": { "type": "string" },
-            "filename": { "type": "string" }
+            "icon": {
+              "type": "string"
+            },
+            "payload": {
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            }
           }
         }
       },
-
+      "publishedDataActionsEnabled": {
+        "type": "boolean"
+      },
+      "publishedDataActions": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "order": {
+              "type": "number"
+            },
+            "files": {
+              "type": "string"
+            },
+            "mat_icon": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "string"
+            },
+            "authorization": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "inputs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "variables": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "headers": {
+              "type": "object",
+              "properties": {
+                "content-type": {
+                  "type": "string"
+                },
+                "Authorization": {
+                  "type": "string"
+                }
+              }
+            },
+            "method": {
+              "type": "string",
+              "enum": [
+                "GET",
+                "POST",
+                "PUT",
+                "DELETE",
+                "PATCH"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "form",
+                "xhr",
+                "link",
+                "json-download"
+              ]
+            },
+            "icon": {
+              "type": "string"
+            },
+            "payload": {
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "defaultDatasetsListSettings": {
         "type": "object",
         "properties": {
@@ -177,18 +474,33 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
-                "order": { "type": "number" },
-                "width": { "type": "number" },
+                "name": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                },
+                "width": {
+                  "type": "number"
+                },
                 "type": {
                   "type": "string",
-                  "enum": ["standard", "hoverContent", "editable", "date"]
+                  "enum": [
+                    "standard",
+                    "hoverContent",
+                    "editable",
+                    "date"
+                  ]
                 },
                 "format": {
                   "type": "string"
                 },
-                "enabled": { "type": "boolean" },
-                "sort": { "type": "string" }
+                "enabled": {
+                  "type": "boolean"
+                },
+                "sort": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -197,14 +509,27 @@
             "items": {
               "type": "object",
               "properties": {
-                "key": { "type": "string" },
-                "label": { "type": "string" },
+                "key": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
                 "type": {
                   "type": "string",
-                  "enum": ["text", "multiSelect", "dateRange", "checkbox"]
+                  "enum": [
+                    "text",
+                    "multiSelect",
+                    "dateRange",
+                    "checkbox"
+                  ]
                 },
-                "description": { "type": "string" },
-                "enabled": { "type": "boolean" }
+                "description": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
               }
             }
           },
@@ -241,10 +566,16 @@
                     },
                     "unitsOptions": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
-                  "required": ["lhs", "relation", "rhs"]
+                  "required": [
+                    "lhs",
+                    "relation",
+                    "rhs"
+                  ]
                 }
               }
             }
@@ -259,15 +590,30 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
-                "enabled": { "type": "boolean" },
-                "width": { "type": "number" },
+                "name": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "width": {
+                  "type": "number"
+                },
                 "type": {
                   "type": "string",
-                  "enum": ["standard", "hoverContent", "editable", "date"]
+                  "enum": [
+                    "standard",
+                    "hoverContent",
+                    "editable",
+                    "date"
+                  ]
                 },
-                "format": { "type": "string" },
-                "sort": { "type": "string" }
+                "format": {
+                  "type": "string"
+                },
+                "sort": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -276,14 +622,27 @@
             "items": {
               "type": "object",
               "properties": {
-                "key": { "type": "string" },
-                "label": { "type": "string" },
+                "key": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
                 "type": {
                   "type": "string",
-                  "enum": ["text", "multiSelect", "dateRange", "checkbox"]
+                  "enum": [
+                    "text",
+                    "multiSelect",
+                    "dateRange",
+                    "checkbox"
+                  ]
                 },
-                "description": { "type": "string" },
-                "enabled": { "type": "boolean" }
+                "description": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
               }
             }
           }
@@ -297,10 +656,17 @@
             "items": {
               "type": "object",
               "properties": {
-                "key": { "type": "string" },
-                "value": { "type": "string" }
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               },
-              "required": ["key", "value"]
+              "required": [
+                "key",
+                "value"
+              ]
             }
           },
           "proposal": {
@@ -308,10 +674,17 @@
             "items": {
               "type": "object",
               "properties": {
-                "key": { "type": "string" },
-                "value": { "type": "string" }
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
               },
-              "required": ["key", "value"]
+              "required": [
+                "key",
+                "value"
+              ]
             }
           }
         }
@@ -319,13 +692,17 @@
       "datasetDetailComponent": {
         "type": "object",
         "properties": {
-          "enableCustomizedComponent": { "type": "boolean" },
+          "enableCustomizedComponent": {
+            "type": "boolean"
+          },
           "customization": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "label": { "type": "string" },
+                "label": {
+                  "type": "string"
+                },
                 "type": {
                   "type": "string",
                   "enum": [
@@ -335,27 +712,48 @@
                     "regular"
                   ]
                 },
-                "order": { "type": "number" },
-                "row": { "type": "number" },
-                "col": { "type": "number" },
+                "order": {
+                  "type": "number"
+                },
+                "row": {
+                  "type": "number"
+                },
+                "col": {
+                  "type": "number"
+                },
                 "viewMode": {
                   "type": "string",
-                  "enum": ["table", "json", "tree"]
+                  "enum": [
+                    "table",
+                    "json",
+                    "tree"
+                  ]
                 },
-
                 "options": {
                   "type": "object",
                   "properties": {
-                    "limit": { "type": "number" },
+                    "limit": {
+                      "type": "number"
+                    },
                     "size": {
                       "type": "string",
-                      "enum": ["small", "medium", "large"]
+                      "enum": [
+                        "small",
+                        "medium",
+                        "large"
+                      ]
                     }
                   }
                 },
                 "fields": {
                   "type": "array",
-                  "default": [{ "element": "text", "source": "", "order": 0 }],
+                  "default": [
+                    {
+                      "element": "text",
+                      "source": "",
+                      "order": 0
+                    }
+                  ],
                   "items": {
                     "type": "object",
                     "properties": {
@@ -370,10 +768,18 @@
                           "internalLink"
                         ]
                       },
-                      "source": { "type": "string" },
-                      "order": { "type": "number" }
+                      "source": {
+                        "type": "string"
+                      },
+                      "order": {
+                        "type": "number"
+                      }
                     },
-                    "required": ["element", "source", "order"]
+                    "required": [
+                      "element",
+                      "source",
+                      "order"
+                    ]
                   }
                 }
               }
@@ -387,27 +793,59 @@
           "nonAuthenticatedUser": {
             "type": "object",
             "properties": {
-              "datasets": { "type": "boolean" },
-              "files": { "type": "boolean" },
-              "instruments": { "type": "boolean" },
-              "jobs": { "type": "boolean" },
-              "policies": { "type": "boolean" },
-              "proposals": { "type": "boolean" },
-              "publishedData": { "type": "boolean" },
-              "samples": { "type": "boolean" }
+              "datasets": {
+                "type": "boolean"
+              },
+              "files": {
+                "type": "boolean"
+              },
+              "instruments": {
+                "type": "boolean"
+              },
+              "jobs": {
+                "type": "boolean"
+              },
+              "policies": {
+                "type": "boolean"
+              },
+              "proposals": {
+                "type": "boolean"
+              },
+              "publishedData": {
+                "type": "boolean"
+              },
+              "samples": {
+                "type": "boolean"
+              }
             }
           },
           "authenticatedUser": {
             "type": "object",
             "properties": {
-              "datasets": { "type": "boolean" },
-              "files": { "type": "boolean" },
-              "instruments": { "type": "boolean" },
-              "jobs": { "type": "boolean" },
-              "policies": { "type": "boolean" },
-              "proposals": { "type": "boolean" },
-              "publishedData": { "type": "boolean" },
-              "samples": { "type": "boolean" }
+              "datasets": {
+                "type": "boolean"
+              },
+              "files": {
+                "type": "boolean"
+              },
+              "instruments": {
+                "type": "boolean"
+              },
+              "jobs": {
+                "type": "boolean"
+              },
+              "policies": {
+                "type": "boolean"
+              },
+              "proposals": {
+                "type": "boolean"
+              },
+              "publishedData": {
+                "type": "boolean"
+              },
+              "samples": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -417,7 +855,12 @@
         "properties": {
           "proposal": {
             "type": "string",
-            "enum": ["details", "datasets", "relatedProposals", "logbook"],
+            "enum": [
+              "details",
+              "datasets",
+              "relatedProposals",
+              "logbook"
+            ],
             "default": "details"
           }
         }
@@ -434,53 +877,142 @@
           "expandable": true
         },
         "elements": [
-          { "type": "Control", "scope": "#/properties/dateFormat" },
-          { "type": "Control", "scope": "#/properties/timezone" },
-          { "type": "Control", "scope": "#/properties/accessTokenPrefix" },
-          { "type": "Control", "scope": "#/properties/landingPage" },
-          { "type": "Control", "scope": "#/properties/metadataStructure" },
-          { "type": "Control", "scope": "#/properties/riotBaseUrl" },
-          { "type": "Control", "scope": "#/properties/jupyterHubUrl" },
-          { "type": "Control", "scope": "#/properties/lbBaseURL" },
+          {
+            "type": "Control",
+            "scope": "#/properties/dateFormat"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/timezone"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/accessTokenPrefix"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/landingPage"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/metadataStructure"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/riotBaseUrl"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/jupyterHubUrl"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/lbBaseURL"
+          },
           {
             "type": "Control",
             "scope": "#/properties/externalAuthEndpoint"
           },
-          { "type": "Control", "scope": "#/properties/facility" },
-          { "type": "Control", "scope": "#/properties/siteIcon" },
-          { "type": "Control", "scope": "#/properties/siteTitle" },
-          { "type": "Control", "scope": "#/properties/siteSciCatLogo" },
-          { "type": "Control", "scope": "#/properties/statusBannerMessage" },
-          { "type": "Control", "scope": "#/properties/statusBannerCode" },
-          { "type": "Control", "scope": "#/properties/addDatasetEnabled" },
-          { "type": "Control", "scope": "#/properties/tableSciDataEnabled" },
+          {
+            "type": "Control",
+            "scope": "#/properties/facility"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/siteIcon"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/siteTitle"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/siteSciCatLogo"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/statusBannerMessage"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/statusBannerCode"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/addDatasetEnabled"
+          },
           {
             "type": "Control",
             "scope": "#/properties/skipSciCatLoginPageEnabled"
           },
-          { "type": "Control", "scope": "#/properties/allowConfigOverrides" },
-          { "type": "Control", "scope": "#/properties/archiveWorkflowEnabled" },
-          { "type": "Control", "scope": "#/properties/datasetReduceEnabled" },
+          {
+            "type": "Control",
+            "scope": "#/properties/allowConfigOverrides"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/archiveWorkflowEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/datasetReduceEnabled"
+          },
           {
             "type": "Control",
             "scope": "#/properties/datasetJsonScientificMetadata"
           },
-          { "type": "Control", "scope": "#/properties/datasetPageSizeOptions" },
-          { "type": "Control", "scope": "#/properties/editDatasetEnabled" },
+          {
+            "type": "Control",
+            "scope": "#/properties/datasetPageSizeOptions"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/editDatasetEnabled"
+          },
           {
             "type": "Control",
             "scope": "#/properties/editDatasetSampleEnabled"
           },
-          { "type": "Control", "scope": "#/properties/editMetadataEnabled" },
-          { "type": "Control", "scope": "#/properties/addSampleEnabled" },
-          { "type": "Control", "scope": "#/properties/fileColorEnabled" },
-          { "type": "Control", "scope": "#/properties/fileDownloadEnabled" },
-          { "type": "Control", "scope": "#/properties/jobsEnabled" },
-          { "type": "Control", "scope": "#/properties/jsonMetadataEnabled" },
-          { "type": "Control", "scope": "#/properties/logbookEnabled" },
-          { "type": "Control", "scope": "#/properties/loginFormEnabled" },
-          { "type": "Control", "scope": "#/properties/metadataPreviewEnabled" },
-          { "type": "Control", "scope": "#/properties/autoApplyFilters" }
+          {
+            "type": "Control",
+            "scope": "#/properties/editMetadataEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/addSampleEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/fileColorEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/fileDownloadEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/jobsEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/jsonMetadataEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/logbookEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/loginFormEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/metadataPreviewEnabled"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/autoApplyFilters"
+          }
         ]
       },
       {
@@ -513,7 +1045,6 @@
           }
         ]
       },
-
       {
         "type": "Group",
         "options": {
@@ -524,9 +1055,18 @@
           {
             "type": "HorizontalLayout",
             "elements": [
-              { "type": "Control", "scope": "#/properties/loginFacilityLabel" },
-              { "type": "Control", "scope": "#/properties/loginLdapLabel" },
-              { "type": "Control", "scope": "#/properties/loginLocalLabel" }
+              {
+                "type": "Control",
+                "scope": "#/properties/loginFacilityLabel"
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/loginLdapLabel"
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/loginLocalLabel"
+              }
             ]
           },
           {
@@ -536,8 +1076,14 @@
                 "type": "Control",
                 "scope": "#/properties/loginFacilityEnabled"
               },
-              { "type": "Control", "scope": "#/properties/loginLdapEnabled" },
-              { "type": "Control", "scope": "#/properties/loginLocalEnabled" }
+              {
+                "type": "Control",
+                "scope": "#/properties/loginLdapEnabled"
+              },
+              {
+                "type": "Control",
+                "scope": "#/properties/loginLocalEnabled"
+              }
             ]
           }
         ]
@@ -549,11 +1095,16 @@
         },
         "label": "Download Settings",
         "elements": [
-          { "type": "Control", "scope": "#/properties/multipleDownloadAction" },
-          { "type": "Control", "scope": "#/properties/multipleDownloadEnabled" }
+          {
+            "type": "Control",
+            "scope": "#/properties/multipleDownloadAction"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/multipleDownloadEnabled"
+          }
         ]
       },
-
       {
         "type": "Group",
         "options": {
@@ -590,8 +1141,14 @@
           "expandable": true
         },
         "elements": [
-          { "type": "Control", "scope": "#/properties/sftpHost" },
-          { "type": "Control", "scope": "#/properties/sourceFolder" }
+          {
+            "type": "Control",
+            "scope": "#/properties/sftpHost"
+          },
+          {
+            "type": "Control",
+            "scope": "#/properties/sourceFolder"
+          }
         ]
       },
       {
@@ -605,7 +1162,10 @@
             "type": "Control",
             "scope": "#/properties/maxDirectDownloadSize"
           },
-          { "type": "Control", "scope": "#/properties/maxFileSizeWarning" }
+          {
+            "type": "Control",
+            "scope": "#/properties/maxFileSizeWarning"
+          }
         ]
       },
       {
@@ -622,30 +1182,65 @@
               "detail": {
                 "type": "VerticalLayout",
                 "elements": [
-                  { "type": "Control", "scope": "#/properties/label" },
-                  { "type": "Control", "scope": "#/properties/id" },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/label"
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/id"
+                  },
                   {
                     "type": "Control",
                     "scope": "#/properties/description"
                   },
-                  { "type": "Control", "scope": "#/properties/order" },
-                  { "type": "Control", "scope": "#/properties/files" },
-                  { "type": "Control", "scope": "#/properties/mat_icon" },
-                  { "type": "Control", "scope": "#/properties/url" },
-                  { "type": "Control", "scope": "#/properties/target" },
-                  { "type": "Control", "scope": "#/properties/enabled" },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/order"
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/files"
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/mat_icon"
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/url"
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/target"
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/enabled"
+                  },
                   {
                     "type": "Control",
                     "scope": "#/properties/method"
                   },
-                  { "type": "Control", "scope": "#/properties/type" },
-                  { "type": "Control", "scope": "#/properties/icon" },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/type"
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/icon"
+                  },
                   {
                     "type": "Control",
                     "scope": "#/properties/payload",
-                    "options": { "multi": true }
+                    "options": {
+                      "multi": true
+                    }
                   },
-                  { "type": "Control", "scope": "#/properties/filename" },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/filename"
+                  },
                   {
                     "type": "Control",
                     "scope": "#/properties/authorization"
@@ -657,8 +1252,14 @@
                       "detail": {
                         "type": "HorizontalLayout",
                         "elements": [
-                          { "type": "Control", "scope": "#/properties/key" },
-                          { "type": "Control", "scope": "#/properties/value" }
+                          {
+                            "type": "Control",
+                            "scope": "#/properties/key"
+                          },
+                          {
+                            "type": "Control",
+                            "scope": "#/properties/value"
+                          }
                         ]
                       }
                     }
@@ -670,8 +1271,14 @@
                       "detail": {
                         "type": "HorizontalLayout",
                         "elements": [
-                          { "type": "Control", "scope": "#/properties/key" },
-                          { "type": "Control", "scope": "#/properties/value" }
+                          {
+                            "type": "Control",
+                            "scope": "#/properties/key"
+                          },
+                          {
+                            "type": "Control",
+                            "scope": "#/properties/value"
+                          }
                         ]
                       }
                     }
@@ -706,7 +1313,9 @@
           {
             "type": "Group",
             "label": "Dataset",
-            "options": { "expandable": true },
+            "options": {
+              "expandable": true
+            },
             "elements": [
               {
                 "type": "Control",
@@ -717,7 +1326,9 @@
           {
             "type": "Group",
             "label": "Proposal",
-            "options": { "expandable": true },
+            "options": {
+              "expandable": true
+            },
             "elements": [
               {
                 "type": "Control",
@@ -749,11 +1360,26 @@
                   {
                     "type": "HorizontalLayout",
                     "elements": [
-                      { "type": "Control", "scope": "#/properties/label" },
-                      { "type": "Control", "scope": "#/properties/type" },
-                      { "type": "Control", "scope": "#/properties/order" },
-                      { "type": "Control", "scope": "#/properties/row" },
-                      { "type": "Control", "scope": "#/properties/col" },
+                      {
+                        "type": "Control",
+                        "scope": "#/properties/label"
+                      },
+                      {
+                        "type": "Control",
+                        "scope": "#/properties/type"
+                      },
+                      {
+                        "type": "Control",
+                        "scope": "#/properties/order"
+                      },
+                      {
+                        "type": "Control",
+                        "scope": "#/properties/row"
+                      },
+                      {
+                        "type": "Control",
+                        "scope": "#/properties/col"
+                      },
                       {
                         "type": "Control",
                         "scope": "#/properties/viewMode",
@@ -846,36 +1472,49 @@
           {
             "type": "Group",
             "label": "Default Datasets List Settings",
-            "options": { "expandable": true },
+            "options": {
+              "expandable": true
+            },
             "elements": [
               {
                 "type": "Group",
                 "label": "Columns list",
-                "options": { "expandable": true, "showSortButtons": true },
+                "options": {
+                  "expandable": true,
+                  "showSortButtons": true
+                },
                 "elements": [
                   {
                     "type": "Control",
                     "scope": "#/properties/defaultDatasetsListSettings/properties/columns",
-                    "options": { "showSortButtons": true }
+                    "options": {
+                      "showSortButtons": true
+                    }
                   }
                 ]
               },
               {
                 "type": "Group",
                 "label": "Filters list",
-                "options": { "expandable": true },
+                "options": {
+                  "expandable": true
+                },
                 "elements": [
                   {
                     "type": "Control",
                     "scope": "#/properties/defaultDatasetsListSettings/properties/filters",
-                    "options": { "showSortButtons": true }
+                    "options": {
+                      "showSortButtons": true
+                    }
                   }
                 ]
               },
               {
                 "type": "Group",
                 "label": "Conditions list",
-                "options": { "expandable": true },
+                "options": {
+                  "expandable": true
+                },
                 "elements": [
                   {
                     "type": "ListWithDetail",
@@ -891,29 +1530,39 @@
           {
             "type": "Group",
             "label": "Default Proposals List Settings",
-            "options": { "expandable": true },
+            "options": {
+              "expandable": true
+            },
             "elements": [
               {
                 "type": "Group",
-                "options": { "expandable": true },
+                "options": {
+                  "expandable": true
+                },
                 "label": "Columns list",
                 "elements": [
                   {
                     "type": "Control",
                     "scope": "#/properties/defaultProposalsListSettings/properties/columns",
-                    "options": { "showSortButtons": true }
+                    "options": {
+                      "showSortButtons": true
+                    }
                   }
                 ]
               },
               {
                 "type": "Group",
-                "options": { "expandable": true },
+                "options": {
+                  "expandable": true
+                },
                 "label": "Filters list",
                 "elements": [
                   {
                     "type": "Control",
                     "scope": "#/properties/defaultProposalsListSettings/properties/filters",
-                    "options": { "showSortButtons": true }
+                    "options": {
+                      "showSortButtons": true
+                    }
                   }
                 ]
               }

--- a/src/app/app-config.service.spec.ts
+++ b/src/app/app-config.service.spec.ts
@@ -5,7 +5,6 @@ import {
   AppConfigService,
   HelpMessages,
 } from "app-config.service";
-import { time } from "node:console";
 import { Observable, of } from "rxjs";
 import { MockHttp } from "shared/MockStubs";
 
@@ -94,6 +93,8 @@ const appConfig: AppConfigInterface = {
   datafilesActions: [],
   datasetSelectionActionsEnabled: false,
   datasetSelectionActions: [],
+  publishedDataActionsEnabled: false,
+  publishedDataActions: [],
   defaultDatasetsListSettings: {
     columns: [
       {

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -10,6 +10,7 @@ import {
   ListSettings,
   TableColumn,
 } from "state-management/models";
+import { ActionConfig } from "shared/modules/configurable-actions/configurable-action.interfaces";
 
 export interface OAuth2Endpoint {
   authURL: string;
@@ -88,14 +89,14 @@ export interface AppConfigInterface {
   datasetReduceEnabled: boolean;
   datasetDetailsShowMissingProposalId: boolean;
   datasetActionsEnabled: boolean;
-  datasetActions: any[];
+  datasetActions: ActionConfig[];
   datafilesActionsEnabled: boolean;
-  datafilesActions: any[];
+  datafilesActions: ActionConfig[];
   datasetDetailsActionsEnabled: boolean;
-  datasetDetailsActions: any[];
+  datasetDetailsActions: ActionConfig[];
   datasetSelectionActionsEnabled: boolean;
-  datasetSelectionActions: any[];
-  publishedDataActions: any[];
+  datasetSelectionActions: ActionConfig[];
+  publishedDataActions: ActionConfig[];
   publishedDataActionsEnabled: boolean;
   editDatasetEnabled: boolean;
   editDatasetSampleEnabled: boolean;

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -95,6 +95,8 @@ export interface AppConfigInterface {
   datasetDetailsActions: any[];
   datasetSelectionActionsEnabled: boolean;
   datasetSelectionActions: any[];
+  publishedDataActions: any[];
+  publishedDataActionsEnabled: boolean;
   editDatasetEnabled: boolean;
   editDatasetSampleEnabled: boolean;
   editMetadataEnabled: boolean;

--- a/src/app/datasets/datafiles/datafiles.component.html
+++ b/src/app/datasets/datafiles/datafiles.component.html
@@ -35,6 +35,7 @@
     <configurable-actions
       [actionsConfig]="appConfig.datafilesActions"
       [actionItems]="actionItems"
+      (actionPerformed)="onActionPerformed()"
     ></configurable-actions>
   </div>
 

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -73,6 +73,7 @@ export class DatafilesComponent implements OnDestroy, OnInit, AfterViewChecked {
   datasetPid = "";
   actionItems: ActionItems = {
     datasets: [],
+    publisheddata: []
   };
 
   count = 0;

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -41,6 +41,10 @@ import {
   ActionItems,
 } from "shared/modules/configurable-actions/configurable-action.interfaces";
 import { AuthService } from "shared/services/auth/auth.service";
+import {
+  fetchDatasetAction,
+  fetchDatablocksAction,
+} from "state-management/actions/datasets.actions";
 
 @Component({
   selector: "datafiles",
@@ -249,10 +253,18 @@ export class DatafilesComponent implements OnDestroy, OnInit, AfterViewChecked {
     return warning;
   }
   //ngAfterViewInit() {
+  onActionPerformed() {
+    if (this.datasetPid) {
+      this.store.dispatch(fetchDatasetAction({ pid: this.datasetPid }));
+      this.store.dispatch(fetchDatablocksAction({ pid: this.datasetPid }));
+    }
+  }
+
   ngOnInit() {
     this.subscriptions.push(
       this.dataset$.subscribe((dataset) => {
         if (dataset) {
+          this.datasetPid = dataset.pid;
           this.actionItems.datasets = <ActionItemDataset[]>[dataset];
         }
       }),

--- a/src/app/datasets/datafiles/datafiles.component.ts
+++ b/src/app/datasets/datafiles/datafiles.component.ts
@@ -77,7 +77,7 @@ export class DatafilesComponent implements OnDestroy, OnInit, AfterViewChecked {
   datasetPid = "";
   actionItems: ActionItems = {
     datasets: [],
-    publisheddata: []
+    publisheddata: [],
   };
 
   count = 0;

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
@@ -16,6 +16,7 @@
     <configurable-actions
       [actionsConfig]="appConfig.datasetActions"
       [actionItems]="actionItems"
+      (actionPerformed)="onActionPerformed()"
     ></configurable-actions>
   </div>
   <div style="clear: both"></div>

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
@@ -34,6 +34,7 @@ import {
   ActionItemDataset,
   ActionItems,
 } from "shared/modules/configurable-actions/configurable-action.interfaces";
+import { fetchDatasetAction } from "state-management/actions/datasets.actions";
 
 /**
  * Component to show customizable details for a dataset, using the
@@ -289,6 +290,12 @@ export class DatasetDetailDynamicComponent implements OnInit, OnDestroy {
       );
     }
     return true;
+  }
+
+  onActionPerformed() {
+    if (this.dataset?.pid) {
+      this.store.dispatch(fetchDatasetAction({ pid: this.dataset.pid }));
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
@@ -71,6 +71,7 @@ export class DatasetDetailDynamicComponent implements OnInit, OnDestroy {
   actionItems: ActionItems = {
     datasets: [],
     instruments: undefined,
+    publisheddata: []
   };
 
   constructor(

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
@@ -72,7 +72,7 @@ export class DatasetDetailDynamicComponent implements OnInit, OnDestroy {
   actionItems: ActionItems = {
     datasets: [],
     instruments: undefined,
-    publisheddata: []
+    publisheddata: [],
   };
 
   constructor(

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
@@ -1,5 +1,13 @@
+
+<configurable-actions
+  *ngIf="appConfig.publishedDataActionsEnabled"
+  [actionsConfig]="appConfig.publishedDataActions"
+  [actionItems]="actionItems">
+</configurable-actions>
+
 <div fxLayout="row" fxLayout.xs="column" *ngIf="publishedData">
   <div fxFlex="80">
+
     <mat-card>
       <mat-card-header class="status-header">
         <div mat-card-avatar class="section-icon">
@@ -25,35 +33,6 @@
           </ng-template>
         </table>
       </mat-card-content>
-
-      <mat-card-actions *ngIf="isLoggedIn$ | async">
-        <button
-          mat-raised-button
-          color="primary"
-          *ngIf="publishedData.status === 'registered'"
-          (click)="onAmendClick(publishedData.doi)"
-        >
-          Amend
-        </button>
-        <button
-          mat-raised-button
-          color="primary"
-          *ngIf="publishedData.status === 'public'"
-          (click)="onRegisterClick(publishedData.doi)"
-          data-cy="registerButton"
-        >
-          Register
-        </button>
-        <button
-          mat-raised-button
-          color="primary"
-          *ngIf="publishedData.status === 'private'"
-          (click)="onPublishClick(publishedData.doi)"
-          data-cy="publishButton"
-        >
-          Publish
-        </button>
-      </mat-card-actions>
     </mat-card>
 
     <mat-card>

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
@@ -1,10 +1,3 @@
-
-<configurable-actions
-  *ngIf="appConfig.publishedDataActionsEnabled"
-  [actionsConfig]="appConfig.publishedDataActions"
-  [actionItems]="actionItems">
-</configurable-actions>
-
 <div fxLayout="row" fxLayout.xs="column" *ngIf="publishedData">
   <div fxFlex="80">
 
@@ -33,6 +26,13 @@
           </ng-template>
         </table>
       </mat-card-content>
+      <mat-card-actions>
+        <configurable-actions
+          *ngIf="appConfig.publishedDataActionsEnabled"
+          [actionsConfig]="appConfig.publishedDataActions"
+          [actionItems]="actionItems">
+        </configurable-actions>
+      </mat-card-actions>
     </mat-card>
 
     <mat-card>

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
@@ -30,7 +30,8 @@
         <configurable-actions
           *ngIf="appConfig.publishedDataActionsEnabled"
           [actionsConfig]="appConfig.publishedDataActions"
-          [actionItems]="actionItems">
+          [actionItems]="actionItems"
+          (actionPerformed)="onActionPerformed()">
         </configurable-actions>
       </mat-card-actions>
     </mat-card>

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.scss
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.scss
@@ -30,3 +30,9 @@ mat-card {
     margin: 0 1em;
   }
 }
+
+configurable-actions {
+  display: flex;
+  flex-direction: row-reverse;
+  max-width: 80%;
+}

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
@@ -2,9 +2,17 @@ import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { PublisheddataDetailsComponent } from "./publisheddata-details.component";
 import {
   MockActivatedRoute,
+  MockAuthService,
   MockPublishedDataApi,
   MockRouter,
+  MockUserApi,
 } from "shared/MockStubs";
+import { UsersService } from "@scicatproject/scicat-sdk-ts-angular";
+import { AuthService } from "shared/services/auth/auth.service";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
 import { provideMockStore, MockStore } from "@ngrx/store/testing";
 import { NgxJsonViewerModule } from "ngx-json-viewer";
 import { Router, ActivatedRoute } from "@angular/router";
@@ -28,6 +36,15 @@ const getConfig = () => ({
   editMetadataEnabled: true,
   editPublishedData: true,
   jsonMetadataEnabled: true,
+  publishedDataActionsEnabled: true,
+  publishedDataActions: [
+    {
+      id: "test-action",
+      label: "Test Action",
+      type: "link",
+      url: "https://example.com",
+    },
+  ],
 });
 
 const createPublishedData = (status: string) =>
@@ -55,10 +72,13 @@ describe("PublisheddataDetailsComponent", () => {
         SharedScicatFrontendModule,
       ],
       providers: [
+        provideHttpClient(withInterceptorsFromDi()),
         provideMockStore(),
         { provide: Router, useClass: MockRouter },
         { provide: ActivatedRoute, useClass: MockActivatedRoute },
         { provide: PublishedDataService, useClass: MockPublishedDataApi },
+        { provide: UsersService, useClass: MockUserApi },
+        { provide: AuthService, useClass: MockAuthService },
         { provide: AppConfigService, useValue: { getConfig } },
       ],
     }).compileComponents();
@@ -82,21 +102,10 @@ describe("PublisheddataDetailsComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  describe("login state", () => {
-    it("should hide status actions when the user is not logged in", () => {
+  describe("configurable actions", () => {
+    it("should render configurable-actions element when publishedDataActions are configured", () => {
       const compiled = fixture.debugElement.nativeElement;
-      expect(compiled.querySelector('[data-cy="registerButton"]')).toBeNull();
-    });
-
-    it("should show status actions when the user is logged in", () => {
-      store.overrideSelector(selectIsLoggedIn, true);
-      store.refreshState();
-      fixture.detectChanges();
-
-      const compiled = fixture.debugElement.nativeElement;
-      expect(
-        compiled.querySelector('[data-cy="registerButton"]'),
-      ).not.toBeNull();
+      expect(compiled.querySelector("configurable-actions")).not.toBeNull();
     });
   });
 

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
@@ -23,7 +23,6 @@ import {
   selectIsAdmin,
   selectIsLoggedIn,
 } from "state-management/selectors/user.selectors";
-import { ConfigurableActionsComponent } from "shared/modules/configurable-actions/configurable-actions.component";
 
 const getConfig = () => ({
   editMetadataEnabled: true,
@@ -60,7 +59,6 @@ describe("PublisheddataDetailsComponent", () => {
         { provide: Router, useClass: MockRouter },
         { provide: ActivatedRoute, useClass: MockActivatedRoute },
         { provide: PublishedDataService, useClass: MockPublishedDataApi },
-        { provide: ConfigurableActionsComponent },
         { provide: AppConfigService, useValue: { getConfig } },
       ],
     }).compileComponents();

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.spec.ts
@@ -23,6 +23,7 @@ import {
   selectIsAdmin,
   selectIsLoggedIn,
 } from "state-management/selectors/user.selectors";
+import { ConfigurableActionsComponent } from "shared/modules/configurable-actions/configurable-actions.component";
 
 const getConfig = () => ({
   editMetadataEnabled: true,
@@ -59,6 +60,7 @@ describe("PublisheddataDetailsComponent", () => {
         { provide: Router, useClass: MockRouter },
         { provide: ActivatedRoute, useClass: MockActivatedRoute },
         { provide: PublishedDataService, useClass: MockPublishedDataApi },
+        { provide: ConfigurableActionsComponent },
         { provide: AppConfigService, useValue: { getConfig } },
       ],
     }).compileComponents();

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
@@ -18,6 +18,9 @@ import {
   selectIsAdmin,
   selectIsLoggedIn,
 } from "state-management/selectors/user.selectors";
+import {
+  ActionItems,
+} from "shared/modules/configurable-actions/configurable-action.interfaces";
 
 @Component({
   selector: "publisheddata-details",
@@ -36,6 +39,10 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
   landingPageUrl = "";
   doi = "";
 
+  actionItems: ActionItems = {
+    datasets: [],
+    publisheddata: []
+  };
   constructor(
     private appConfigService: AppConfigService,
     private route: ActivatedRoute,
@@ -55,6 +62,7 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
       this.currentData$.subscribe((data) => {
         if (data) {
           this.publishedData = data;
+          this.actionItems.publisheddata[0] = data;
 
           if (this.appConfig.landingPage) {
             this.landingPageUrl =

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
@@ -18,9 +18,7 @@ import {
   selectIsAdmin,
   selectIsLoggedIn,
 } from "state-management/selectors/user.selectors";
-import {
-  ActionItems,
-} from "shared/modules/configurable-actions/configurable-action.interfaces";
+import { ActionItems } from "shared/modules/configurable-actions/configurable-action.interfaces";
 
 @Component({
   selector: "publisheddata-details",
@@ -41,7 +39,7 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
 
   actionItems: ActionItems = {
     datasets: [],
-    publisheddata: []
+    publisheddata: [],
   };
   constructor(
     private appConfigService: AppConfigService,

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
@@ -77,6 +77,10 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
     this.subscriptions.forEach((subscription) => subscription.unsubscribe());
   }
 
+  onActionPerformed() {
+    this.store.dispatch(fetchPublishedDataAction({ id: this.doi }));
+  }
+
   onRegisterClick(doi: string) {
     if (
       confirm(

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.html
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.html
@@ -12,3 +12,16 @@
     {{ actionConfig.label }}
   </button>
 </ng-template>
+
+<div class="popup-backdrop" *ngIf="showPopup" (click)="closePopup()"></div>
+<div class="popup" *ngIf="showPopup" [class.show]="showPopup">
+  <div class="popup-content">
+    <p>{{ actionConfig.alertMessage }}</p>
+    <div class="popup-actions">
+      <button mat-raised-button color="primary" (click)="confirmAction()">
+        Confirm
+      </button>
+      <button mat-raised-button (click)="closePopup()">Cancel</button>
+    </div>
+  </div>
+</div>

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.html
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.html
@@ -12,16 +12,3 @@
     {{ actionConfig.label }}
   </button>
 </ng-template>
-
-<div class="popup-backdrop" *ngIf="showPopup" (click)="closePopup()"></div>
-<div class="popup" *ngIf="showPopup" [class.show]="showPopup">
-  <div class="popup-content">
-    <p>{{ actionConfig.alertMessage }}</p>
-    <div class="popup-actions">
-      <button mat-raised-button color="primary" (click)="confirmAction()">
-        Confirm
-      </button>
-      <button mat-raised-button (click)="closePopup()">Cancel</button>
-    </div>
-  </div>
-</div>

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.scss
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.scss
@@ -1,10 +1,35 @@
 button {
   margin-left: 4px;
   margin-right: 0;
+  cursor: pointer;
 
   img {
     height: 18px;
     width: auto;
     vertical-align: middle;
   }
+
+  &.action-button:target {
+    background-color: var(--theme-accent-darker);
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: 0.7;
+  }
+}
+
+.popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 20px;
+  border-radius: 5px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  display: none;
+}
+
+.popup.show {
+  display: block;
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.scss
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.scss
@@ -17,19 +17,46 @@ button {
   }
 }
 
+.popup-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 999;
+}
+
 .popup {
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   background-color: white;
-  padding: 20px;
-  border-radius: 5px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
   z-index: 1000;
+  min-width: 320px;
+  max-width: 480px;
   display: none;
 }
 
 .popup.show {
   display: block;
+}
+
+.popup-content {
+  p {
+    margin: 0 0 20px 0;
+    font-size: 15px;
+    line-height: 1.5;
+    color: rgba(0, 0, 0, 0.87);
+  }
+}
+
+.popup-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.scss
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.scss
@@ -9,54 +9,9 @@ button {
     vertical-align: middle;
   }
 
-  &.action-button:target {
-    background-color: var(--theme-accent-darker);
+  &.action-button:disabled {
     cursor: not-allowed;
     pointer-events: none;
     opacity: 0.7;
   }
-}
-
-.popup-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.4);
-  z-index: 999;
-}
-
-.popup {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: white;
-  padding: 24px;
-  border-radius: 8px;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
-  z-index: 1000;
-  min-width: 320px;
-  max-width: 480px;
-  display: none;
-}
-
-.popup.show {
-  display: block;
-}
-
-.popup-content {
-  p {
-    margin: 0 0 20px 0;
-    font-size: 15px;
-    line-height: 1.5;
-    color: rgba(0, 0, 0, 0.87);
-  }
-}
-
-.popup-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -1,8 +1,10 @@
 import {
   Component,
+  EventEmitter,
   Input,
   OnChanges,
   OnInit,
+  Output,
   SimpleChanges,
 } from "@angular/core";
 import { DatePipe } from "@angular/common";
@@ -30,6 +32,7 @@ import { Subscription } from "rxjs";
 export class ConfigurableActionComponent implements OnInit, OnChanges {
   @Input({ required: true }) actionConfig: ActionConfig;
   @Input({ required: true }) actionItems: ActionItems;
+  @Output() actionPerformed = new EventEmitter<void>();
   //@Input() files?: DataFiles_File[];
   userProfile$ = this.store.select(selectProfile);
   isAdmin$ = this.store.select(selectIsAdmin);
@@ -570,7 +573,6 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
         if (response.ok) {
           return response.blob();
         } else {
-          // http error
           return Promise.reject(
             new Error(`HTTP Error code: ${response.status}`),
           );
@@ -583,6 +585,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
         a.download = filename;
         a.click();
         URL.revokeObjectURL(url);
+        this.actionPerformed.emit();
       })
       .catch((error) => {
         this.snackBar.open(
@@ -621,16 +624,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
             new Error(`HTTP Error code: ${response.status}`),
           );
         }
-
-        // specific only for datasets
-        // cannot be used
-        // this.store.dispatch(
-        //   updatePropertyAction({
-        //     method: this.actionConfig.method,
-        //     pid: element.pid,
-        //     property: JSON.parse(this.actionConfig.payload),
-        //   }),
-        // );
+        this.actionPerformed.emit();
         return response;
       })
       .catch((error) => {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -571,7 +571,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
 
   type_xhr() {
     const url = this.actionConfig.url.replace(
-      /{{\s*(\w+)\s*}}/g,
+      /{{\s*([@#]?\w+)\s*}}/g,
       (_, variableName) =>
         encodeURIComponent(this.get_value_from_definition(variableName)),
     );
@@ -603,7 +603,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
         //     property: JSON.parse(this.actionConfig.payload),
         //   }),
         // );
-
+        alert("Transfer requested!");        
         return response;
       })
       .catch((error) => {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -42,6 +42,9 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
 
   form: HTMLFormElement = null;
 
+  showPopup = false;
+  pendingAction: (() => void) | null = null;
+
   subscriptions: Subscription[] = [];
 
   userProfile: any = {};
@@ -379,7 +382,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
     return input;
   }
 
-  perform_action() {
+  execute_action() {
     const action_type = this.actionConfig.type || "form";
     switch (action_type) {
       case "json-download":
@@ -391,6 +394,28 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
       case "form":
       default:
         return this.type_form();
+    }
+  }
+
+  perform_action() {
+    if (this.actionConfig.alertMessage) {
+      this.pendingAction = () => this.execute_action();
+      this.showPopup = true;
+      return;
+    }
+    this.execute_action();
+  }
+
+  closePopup() {
+    this.showPopup = false;
+    this.pendingAction = null;
+  }
+
+  confirmAction() {
+    this.showPopup = false;
+    if (this.pendingAction) {
+      this.pendingAction();
+      this.pendingAction = null;
     }
   }
 
@@ -606,7 +631,6 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
         //     property: JSON.parse(this.actionConfig.payload),
         //   }),
         // );
-        alert("Transfer requested!");        
         return response;
       })
       .catch((error) => {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -14,6 +14,8 @@ import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 import { AuthService } from "shared/services/auth/auth.service";
 import { v4 } from "uuid";
 import { MatSnackBar } from "@angular/material/snack-bar";
+import { MatDialog } from "@angular/material/dialog";
+import { ConfirmationDialogComponent } from "./confirmation-dialog/confirmation-dialog.component";
 import { Store } from "@ngrx/store";
 import { Router } from "@angular/router";
 import { AppConfigService } from "app-config.service";
@@ -45,9 +47,6 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
 
   form: HTMLFormElement = null;
 
-  showPopup = false;
-  pendingAction: (() => void) | null = null;
-
   subscriptions: Subscription[] = [];
 
   userProfile: any = {};
@@ -61,6 +60,7 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
     private store: Store,
     private router: Router,
     private datePipe: DatePipe,
+    private dialog: MatDialog,
   ) {
     this.usersService.usersControllerGetUserJWTV3().subscribe((jwt) => {
       this.jwt = jwt.jwt;
@@ -137,22 +137,22 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
   ): string | string[] | number | number[] {
     // Map of static patterns to processing functions
     const keywordMap: { [pattern: string]: (RegExpMatchArray) => any } = {
-      "#Dataset0Pid": (m) => jsonObject.datasets[0]?.pid,
+      "#Dataset0Pid": (m) => jsonObject.datasets?.[0]?.pid,
       "#Dataset0FilesPath": (m) =>
-        jsonObject.datasets[0]?.files?.map((i) => i.path),
+        jsonObject.datasets?.[0]?.files?.map((i) => i.path),
       "#Dataset0FilesTotalSize": (m) =>
-        jsonObject.datasets[0]?.files
+        jsonObject.datasets?.[0]?.files
           ?.map((i) => Number(i.size))
           .reduce((acc, val) => acc + val, 0),
-      "#Dataset0SourceFolder": (m) => jsonObject.datasets[0]?.sourceFolder,
+      "#Dataset0SourceFolder": (m) => jsonObject.datasets?.[0]?.sourceFolder,
       "#Dataset0SelectedFilesPath": (m) =>
-        jsonObject.datasets[0]?.files
+        jsonObject.datasets?.[0]?.files
           ?.filter((i) => i.selected)
           .map((i) => i.path),
       "#Dataset0SelectedFilesCount": (m) =>
-        jsonObject.datasets[0]?.files?.filter((i) => i.selected).length,
+        jsonObject.datasets?.[0]?.files?.filter((i) => i.selected).length,
       "#Dataset0SelectedFilesTotalSize": (m) =>
-        jsonObject.datasets[0]?.files
+        jsonObject.datasets?.[0]?.files
           ?.filter((i) => i.selected)
           .map((i) => Number(i.size))
           .reduce((acc, val) => acc + val, 0),
@@ -402,24 +402,19 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
 
   perform_action() {
     if (this.actionConfig.alertMessage) {
-      this.pendingAction = () => this.execute_action();
-      this.showPopup = true;
+      const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+        data: { message: this.actionConfig.alertMessage },
+        ariaLabel: "Confirmation dialog",
+      });
+
+      dialogRef.afterClosed().subscribe((confirmed) => {
+        if (confirmed) {
+          this.execute_action();
+        }
+      });
       return;
     }
     this.execute_action();
-  }
-
-  closePopup() {
-    this.showPopup = false;
-    this.pendingAction = null;
-  }
-
-  confirmAction() {
-    this.showPopup = false;
-    if (this.pendingAction) {
-      this.pendingAction();
-      this.pendingAction = null;
-    }
   }
 
   get_value_from_definition(definition: string) {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -129,10 +129,6 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
     jsonObject: ActionItems,
     selector: string,
   ): string | string[] | number | number[] {
-    if (!jsonObject.datasets?.length) {
-      console.warn("No datasets available");
-      return undefined;
-    }
     // Map of static patterns to processing functions
     const keywordMap: { [pattern: string]: (RegExpMatchArray) => any } = {
       "#Dataset0Pid": (m) => jsonObject.datasets[0]?.pid,
@@ -195,6 +191,13 @@ export class ConfigurableActionComponent implements OnInit, OnChanges {
       // eslint-disable-next-line no-useless-escape
       "#DatasetsField\\[(\\w+)\\]": (m) =>
         jsonObject.datasets?.map((i) => i[m[1]]),
+      "#PublishedData0Doi": (m) => jsonObject.publisheddata[0]?.doi,
+      "#PublishedData0Status": (m) => jsonObject.publisheddata[0]?.status,
+      "#PublishedData\\[(\\d+)\\]Field\\[(\\w+)\\]": (m) => {
+        if (jsonObject.publisheddata?.[Number(m[1])]) {
+          return jsonObject.publisheddata?.[Number(m[1])][m[2]];
+        }
+      },
       "#Instruments\\[(\\d+)\\]Field\\[(\\w+)\\]": (m) => {
         if (jsonObject.instruments?.[Number(m[1])]) {
           return jsonObject.instruments?.[Number(m[1])][m[2]];

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -38,7 +38,14 @@ export interface ActionItemDataset {
   files?: DataFiles_File[];
 }
 
+export interface ActionItemPublishedData {
+  doi: string;
+  status: string;
+}
+
 export interface ActionItems {
   datasets: ActionItemDataset[];
   instruments?: Instrument[];
+  publisheddata: ActionItemPublishedData[];
+
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -48,5 +48,4 @@ export interface ActionItems {
   datasets: ActionItemDataset[];
   instruments?: Instrument[];
   publisheddata: ActionItemPublishedData[];
-
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -22,6 +22,7 @@ export interface ActionConfig {
   variables?: Record<string, string>;
   inputs?: Record<string, string>;
   headers?: Record<string, string>;
+  alertMessage?: string;
 }
 
 // export interface ActionItem {

--- a/src/app/shared/modules/configurable-actions/configurable-actions.component.html
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.component.html
@@ -4,6 +4,7 @@
       *ngFor="let actionConfig of sortedActionsConfig"
       [actionConfig]="actionConfig"
       [actionItems]="actionItems"
+      (actionPerformed)="actionPerformed.emit()"
     >
     </configurable-action>
   </div>

--- a/src/app/shared/modules/configurable-actions/configurable-actions.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.component.spec.ts
@@ -80,13 +80,15 @@ describe("1010: ConfigurableActionsComponent", () => {
     }
   });
 
-  it("0020: actions should be not visible when disabled in configuration", () => {
-    mockAppConfigService.appConfig.datafilesActionsEnabled = false;
+  it("0020: actions should be not visible when no actions are configured", () => {
+    component.actionsConfig = [];
+    fixture.detectChanges();
     expect(component.visible).toEqual(false);
   });
 
-  it("0030: actions should be visible when enabled in configuration", () => {
-    mockAppConfigService.appConfig.datafilesActionsEnabled = true;
+  it("0030: actions should be visible when actions are configured", () => {
+    component.actionsConfig = mockActionsConfig;
+    fixture.detectChanges();
     expect(component.visible).toEqual(true);
   });
 

--- a/src/app/shared/modules/configurable-actions/configurable-actions.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { ActionConfig, ActionItems } from "./configurable-action.interfaces";
 
 import { AppConfigService } from "app-config.service";
@@ -12,6 +12,7 @@ import { AppConfigService } from "app-config.service";
 export class ConfigurableActionsComponent {
   @Input({ required: true }) actionsConfig: ActionConfig[] = [];
   @Input({ required: true }) actionItems: ActionItems;
+  @Output() actionPerformed = new EventEmitter<void>();
 
   constructor(public appConfigService: AppConfigService) {}
 

--- a/src/app/shared/modules/configurable-actions/configurable-actions.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.component.ts
@@ -16,7 +16,7 @@ export class ConfigurableActionsComponent {
   constructor(public appConfigService: AppConfigService) {}
 
   get visible(): boolean {
-    return this.appConfigService.getConfig().datafilesActionsEnabled;
+    return this.actionsConfig?.length > 0;
   }
 
   get maxFileSize(): number {

--- a/src/app/shared/modules/configurable-actions/configurable-actions.module.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.module.ts
@@ -5,10 +5,16 @@ import { MatButtonModule } from "@angular/material/button";
 import { ConfigurableActionsComponent } from "./configurable-actions.component";
 import { ConfigurableActionComponent } from "./configurable-action.component";
 import { MatIconModule } from "@angular/material/icon";
+import { MatDialogModule } from "@angular/material/dialog";
+import { ConfirmationDialogComponent } from "./confirmation-dialog/confirmation-dialog.component";
 
 @NgModule({
-  imports: [CommonModule, MatIconModule, MatButtonModule],
-  declarations: [ConfigurableActionsComponent, ConfigurableActionComponent],
+  imports: [CommonModule, MatIconModule, MatButtonModule, MatDialogModule],
+  declarations: [
+    ConfigurableActionsComponent,
+    ConfigurableActionComponent,
+    ConfirmationDialogComponent,
+  ],
   exports: [ConfigurableActionsComponent, ConfigurableActionComponent],
 })
 export class ConfigurableActionsModule {}

--- a/src/app/shared/modules/configurable-actions/configurable-actions.test.data.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.test.data.ts
@@ -266,6 +266,7 @@ export const mockActionItems: ActionItems = {
       ],
     },
   ],
+  publisheddata: [],
 };
 
 /*
@@ -289,15 +290,19 @@ function filesSelection(
 
 export const mockActionItemsDatafilesNofiles = {
   datasets: filesSelection(mockActionItems.datasets.slice(0, 1), []),
+  publisheddata: [],
 };
 export const mockActionItemsDatafilesFile1 = {
   datasets: filesSelection(mockActionItems.datasets.slice(0, 1), [1]),
+  publisheddata: [],
 };
 export const mockActionItemsDatafilesFile2 = {
   datasets: filesSelection(mockActionItems.datasets.slice(0, 1), [2]),
+  publisheddata: [],
 };
 export const mockActionItemsDatafilesAllfiles = {
   datasets: filesSelection(mockActionItems.datasets.slice(0, 1), [1, 2, 3]),
+  publisheddata: [],
 };
 
 export const lowerMaxFileSizeLimit = 5000;

--- a/src/app/shared/modules/configurable-actions/confirmation-dialog/confirmation-dialog.component.html
+++ b/src/app/shared/modules/configurable-actions/confirmation-dialog/confirmation-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>Confirm Action</h2>
+<mat-dialog-content>
+  <p>{{ data.message }}</p>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-raised-button (click)="dialogRef.close(false)">Cancel</button>
+  <button mat-raised-button color="primary" (click)="dialogRef.close(true)">Confirm</button>
+</mat-dialog-actions>

--- a/src/app/shared/modules/configurable-actions/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/app/shared/modules/configurable-actions/confirmation-dialog/confirmation-dialog.component.ts
@@ -1,0 +1,18 @@
+import { Component, Inject } from "@angular/core";
+import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
+
+export interface ConfirmationDialogData {
+  message: string;
+}
+
+@Component({
+  selector: "confirmation-dialog",
+  templateUrl: "./confirmation-dialog.component.html",
+  standalone: false,
+})
+export class ConfirmationDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmationDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmationDialogData,
+  ) {}
+}

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -309,7 +309,7 @@
       "mat_icon": "publish",
       "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/private",
-      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'public')",
       "authorization": "#datasetOwner || #userIsAdmin",
       "variables": {
         "doi": "#PublishedData0Doi",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -307,13 +307,13 @@
       "label": "Private",
       "type": "xhr",
       "mat_icon": "publish",
-      "method" : "POST",
+      "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/private",
       "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
       "authorization": "#datasetOwner || #userIsAdmin",
-      "variables" : {
+      "variables": {
         "doi": "#PublishedData0Doi",
-        "status" : "#PublishedData[0]Field[status]"
+        "status": "#PublishedData[0]Field[status]"
       },
       "headers": {
         "Content-Type": "application/json",
@@ -327,13 +327,13 @@
       "label": "publish",
       "type": "xhr",
       "mat_icon": "publish",
-      "method" : "POST",
+      "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/publish",
       "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"private\")",
       "authorization": "#datasetOwner || #userIsAdmin",
-      "variables" : {
+      "variables": {
         "doi": "#PublishedData0Doi",
-        "status" : "#PublishedData[0]Field[status]"
+        "status": "#PublishedData[0]Field[status]"
       },
       "headers": {
         "Content-Type": "application/json",
@@ -347,13 +347,13 @@
       "label": "Register",
       "type": "xhr",
       "mat_icon": "publish",
-      "method" : "POST",
+      "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/register",
       "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
       "authorization": "#datasetOwner && #userIsAdmin",
-      "variables" : {
+      "variables": {
         "doi": "#PublishedData0Doi",
-        "status" : "#PublishedData[0]Field[status]"
+        "status": "#PublishedData[0]Field[status]"
       },
       "headers": {
         "Content-Type": "application/json"
@@ -366,13 +366,13 @@
       "label": "Amend",
       "type": "xhr",
       "mat_icon": "publish",
-      "method" : "POST",
+      "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/amend",
       "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"registered\")",
       "authorization": "true",
-      "variables" : {
+      "variables": {
         "doi": "#PublishedData0Doi",
-        "status" : "#PublishedData[0]Field[status]"
+        "status": "#PublishedData[0]Field[status]"
       },
       "headers": {
         "Content-Type": "application/json"

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -330,7 +330,7 @@
       "mat_icon": "publish",
       "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/publish",
-      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"private\")",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'private')",
       "authorization": "#datasetOwner || #userIsAdmin",
       "variables": {
         "doi": "#PublishedData0Doi",
@@ -351,7 +351,7 @@
       "mat_icon": "publish",
       "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/register",
-      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'published')",
       "authorization": "#datasetOwner && #userIsAdmin",
       "variables": {
         "doi": "#PublishedData0Doi",
@@ -371,7 +371,7 @@
       "mat_icon": "publish",
       "method": "POST",
       "url": "/api/v4/publisheddata/{{ @doi }}/amend",
-      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"registered\")",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == 'registered')",
       "authorization": "true",
       "variables": {
         "doi": "#PublishedData0Doi",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -318,7 +318,8 @@
       "headers": {
         "Content-Type": "application/json",
         "Authorization": "#tokenBearer"
-      }
+      },
+      "alertMessage": "Are you sure you want to make this published data record private?"
     },
     {
       "id": "publish",
@@ -338,7 +339,8 @@
       "headers": {
         "Content-Type": "application/json",
         "Authorization": "#tokenBearer"
-      }
+      },
+      "alertMessage": "Are you sure you want to publish this record locally?"
     },
     {
       "id": "register",
@@ -357,7 +359,8 @@
       },
       "headers": {
         "Content-Type": "application/json"
-      }
+      },
+      "alertMessage": "Are you sure you want to register this published data with DataCite? No further changes can be made after this action."
     },
     {
       "id": "amend",
@@ -376,7 +379,8 @@
       },
       "headers": {
         "Content-Type": "application/json"
-      }
+      },
+      "alertMessage": "Are you sure you want to amend this published data record?"
     }
   ],
   "selectionActionsEnabled": true,

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -298,6 +298,87 @@
   ],
   "datasetDetailsActionsEnabled": false,
   "datasetDetailsActions": [],
+  "publishedDataActionsEnabled": true,
+  "publishedDataActions": [
+    {
+      "id": "private",
+      "description": "This action makes a published data record private.",
+      "order": 1,
+      "label": "Private",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method" : "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/private",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
+      "authorization": "#datasetOwner || #userIsAdmin",
+      "variables" : {
+        "doi": "#PublishedData0Doi",
+        "status" : "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "#tokenBearer"
+      }
+    },
+    {
+      "id": "publish",
+      "description": "This publishes the record locally.",
+      "order": 1,
+      "label": "publish",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method" : "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/publish",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"private\")",
+      "authorization": "#datasetOwner || #userIsAdmin",
+      "variables" : {
+        "doi": "#PublishedData0Doi",
+        "status" : "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "#tokenBearer"
+      }
+    },
+    {
+      "id": "register",
+      "description": "This action register the published data record with datacite.",
+      "order": 2,
+      "label": "Register",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method" : "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/register",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"published\")",
+      "authorization": "#datasetOwner && #userIsAdmin",
+      "variables" : {
+        "doi": "#PublishedData0Doi",
+        "status" : "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    },
+    {
+      "id": "amend",
+      "description": "This action amend the published data record.",
+      "order": 3,
+      "label": "Amend",
+      "type": "xhr",
+      "mat_icon": "publish",
+      "method" : "POST",
+      "url": "/api/v4/publisheddata/{{ @doi }}/amend",
+      "enabled": "(#datasetOwner || #userIsAdmin) && (@status == \"registered\")",
+      "authorization": "true",
+      "variables" : {
+        "doi": "#PublishedData0Doi",
+        "status" : "#PublishedData[0]Field[status]"
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  ],
   "selectionActionsEnabled": true,
   "selectionActions": [],
   "labelMaps": {


### PR DESCRIPTION
## Description
PublishedData can be fully customized using configurable actions.


## Motivation
Hardcoded buttons do not fulfull all needs, so we added configurable actions in the published data section, too.
Mainly, in order to customize our publish workflow but it can now be changed.
Also, users now must confirm the action and the status of the button is immediately reflected after a click.
This has also been adressed by @minottic but has not been merged in upstream yet.

## Screenshots 
Configurable buttons, recreating the original setup:


<img width="1188" height="347" alt="Screenshot 2026-06-15 at 19 23 12" src="https://github.com/user-attachments/assets/e677f270-d9bd-4bf7-8e7f-aae09bd7f7d3" />

Confirm screen, which is also part of configurable actions config:

<img width="1176" height="581" alt="Screenshot 2026-06-15 at 19 23 20" src="https://github.com/user-attachments/assets/0c7e0354-4e0a-4d27-a340-9a99e7c26408" />


## Fixes:
Please provide a list of the fixes implemented in this PR


* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
