### PR TITLE
fix: url resolving for link configurable action

### DIFF
--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -444,7 +444,10 @@ export class ConfigurableActionComponent
   }
 
   private typeLink() {
-    window.open(this.actionConfig.url, this.actionConfig.target || "_self");
+    window.open(
+      this.interpolate(this.actionConfig.url),
+      this.actionConfig.target || "_self",
+    );
   }
 
   private typeDialog() {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -455,7 +455,10 @@ export class ConfigurableActionComponent
   }
 
   private typeLink() {
-    window.open(this.actionConfig.url, this.actionConfig.target || "_self");
+    window.open(
+      this.interpolate(this.actionConfig.url),
+      this.actionConfig.target || "_self",
+    );
   }
 
   private typeDialog() {


### PR DESCRIPTION
## Description
fixes URL resolving for `link` type actions, omitted in a previous commit.


## Changes:
- `link` type configurable actions.


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Bug Fixes:
- Resolve interpolated URLs when opening configurable actions of type `link`.