### PR TITLE
test: add e2e test for relationships tab feature

### DIFF
--- a/CI/e2e/frontend.config.e2e.json
+++ b/CI/e2e/frontend.config.e2e.json
@@ -9,6 +9,7 @@
   "allowConfigOverrides": true,
   "archiveWorkflowEnabled": false,
   "datasetReduceEnabled": true,
+  "datasetRelationshipsEnabled": true,
   "datasetJsonScientificMetadata": true,
   "editDatasetEnabled": true,
   "editDatasetSampleEnabled": true,

--- a/cypress/e2e/datasets/datasets-relationships.cy.js
+++ b/cypress/e2e/datasets/datasets-relationships.cy.js
@@ -48,10 +48,13 @@ describe("Datasets relationships tab", () => {
       const mergedConfig = mergeConfig(baseConfig, {
         datasetRelationshipsEnabled: false,
       });
-      cy.intercept("GET", "**/admin/config", mergedConfig);
+      cy.intercept("GET", "**/admin/config", mergedConfig).as(
+        "getFrontendConfig",
+      );
     });
 
     cy.visit("/datasets");
+    cy.wait("@getFrontendConfig");
     cy.get(".dataset-table mat-row").contains("Cypress Dataset").click();
     cy.get("[data-cy=dataset-dashboard-tabs]").should(
       "not.contain",

--- a/cypress/e2e/datasets/datasets-relationships.cy.js
+++ b/cypress/e2e/datasets/datasets-relationships.cy.js
@@ -18,8 +18,6 @@ describe("Datasets relationships tab", () => {
     ],
   };
 
-  // /admin/config must be stubbed in every test (even if the default response from backend is needed)
-  // Otherwise tests that need a stubbed response might fail, if /admin/config is found in browser cache 
   const stubFrontendConfig = (overrides = {}) =>
     cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
       cy.intercept(
@@ -30,6 +28,10 @@ describe("Datasets relationships tab", () => {
     });
 
   beforeEach(() => {
+    // /admin/config must be stubbed in every test (even if the default response from backend is needed)
+    // Otherwise tests that need a stubbed response might fail, if /admin/config is found in browser cache
+    stubFrontendConfig();
+
     cy.login(Cypress.env("username"), Cypress.env("password"));
     cy.createDataset(relationships);
   });
@@ -39,8 +41,6 @@ describe("Datasets relationships tab", () => {
   });
 
   it("displays relationships table with correct values", () => {
-    stubFrontendConfig();
-
     cy.visit("/datasets");
     cy.wait("@getFrontendConfig");
     cy.get(".dataset-table mat-row").contains("Cypress Dataset").click();
@@ -49,11 +49,13 @@ describe("Datasets relationships tab", () => {
       .click();
     relationships.relationships.forEach((r, i) => {
       const vals = [
-        r.identifierType == "URL" && r.externalId ? r.externalId : r.identifier,
+        r.identifierType === "URL" && r.externalId
+          ? r.externalId
+          : r.identifier,
         r.entityType,
         r.identifierType,
       ];
-      Object.values(vals).forEach((v) => cy.get("mat-row").eq(i).contains(v));
+      vals.forEach((v) => cy.get("mat-row").eq(i).contains(v));
     });
   });
 

--- a/cypress/e2e/datasets/datasets-relationships.cy.js
+++ b/cypress/e2e/datasets/datasets-relationships.cy.js
@@ -18,6 +18,17 @@ describe("Datasets relationships tab", () => {
     ],
   };
 
+  // /admin/config must be stubbed in every test (even if the default response from backend is needed)
+  // Otherwise tests that need a stubbed response might fail, if /admin/config is found in browser cache 
+  const stubFrontendConfig = (overrides = {}) =>
+    cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
+      cy.intercept(
+        "GET",
+        "**/admin/config",
+        mergeConfig(baseConfig, overrides),
+      ).as("getFrontendConfig");
+    });
+
   beforeEach(() => {
     cy.login(Cypress.env("username"), Cypress.env("password"));
     cy.createDataset(relationships);
@@ -28,7 +39,10 @@ describe("Datasets relationships tab", () => {
   });
 
   it("displays relationships table with correct values", () => {
+    stubFrontendConfig();
+
     cy.visit("/datasets");
+    cy.wait("@getFrontendConfig");
     cy.get(".dataset-table mat-row").contains("Cypress Dataset").click();
     cy.get("[data-cy=dataset-dashboard-tabs]")
       .contains("Relationships")
@@ -44,14 +58,7 @@ describe("Datasets relationships tab", () => {
   });
 
   it("does not display relationships tab when disabled by config", () => {
-    cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
-      const mergedConfig = mergeConfig(baseConfig, {
-        datasetRelationshipsEnabled: false,
-      });
-      cy.intercept("GET", "**/admin/config", mergedConfig).as(
-        "getFrontendConfig",
-      );
-    });
+    stubFrontendConfig({ datasetRelationshipsEnabled: false });
 
     cy.visit("/datasets");
     cy.wait("@getFrontendConfig");

--- a/cypress/e2e/datasets/datasets-relationships.cy.js
+++ b/cypress/e2e/datasets/datasets-relationships.cy.js
@@ -1,0 +1,61 @@
+import { mergeConfig } from "../../support/utils";
+
+describe("Datasets relationships tab", () => {
+  const relationships = {
+    relationships: [
+      {
+        identifier:
+          "https://scilog.development.psi.ch/logbooks/6895bea625f055bca783dfdd",
+        identifierType: "URL",
+        entityType: "Logbook",
+        externalId: "6895bea625f055bca783dfdd",
+      },
+      {
+        identifier: "10.1016/j.epsl.2011.11.037",
+        identifierType: "DOI",
+        entityType: "JournalArticle",
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    cy.login(Cypress.env("username"), Cypress.env("password"));
+    cy.createDataset(relationships);
+  });
+
+  after(() => {
+    cy.removeDatasets();
+  });
+
+  it("displays relationships table with correct values", () => {
+    cy.visit("/datasets");
+    cy.get(".dataset-table mat-row").contains("Cypress Dataset").click();
+    cy.get("[data-cy=dataset-dashboard-tabs]")
+      .contains("Relationships")
+      .click();
+    relationships.relationships.forEach((r, i) => {
+      const vals = [
+        r.identifierType == "URL" && r.externalId ? r.externalId : r.identifier,
+        r.entityType,
+        r.identifierType,
+      ];
+      Object.values(vals).forEach((v) => cy.get("mat-row").eq(i).contains(v));
+    });
+  });
+
+  it("does not display relationships tab when disabled by config", () => {
+    cy.readFile("CI/e2e/frontend.config.e2e.json").then((baseConfig) => {
+      const mergedConfig = mergeConfig(baseConfig, {
+        datasetRelationshipsEnabled: false,
+      });
+      cy.intercept("GET", "**/admin/config", mergedConfig);
+    });
+
+    cy.visit("/datasets");
+    cy.get(".dataset-table mat-row").contains("Cypress Dataset").click();
+    cy.get("[data-cy=dataset-dashboard-tabs]").should(
+      "not.contain",
+      "Relationships",
+    );
+  });
+});

--- a/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
+++ b/src/app/datasets/dataset-details-dashboard/dataset-details-dashboard.component.html
@@ -17,7 +17,7 @@
       Add to Selection
     </button>
   </div>
-  <nav mat-tab-nav-bar [tabPanel]="tabPanel">
+  <nav data-cy="dataset-dashboard-tabs" mat-tab-nav-bar [tabPanel]="tabPanel">
     <ng-container *ngFor="let link of navLinks">
       <a
         mat-tab-link


### PR DESCRIPTION
## Description
Adding Cypress tests for the Relationships tab feature introduced in https://github.com/SciCatProject/frontend/pull/2416
1. Check relationship table populated with correct values when feature is enabled
2. Check Relationships tab is not displayed when feature is disabled

Feature under test:
<img width="1299" height="703" alt="Screenshot from 2026-08-13 11-23-47" src="https://github.com/user-attachments/assets/775ce4fa-d90e-4399-861a-fb0fe8e5fad5" />


## Motivation

https://github.com/SciCatProject/frontend/pull/2416#pullrequestreview-4647325019

## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Add end-to-end coverage for the dataset relationships tab behavior in the datasets dashboard.

Enhancements:
- Tag the dataset details dashboard tab navigation with a data-cy attribute to support stable test selectors.

Tests:
- Add Cypress e2e tests verifying the relationships table renders correct values when the feature is enabled.
- Add Cypress e2e tests ensuring the Relationships tab is hidden when the feature is disabled via configuration.

## Summary by Sourcery

Add end-to-end coverage for dataset relationships tab visibility and displayed relationship data.

Enhancements:
- Add a stable selector to the dataset details dashboard tabs for end-to-end testing.

Tests:
- Add Cypress coverage verifying that enabled dataset relationships display the expected table values.
- Add Cypress coverage verifying that the Relationships tab is hidden when disabled by configuration.