### PR TITLE
fix: reset search text in add condition dialog and persist search text in globalTextSearch on refresh and navigating between pages

### DIFF
--- a/src/app/datasets/dataset-table/dataset-table.component.ts
+++ b/src/app/datasets/dataset-table/dataset-table.component.ts
@@ -31,6 +31,7 @@ import {
   selectTotalSets,
   selectDatasetsInBatch,
   selectDatasetsFacetCountsIsLoading,
+  selectTextFilter,
 } from "state-management/selectors/datasets.selectors";
 import { AppConfigService } from "app-config.service";
 import {
@@ -65,6 +66,7 @@ import { TableConfigService } from "shared/services/table-config.service";
 import { selectInstruments } from "state-management/selectors/instruments.selectors";
 import { DatasetsListService } from "shared/services/datasets-list.service";
 import { DatasetInlineEditCellComponent } from "./dataset-inline-edit-cell.component";
+import { Router } from "@angular/router";
 
 export interface SortChangeEvent {
   active: string;
@@ -159,6 +161,7 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private tableConfigService: TableConfigService,
     private datasetsListService: DatasetsListService,
+    private router: Router,
   ) {}
 
   private decorateColumns(columns: TableField<any>[] = []): TableField<any>[] {
@@ -395,10 +398,12 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
         ),
     );
     this.subscriptions.push(
-      this.route.queryParams.subscribe((queryParams) => {
-        const searchQuery = JSON.parse(queryParams.searchQuery || "{}");
-        this.globalTextSearch = searchQuery.text || "";
-      }),
+      this.route.queryParams
+        .pipe(combineLatestWith(this.store.select(selectTextFilter)))
+        .subscribe(([queryParams, storeSearchTerm]) => {
+          const searchQuery = JSON.parse(queryParams.searchQuery || "{}");
+          this.globalTextSearch = searchQuery.text || storeSearchTerm || "";
+        }),
     );
   }
 
@@ -406,6 +411,19 @@ export class DatasetTableComponent implements OnInit, OnDestroy {
     this.globalTextSearch = term;
     this.store.dispatch(setSearchTermsAction({ terms: term }));
     this.store.dispatch(setTextFilterAction({ text: term }));
+
+    const { queryParams } = this.route.snapshot;
+    const searchQuery = JSON.parse(queryParams.searchQuery || "{}");
+
+    this.router.navigate([], {
+      queryParams: {
+        searchQuery: JSON.stringify({
+          ...searchQuery,
+          text: term,
+        }),
+      },
+      queryParamsHandling: "merge",
+    });
   }
 
   onTextSearchAction() {

--- a/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
+++ b/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
@@ -120,7 +120,10 @@ export class SearchParametersDialogComponent {
     this.dialogRef.close({ data: { lhs: metadataKey, relation, rhs, unit } });
   };
 
-  cancel = (): void => this.dialogRef.close();
+  cancel = (): void => {
+    this.store.dispatch(fetchMetadataKeysAction({ searchTerm: "" }));
+    this.dialogRef.close();
+  };
 
   searchMetadataKeys = (): void => {
     const searchTerm = this.parametersForm.get("lhs")?.value || "";

--- a/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
+++ b/src/app/shared/modules/search-parameters-dialog/search-parameters-dialog.component.ts
@@ -99,6 +99,7 @@ export class SearchParametersDialogComponent {
       .subscribe((keys) => {
         this.parameterKeys = keys;
       });
+    this.store.dispatch(fetchMetadataKeysAction({ searchTerm: "" }));
   }
 
   add = (): void => {
@@ -125,7 +126,6 @@ export class SearchParametersDialogComponent {
   };
 
   cancel = (): void => {
-    this.store.dispatch(fetchMetadataKeysAction({ searchTerm: "" }));
     this.dialogRef.close();
   };
 


### PR DESCRIPTION
## Description
This PR fixes two search issues. 

First the search parameters dialog(add condition dialog) now clears the search text when cancelled so the metadata keys list displays properly on reopen. 

Second the dataset table now saves search text to the URL queryParams when applied which matches the behavior in e.g. proposals, files etc, and restores the value visually when navigating back to the datasets page.

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Persist dataset table global text search in URL query parameters and reset metadata key search when cancelling the add-condition dialog.

Bug Fixes:
- Restore global text search value in the datasets table when navigating back via URL query parameters or store state.
- Ensure the metadata keys list in the search parameters dialog is reset by clearing the search term on dialog cancel.

Enhancements:
- Synchronize dataset table text search between URL query parameters and store for consistent behavior across navigations.