### PR TITLE
feat: add configurable dataset banner

### DIFF
--- a/docs/contributors/dataset_banner.md
+++ b/docs/contributors/dataset_banner.md
@@ -12,6 +12,8 @@ The dataset status banner is a small, colored notice rendered above the dataset 
 
 This feature is unrelated to the existing global **statusBannerMessage** setting, which renders a single, static banner in the application header regardless of which page or dataset is being viewed. The dataset status banner described here is per-dataset and conditional, driven by rules evaluated against the dataset actually loaded.
 
+Both `datasetStatusBanner` and the `statusBanner` entry in `datasetDetailComponent.customization` (see [Placement](#placement-on-the-dataset-detail-page) below) are also editable through the Admin config editor, backed by `src/app/admin/schema/frontend.config.jsonforms.json`.
+
 ## Configuration
 
 The banner is controlled by the **datasetStatusBanner** property in the frontend configuration (`src/assets/config.json`):

--- a/docs/contributors/dataset_banner.md
+++ b/docs/contributors/dataset_banner.md
@@ -1,0 +1,107 @@
+---
+title: Dataset Status Banner
+created_by: Carlo Minotti
+created_on: 2026/08/13
+---
+
+# Dataset Status Banner
+
+This page describes the configurable status banner shown on the dataset detail page.
+
+The dataset status banner is a small, colored notice rendered above the dataset details (e.g. "This dataset has been deleted.") that is shown or hidden based on rules matched against fields of the currently viewed dataset. It is fully opt-in: if `datasetStatusBanner` is not configured, or is configured with `enabled: false`, no banner is ever rendered and there is no change in behavior.
+
+This feature is unrelated to the existing global **statusBannerMessage** setting, which renders a single, static banner in the application header regardless of which page or dataset is being viewed. The dataset status banner described here is per-dataset and conditional, driven by rules evaluated against the dataset actually loaded.
+
+## Configuration
+
+The banner is controlled by the **datasetStatusBanner** property in the frontend configuration (`src/assets/config.json`):
+
+- **datasetStatusBanner**  
+  _Type: DatasetStatusBannerConfig_  
+  _Optional_  
+  Configures the per-dataset status banner feature.
+  - **enabled**  
+    _Type: boolean_  
+    _Optional_  
+    Enables or disables the feature. If omitted or `false`, no banner is ever shown.
+  - **rules**  
+    _Type: array of DatasetStatusBannerRule_  
+    The list of rules used to determine whether a banner is shown, and with which message/severity. Rules are evaluated in order and the **first matching rule wins**.
+
+Each element of `rules` is a **DatasetStatusBannerRule**:
+
+- **field**  
+  _Type: string_  
+  Dot-path to the dataset field to check, resolved from the dataset root (e.g. `datasetlifecycle.archiveStatusMessage`). Any nested field on the dataset object can be referenced this way, not just fields under `datasetlifecycle`.
+- **value**  
+  _Type: string_  
+  The value the field must equal (as a string, using strict equality) for this rule to match.
+- **message**  
+  _Type: string_  
+  The message shown in the banner when this rule matches. It is bound via `innerHTML`, so simple HTML markup is supported.
+- **code**  
+  _Type: "INFO" | "WARN"_  
+  _Optional_  
+  _Default: "WARN"_  
+  Controls the banner's icon and color: `WARN` renders an amber banner with a warning icon, `INFO` renders a green banner with an info icon.
+
+### Example
+
+```json
+"datasetStatusBanner": {
+  "enabled": true,
+  "rules": [
+    {
+      "field": "datasetlifecycle.archiveStatusMessage",
+      "value": "deleted",
+      "message": "This dataset has been deleted.",
+      "code": "WARN"
+    },
+    {
+      "field": "datasetlifecycle.archiveStatusMessage",
+      "value": "markedForDeletion",
+      "message": "This dataset is marked for deletion.",
+      "code": "WARN"
+    }
+  ]
+}
+```
+
+With this configuration, a dataset whose `datasetlifecycle.archiveStatusMessage` is `"deleted"` shows an amber banner reading "This dataset has been deleted."; a dataset with `"markedForDeletion"` shows a similar banner with a different message; any other value (or a missing `datasetlifecycle`) shows no banner at all.
+
+## Placement on the dataset detail page
+
+The banner is rendered as a section of the dataset detail page's customizable layout, alongside the other sections such as "General Information" or "Scientific Metadata". It is added by including an entry of type `statusBanner` in `datasetDetailComponent.customization`:
+
+```json
+"datasetDetailComponent": {
+  "enableCustomizedComponent": false,
+  "customization": [
+    {
+      "type": "statusBanner",
+      "label": "Status Banner",
+      "order": -1,
+      "row": 1,
+      "col": 10
+    },
+    ...
+  ]
+}
+```
+
+- **order** controls where the section falls relative to the other sections (lower values render first); a negative order places it above the default sections.
+- **row** / **col** control how many grid rows/columns the section spans in the dataset detail layout.
+
+If no `statusBanner` entry is present in `customization`, the banner component is never rendered, regardless of the `datasetStatusBanner` configuration.
+
+Note that the banner is currently only wired into the **dynamic** (customizable) dataset detail layout (`dataset-detail-dynamic`), not the legacy static layout.
+
+## Implementation
+
+- `DatasetStatusBannerComponent` (`src/app/datasets/dataset-detail/dataset-status-banner/`) receives the current dataset as `@Input() datasetItem` and exposes a `banner` getter that resolves the first matching rule (or `undefined` if the feature is disabled, no dataset is available, or no rule matches).
+- Field resolution walks the dot-path in `field` from the dataset root, returning `undefined` for any missing intermediate segment rather than throwing.
+- `DatasetDetailDynamicComponent` renders `<dataset-status-banner>` for any `statusBanner` section found in the configured `datasetView`, passing it the currently loaded dataset.
+
+### Tests
+
+Unit tests for the component live in `dataset-status-banner.component.spec.ts` and cover: the feature being disabled, no rule matching, message/code selection for a matching rule, first-match-wins precedence when multiple rules could match, the default `code` of `WARN`, and support for arbitrary dot-path fields beyond `datasetlifecycle`.

--- a/docs/contributors/dataset_banner.md
+++ b/docs/contributors/dataset_banner.md
@@ -26,7 +26,8 @@ The banner is controlled by the **datasetStatusBanner** property in the frontend
     Enables or disables the feature. If omitted or `false`, no banner is ever shown.
   - **rules**  
     _Type: array of DatasetStatusBannerRule_  
-    The list of rules used to determine whether a banner is shown, and with which message/severity. Rules are evaluated in order and the **first matching rule wins**.
+    _Optional_  
+    The list of rules used to determine whether a banner is shown, and with which message/severity. Rules are evaluated in order and the **first matching rule wins**. If omitted, no rule can ever match, so no banner is shown.
 
 Each element of `rules` is a **DatasetStatusBannerRule**:
 
@@ -38,7 +39,7 @@ Each element of `rules` is a **DatasetStatusBannerRule**:
   The value the field must equal (as a string, using strict equality) for this rule to match.
 - **message**  
   _Type: string_  
-  The message shown in the banner when this rule matches. It is bound via `innerHTML`, so simple HTML markup is supported.
+  The message shown in the banner when this rule matches. It is rendered as plain text (not HTML), so no markup is interpreted and there is no risk of arbitrary HTML/script injection via configuration.
 - **code**  
   _Type: "INFO" | "WARN"_  
   _Optional_  
@@ -98,8 +99,8 @@ Note that the banner is currently only wired into the **dynamic** (customizable)
 
 ## Implementation
 
-- `DatasetStatusBannerComponent` (`src/app/datasets/dataset-detail/dataset-status-banner/`) receives the current dataset as `@Input() datasetItem` and exposes a `banner` getter that resolves the first matching rule (or `undefined` if the feature is disabled, no dataset is available, or no rule matches).
-- Field resolution walks the dot-path in `field` from the dataset root, returning `undefined` for any missing intermediate segment rather than throwing.
+- `DatasetStatusBannerComponent` (`src/app/datasets/dataset-detail/dataset-status-banner/`) receives the current dataset as `@Input() datasetItem`. On `ngOnChanges`, it resolves the first matching rule into a `banner` field (or `undefined` if the feature is disabled, no dataset is available, or no rule matches), so the lookup runs once per dataset change rather than on every change-detection cycle.
+- Field resolution uses lodash-es's `get` to walk the dot-path in `field` from the dataset root, returning `undefined` for any missing intermediate segment rather than throwing.
 - `DatasetDetailDynamicComponent` renders `<dataset-status-banner>` for any `statusBanner` section found in the configured `datasetView`, passing it the currently loaded dataset.
 
 ### Tests

--- a/src/app/admin/schema/frontend.config.jsonforms.json
+++ b/src/app/admin/schema/frontend.config.jsonforms.json
@@ -105,6 +105,29 @@
       "notificationInterceptorEnabled": { "type": "boolean" },
       "metadataEditingUnitListDisabled": { "type": "boolean" },
       "hideEmptyMetadataTable": { "type": "boolean" },
+      "datasetStatusBanner": {
+        "type": "object",
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "rules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": { "type": "string" },
+                "value": { "type": "string" },
+                "message": { "type": "string" },
+                "code": {
+                  "type": "string",
+                  "enum": ["INFO", "WARN"],
+                  "default": "WARN"
+                }
+              },
+              "required": ["field", "value", "message"]
+            }
+          }
+        }
+      },
       "helpSettings": {
         "type": "object",
         "properties": {
@@ -347,7 +370,8 @@
                     "scientificMetadata",
                     "attachments",
                     "datasetJsonView",
-                    "regular"
+                    "regular",
+                    "statusBanner"
                   ]
                 },
                 "order": { "type": "number" },
@@ -740,6 +764,45 @@
                 "scope": "#/properties/labelsLocalization/properties/proposal"
               }
             ]
+          }
+        ]
+      },
+      {
+        "type": "Group",
+        "label": "Dataset Status Banner",
+        "options": {
+          "expandable": true
+        },
+        "elements": [
+          {
+            "type": "Control",
+            "scope": "#/properties/datasetStatusBanner/properties/enabled"
+          },
+          {
+            "type": "ListWithDetail",
+            "label": "Rules",
+            "scope": "#/properties/datasetStatusBanner/properties/rules",
+            "options": {
+              "labelRef": "#/items/properties/message",
+              "detail": {
+                "type": "VerticalLayout",
+                "elements": [
+                  {
+                    "type": "HorizontalLayout",
+                    "elements": [
+                      { "type": "Control", "scope": "#/properties/field" },
+                      { "type": "Control", "scope": "#/properties/value" },
+                      { "type": "Control", "scope": "#/properties/code" }
+                    ]
+                  },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/message",
+                    "options": { "multi": true }
+                  }
+                ]
+              }
+            }
           }
         ]
       },

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -91,6 +91,17 @@ export interface AboutSettings {
   htmlContent?: string;
 }
 
+export interface DatasetStatusBannerMessageConfig {
+  message?: string;
+  code?: "INFO" | "WARN";
+}
+
+export interface DatasetStatusBannerConfig {
+  enabled?: boolean;
+  markedForDeletion?: DatasetStatusBannerMessageConfig;
+  deleted?: DatasetStatusBannerMessageConfig;
+}
+
 export interface AppConfigInterface {
   allowConfigOverrides?: boolean;
   addScientificMetadataKeysAsColumn?: boolean;
@@ -183,6 +194,7 @@ export interface AppConfigInterface {
   mainMenu?: MainMenuConfiguration;
   supportEmail?: string;
   hideEmptyMetadataTable?: boolean;
+  datasetStatusBanner?: DatasetStatusBannerConfig;
   ingestorComponent?: IngestorComponentConfig;
   defaultTab?: DefaultTab;
   statusBannerMessage?: string;

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -104,7 +104,7 @@ export interface DatasetStatusBannerRule {
 export interface DatasetStatusBannerConfig {
   enabled?: boolean;
   // Evaluated in order; the first matching rule wins.
-  rules: DatasetStatusBannerRule[];
+  rules?: DatasetStatusBannerRule[];
 }
 
 export interface AppConfigInterface {

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -91,15 +91,20 @@ export interface AboutSettings {
   htmlContent?: string;
 }
 
-export interface DatasetStatusBannerMessageConfig {
-  message?: string;
+export interface DatasetStatusBannerRule {
+  // Dot-path to the field to check, resolved from the dataset root,
+  // e.g. "datasetlifecycle.archiveStatusMessage".
+  field: string;
+  // Value the field must equal (as a string) for this rule to match.
+  value: string;
+  message: string;
   code?: "INFO" | "WARN";
 }
 
 export interface DatasetStatusBannerConfig {
   enabled?: boolean;
-  markedForDeletion?: DatasetStatusBannerMessageConfig;
-  deleted?: DatasetStatusBannerMessageConfig;
+  // Evaluated in order; the first matching rule wins.
+  rules: DatasetStatusBannerRule[];
 }
 
 export interface AppConfigInterface {

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
@@ -30,6 +30,16 @@
     <!-- Iterate over each section in datasetView -->
     <ng-container *ngFor="let section of datasetView">
       <ng-container [ngSwitch]="section.type">
+        <!-- Status Banner Section -->
+        <div
+          *ngSwitchCase="'statusBanner'"
+          class="card-container"
+          [style.gridColumn]="'span ' + (section.col || 10)"
+          [style.gridRow]="'span ' + (section.row || 1)"
+        >
+          <dataset-status-banner [datasetItem]="dataset"></dataset-status-banner>
+        </div>
+
         <!-- Regular Section -->
         <div
           *ngSwitchCase="'regular'"

--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.html
@@ -1,4 +1,5 @@
 <ng-template [ngIf]="dataset">
+  <dataset-status-banner [datasetItem]="dataset"></dataset-status-banner>
   <div fxLayout="row">
     <div fxFlex="auto">
       <a

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.html
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.html
@@ -1,0 +1,11 @@
+<div
+  *ngIf="banner as content"
+  class="dataset-status-banner"
+  [ngClass]="'dataset-status-banner-' + content.code"
+  data-cy="dataset-status-banner"
+>
+  <mat-icon class="dataset-status-banner-icon">
+    {{ content.code === "INFO" ? "info" : "warning" }}
+  </mat-icon>
+  <span [innerHTML]="content.message"></span>
+</div>

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.html
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.html
@@ -7,5 +7,5 @@
   <mat-icon class="dataset-status-banner-icon">
     {{ content.code === "INFO" ? "info" : "warning" }}
   </mat-icon>
-  <span [innerHTML]="content.message"></span>
+  <span>{{ content.message }}</span>
 </div>

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.scss
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.scss
@@ -1,0 +1,23 @@
+.dataset-status-banner {
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  padding: 10px 16px;
+  margin-bottom: 12px;
+  font-size: 14px;
+}
+
+.dataset-status-banner-icon {
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+.dataset-status-banner-WARN {
+  background-color: #feefb3;
+  color: #9f6000;
+}
+
+.dataset-status-banner-INFO {
+  background-color: #dff2bf;
+  color: #4f8a10;
+}

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { CommonModule } from "@angular/common";
+import { MatIconModule } from "@angular/material/icon";
+
+import { DatasetStatusBannerComponent } from "./dataset-status-banner.component";
+import { AppConfigInterface, AppConfigService } from "app-config.service";
+import { OutputDatasetObsoleteDto } from "@scicatproject/scicat-sdk-ts-angular";
+
+describe("DatasetStatusBannerComponent", () => {
+  let component: DatasetStatusBannerComponent;
+  let fixture: ComponentFixture<DatasetStatusBannerComponent>;
+  let appConfigServiceSpy: jasmine.SpyObj<AppConfigService>;
+
+  function configureTestBed(config: Partial<AppConfigInterface>) {
+    appConfigServiceSpy = jasmine.createSpyObj("AppConfigService", [
+      "getConfig",
+    ]);
+    appConfigServiceSpy.getConfig.and.returnValue(config as AppConfigInterface);
+
+    TestBed.configureTestingModule({
+      declarations: [DatasetStatusBannerComponent],
+      imports: [CommonModule, MatIconModule],
+      providers: [{ provide: AppConfigService, useValue: appConfigServiceSpy }],
+    });
+  }
+
+  function initComponent(dataset?: Partial<OutputDatasetObsoleteDto>): void {
+    fixture = TestBed.createComponent(DatasetStatusBannerComponent);
+    component = fixture.componentInstance;
+    component.datasetItem = dataset as OutputDatasetObsoleteDto;
+    fixture.detectChanges();
+  }
+
+  it("should create", () => {
+    configureTestBed({ datasetStatusBanner: { enabled: true } });
+    initComponent();
+    expect(component).toBeTruthy();
+  });
+
+  it("should not show a banner when the feature is disabled", () => {
+    configureTestBed({ datasetStatusBanner: { enabled: false } });
+    initComponent({ datasetlifecycle: { deleted: true } as never });
+    expect(component.banner).toBeUndefined();
+  });
+
+  it("should not show a banner when the dataset is not deleted or marked for deletion", () => {
+    configureTestBed({ datasetStatusBanner: { enabled: true } });
+    initComponent({ datasetlifecycle: {} });
+    expect(component.banner).toBeUndefined();
+  });
+
+  it("should show the default deleted message when deleted is true", () => {
+    configureTestBed({ datasetStatusBanner: { enabled: true } });
+    initComponent({ datasetlifecycle: { deleted: true } as never });
+    expect(component.banner).toEqual({
+      message: "This dataset has been deleted.",
+      code: "WARN",
+    });
+  });
+
+  it("should show the default markedForDeletion message when markedForDeletion is true", () => {
+    configureTestBed({ datasetStatusBanner: { enabled: true } });
+    initComponent({
+      datasetlifecycle: { markedForDeletion: true } as never,
+    });
+    expect(component.banner).toEqual({
+      message: "This dataset is marked for deletion.",
+      code: "WARN",
+    });
+  });
+
+  it("should prefer deleted over markedForDeletion when both are true", () => {
+    configureTestBed({ datasetStatusBanner: { enabled: true } });
+    initComponent({
+      datasetlifecycle: { deleted: true, markedForDeletion: true } as never,
+    });
+    expect(component.banner?.message).toBe("This dataset has been deleted.");
+  });
+
+  it("should use configured message and code overrides", () => {
+    configureTestBed({
+      datasetStatusBanner: {
+        enabled: true,
+        deleted: { message: "Custom deleted message", code: "INFO" },
+      },
+    });
+    initComponent({ datasetlifecycle: { deleted: true } as never });
+    expect(component.banner).toEqual({
+      message: "Custom deleted message",
+      code: "INFO",
+    });
+  });
+});

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.spec.ts
@@ -46,6 +46,7 @@ describe("DatasetStatusBannerComponent", () => {
     fixture = TestBed.createComponent(DatasetStatusBannerComponent);
     component = fixture.componentInstance;
     component.datasetItem = dataset as OutputDatasetObsoleteDto;
+    component.ngOnChanges();
     fixture.detectChanges();
   }
 

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.spec.ts
@@ -3,8 +3,26 @@ import { CommonModule } from "@angular/common";
 import { MatIconModule } from "@angular/material/icon";
 
 import { DatasetStatusBannerComponent } from "./dataset-status-banner.component";
-import { AppConfigInterface, AppConfigService } from "app-config.service";
+import {
+  AppConfigInterface,
+  AppConfigService,
+  DatasetStatusBannerRule,
+} from "app-config.service";
 import { OutputDatasetObsoleteDto } from "@scicatproject/scicat-sdk-ts-angular";
+
+const DELETED_RULE: DatasetStatusBannerRule = {
+  field: "datasetlifecycle.archiveStatusMessage",
+  value: "deleted",
+  message: "This dataset has been deleted.",
+  code: "WARN",
+};
+
+const MARKED_FOR_DELETION_RULE: DatasetStatusBannerRule = {
+  field: "datasetlifecycle.archiveStatusMessage",
+  value: "markedForDeletion",
+  message: "This dataset is marked for deletion.",
+  code: "WARN",
+};
 
 describe("DatasetStatusBannerComponent", () => {
   let component: DatasetStatusBannerComponent;
@@ -32,36 +50,61 @@ describe("DatasetStatusBannerComponent", () => {
   }
 
   it("should create", () => {
-    configureTestBed({ datasetStatusBanner: { enabled: true } });
+    configureTestBed({
+      datasetStatusBanner: { enabled: true, rules: [DELETED_RULE] },
+    });
     initComponent();
     expect(component).toBeTruthy();
   });
 
   it("should not show a banner when the feature is disabled", () => {
-    configureTestBed({ datasetStatusBanner: { enabled: false } });
-    initComponent({ datasetlifecycle: { deleted: true } as never });
+    configureTestBed({
+      datasetStatusBanner: { enabled: false, rules: [DELETED_RULE] },
+    });
+    initComponent({
+      datasetlifecycle: { archiveStatusMessage: "deleted" },
+    });
     expect(component.banner).toBeUndefined();
   });
 
-  it("should not show a banner when the dataset is not deleted or marked for deletion", () => {
-    configureTestBed({ datasetStatusBanner: { enabled: true } });
-    initComponent({ datasetlifecycle: {} });
+  it("should not show a banner when no rule matches", () => {
+    configureTestBed({
+      datasetStatusBanner: {
+        enabled: true,
+        rules: [DELETED_RULE, MARKED_FOR_DELETION_RULE],
+      },
+    });
+    initComponent({
+      datasetlifecycle: { archiveStatusMessage: "available" },
+    });
     expect(component.banner).toBeUndefined();
   });
 
-  it("should show the default deleted message when deleted is true", () => {
-    configureTestBed({ datasetStatusBanner: { enabled: true } });
-    initComponent({ datasetlifecycle: { deleted: true } as never });
+  it("should show the message and code of the matching rule", () => {
+    configureTestBed({
+      datasetStatusBanner: {
+        enabled: true,
+        rules: [DELETED_RULE, MARKED_FOR_DELETION_RULE],
+      },
+    });
+    initComponent({
+      datasetlifecycle: { archiveStatusMessage: "deleted" },
+    });
     expect(component.banner).toEqual({
       message: "This dataset has been deleted.",
       code: "WARN",
     });
   });
 
-  it("should show the default markedForDeletion message when markedForDeletion is true", () => {
-    configureTestBed({ datasetStatusBanner: { enabled: true } });
+  it("should match a different rule for a different field value", () => {
+    configureTestBed({
+      datasetStatusBanner: {
+        enabled: true,
+        rules: [DELETED_RULE, MARKED_FOR_DELETION_RULE],
+      },
+    });
     initComponent({
-      datasetlifecycle: { markedForDeletion: true } as never,
+      datasetlifecycle: { archiveStatusMessage: "markedForDeletion" },
     });
     expect(component.banner).toEqual({
       message: "This dataset is marked for deletion.",
@@ -69,24 +112,55 @@ describe("DatasetStatusBannerComponent", () => {
     });
   });
 
-  it("should prefer deleted over markedForDeletion when both are true", () => {
-    configureTestBed({ datasetStatusBanner: { enabled: true } });
-    initComponent({
-      datasetlifecycle: { deleted: true, markedForDeletion: true } as never,
-    });
-    expect(component.banner?.message).toBe("This dataset has been deleted.");
-  });
-
-  it("should use configured message and code overrides", () => {
+  it("should use the first matching rule when multiple rules could match", () => {
+    const higherPriorityDeletedRule: DatasetStatusBannerRule = {
+      ...DELETED_RULE,
+      message: "Higher priority deleted message.",
+    };
     configureTestBed({
       datasetStatusBanner: {
         enabled: true,
-        deleted: { message: "Custom deleted message", code: "INFO" },
+        rules: [higherPriorityDeletedRule, DELETED_RULE],
       },
     });
-    initComponent({ datasetlifecycle: { deleted: true } as never });
+    initComponent({
+      datasetlifecycle: { archiveStatusMessage: "deleted" },
+    });
+    expect(component.banner?.message).toBe("Higher priority deleted message.");
+  });
+
+  it("should default the code to WARN when a rule does not specify one", () => {
+    configureTestBed({
+      datasetStatusBanner: {
+        enabled: true,
+        rules: [{ ...DELETED_RULE, code: undefined }],
+      },
+    });
+    initComponent({
+      datasetlifecycle: { archiveStatusMessage: "deleted" },
+    });
+    expect(component.banner?.code).toBe("WARN");
+  });
+
+  it("should support arbitrary dot-path fields, not just datasetlifecycle ones", () => {
+    configureTestBed({
+      datasetStatusBanner: {
+        enabled: true,
+        rules: [
+          {
+            field: "scientificMetadata.status",
+            value: "embargoed",
+            message: "This dataset is embargoed.",
+            code: "INFO",
+          },
+        ],
+      },
+    });
+    initComponent({
+      scientificMetadata: { status: "embargoed" } as never,
+    });
     expect(component.banner).toEqual({
-      message: "Custom deleted message",
+      message: "This dataset is embargoed.",
       code: "INFO",
     });
   });

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.ts
@@ -1,0 +1,70 @@
+import { Component, Input } from "@angular/core";
+import { AppConfigService } from "app-config.service";
+import {
+  LifecycleClass,
+  OutputDatasetObsoleteDto,
+} from "@scicatproject/scicat-sdk-ts-angular";
+
+type DatasetLifecycleWithDeletionFlags = LifecycleClass & {
+  deleted?: boolean;
+  markedForDeletion?: boolean;
+};
+
+export interface DatasetStatusBannerContent {
+  message: string;
+  code: "INFO" | "WARN";
+}
+
+const DEFAULT_DELETED_MESSAGE = "This dataset has been deleted.";
+const DEFAULT_MARKED_FOR_DELETION_MESSAGE =
+  "This dataset is marked for deletion.";
+
+/**
+ * Displays a configurable warning banner when a dataset's lifecycle is
+ * flagged as deleted or markedForDeletion. Fully opt-in via
+ * appConfig.datasetStatusBanner so deployments without these lifecycle
+ * flags see no change in behavior.
+ */
+@Component({
+  selector: "dataset-status-banner",
+  templateUrl: "./dataset-status-banner.component.html",
+  styleUrls: ["./dataset-status-banner.component.scss"],
+  standalone: false,
+})
+export class DatasetStatusBannerComponent {
+  // Named datasetItem (not "dataset") to avoid colliding with the native
+  // HTMLElement.dataset getter-only property when this element is ever
+  // rendered under NO_ERRORS_SCHEMA (e.g. host component tests that stub
+  // out children).
+  @Input() datasetItem: OutputDatasetObsoleteDto | undefined;
+
+  constructor(private appConfigService: AppConfigService) {}
+
+  get banner(): DatasetStatusBannerContent | undefined {
+    const config = this.appConfigService.getConfig().datasetStatusBanner;
+    if (!config?.enabled) {
+      return undefined;
+    }
+
+    const lifecycle = this.datasetItem
+      ?.datasetlifecycle as DatasetLifecycleWithDeletionFlags;
+
+    if (lifecycle?.deleted) {
+      return {
+        message: config.deleted?.message || DEFAULT_DELETED_MESSAGE,
+        code: config.deleted?.code || "WARN",
+      };
+    }
+
+    if (lifecycle?.markedForDeletion) {
+      return {
+        message:
+          config.markedForDeletion?.message ||
+          DEFAULT_MARKED_FOR_DELETION_MESSAGE,
+        code: config.markedForDeletion?.code || "WARN",
+      };
+    }
+
+    return undefined;
+  }
+}

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.ts
@@ -1,29 +1,18 @@
 import { Component, Input } from "@angular/core";
 import { AppConfigService } from "app-config.service";
-import {
-  LifecycleClass,
-  OutputDatasetObsoleteDto,
-} from "@scicatproject/scicat-sdk-ts-angular";
-
-type DatasetLifecycleWithDeletionFlags = LifecycleClass & {
-  deleted?: boolean;
-  markedForDeletion?: boolean;
-};
+import { OutputDatasetObsoleteDto } from "@scicatproject/scicat-sdk-ts-angular";
 
 export interface DatasetStatusBannerContent {
   message: string;
   code: "INFO" | "WARN";
 }
 
-const DEFAULT_DELETED_MESSAGE = "This dataset has been deleted.";
-const DEFAULT_MARKED_FOR_DELETION_MESSAGE =
-  "This dataset is marked for deletion.";
-
 /**
- * Displays a configurable warning banner when a dataset's lifecycle is
- * flagged as deleted or markedForDeletion. Fully opt-in via
- * appConfig.datasetStatusBanner so deployments without these lifecycle
- * flags see no change in behavior.
+ * Displays a configurable warning banner driven by appConfig.datasetStatusBanner.
+ * Each rule names a dot-path field on the dataset (e.g.
+ * "datasetlifecycle.archiveStatusMessage") and a value it must equal; the
+ * first matching rule's message/code is shown. Fully opt-in, so deployments
+ * without datasetStatusBanner configured see no change in behavior.
  */
 @Component({
   selector: "dataset-status-banner",
@@ -32,39 +21,40 @@ const DEFAULT_MARKED_FOR_DELETION_MESSAGE =
   standalone: false,
 })
 export class DatasetStatusBannerComponent {
-  // Named datasetItem (not "dataset") to avoid colliding with the native
-  // HTMLElement.dataset getter-only property when this element is ever
-  // rendered under NO_ERRORS_SCHEMA (e.g. host component tests that stub
-  // out children).
   @Input() datasetItem: OutputDatasetObsoleteDto | undefined;
 
   constructor(private appConfigService: AppConfigService) {}
 
   get banner(): DatasetStatusBannerContent | undefined {
     const config = this.appConfigService.getConfig().datasetStatusBanner;
-    if (!config?.enabled) {
+    if (!config?.enabled || !this.datasetItem) {
       return undefined;
     }
 
-    const lifecycle = this.datasetItem
-      ?.datasetlifecycle as DatasetLifecycleWithDeletionFlags;
+    const rule = (config.rules || []).find(
+      (candidate) => this.getFieldValue(candidate.field) === candidate.value,
+    );
 
-    if (lifecycle?.deleted) {
-      return {
-        message: config.deleted?.message || DEFAULT_DELETED_MESSAGE,
-        code: config.deleted?.code || "WARN",
-      };
+    if (!rule) {
+      return undefined;
     }
 
-    if (lifecycle?.markedForDeletion) {
-      return {
-        message:
-          config.markedForDeletion?.message ||
-          DEFAULT_MARKED_FOR_DELETION_MESSAGE,
-        code: config.markedForDeletion?.code || "WARN",
-      };
+    return { message: rule.message, code: rule.code || "WARN" };
+  }
+
+  private getFieldValue(path: string): unknown {
+    if (!path) {
+      return undefined;
     }
 
-    return undefined;
+    return path
+      .split(".")
+      .reduce<unknown>(
+        (value, key) =>
+          value && typeof value === "object"
+            ? (value as Record<string, unknown>)[key]
+            : undefined,
+        this.datasetItem,
+      );
   }
 }

--- a/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-status-banner/dataset-status-banner.component.ts
@@ -1,5 +1,9 @@
-import { Component, Input } from "@angular/core";
-import { AppConfigService } from "app-config.service";
+import { Component, Input, OnChanges } from "@angular/core";
+import { get } from "lodash-es";
+import {
+  AppConfigService,
+  DatasetStatusBannerConfig,
+} from "app-config.service";
 import { OutputDatasetObsoleteDto } from "@scicatproject/scicat-sdk-ts-angular";
 
 export interface DatasetStatusBannerContent {
@@ -20,19 +24,21 @@ export interface DatasetStatusBannerContent {
   styleUrls: ["./dataset-status-banner.component.scss"],
   standalone: false,
 })
-export class DatasetStatusBannerComponent {
+export class DatasetStatusBannerComponent implements OnChanges {
+  private readonly config: DatasetStatusBannerConfig | undefined;
   @Input() datasetItem: OutputDatasetObsoleteDto | undefined;
 
-  constructor(private appConfigService: AppConfigService) {}
+  banner: DatasetStatusBannerContent | undefined;
 
-  get banner(): DatasetStatusBannerContent | undefined {
-    const config = this.appConfigService.getConfig().datasetStatusBanner;
-    if (!config?.enabled || !this.datasetItem) {
-      return undefined;
-    }
+  constructor(private appConfigService: AppConfigService) {
+    this.config = this.appConfigService.getConfig().datasetStatusBanner;
+  }
 
-    const rule = (config.rules || []).find(
-      (candidate) => this.getFieldValue(candidate.field) === candidate.value,
+  private resolveBanner(): DatasetStatusBannerContent | undefined {
+    if (!this.config?.enabled || !this.datasetItem) return undefined;
+
+    const rule = (this.config.rules || []).find(
+      (candidate) => get(this.datasetItem, candidate.field) === candidate.value,
     );
 
     if (!rule) {
@@ -42,19 +48,7 @@ export class DatasetStatusBannerComponent {
     return { message: rule.message, code: rule.code || "WARN" };
   }
 
-  private getFieldValue(path: string): unknown {
-    if (!path) {
-      return undefined;
-    }
-
-    return path
-      .split(".")
-      .reduce<unknown>(
-        (value, key) =>
-          value && typeof value === "object"
-            ? (value as Record<string, unknown>)[key]
-            : undefined,
-        this.datasetItem,
-      );
+  ngOnChanges(): void {
+    this.banner = this.resolveBanner();
   }
 }

--- a/src/app/datasets/datasets.module.ts
+++ b/src/app/datasets/datasets.module.ts
@@ -81,6 +81,7 @@ import { JsonFormsModule } from "@jsonforms/angular";
 import { JsonFormsAngularMaterialModule } from "@jsonforms/angular-material";
 import { DatasetDetailDynamicComponent } from "./dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component";
 import { DatasetDetailWrapperComponent } from "./dataset-detail/dataset-detail-wrapper.component";
+import { DatasetStatusBannerComponent } from "./dataset-detail/dataset-status-banner/dataset-status-banner.component";
 import { DatasetInlineEditCellComponent } from "./dataset-table/dataset-inline-edit-cell.component";
 import { JsonHeadPipe } from "shared/pipes/json-head.pipe";
 import { ThumbnailPipe } from "shared/pipes/thumbnail.pipe";
@@ -173,6 +174,7 @@ import { ActionEffects } from "state-management/effects/actions.effect";
     DatasetDetailWrapperComponent,
     DatasetDetailComponent,
     DatasetDetailDynamicComponent,
+    DatasetStatusBannerComponent,
     DatasetTableComponent,
     DatasetInlineEditCellComponent,
     DatasetsFilterComponent,

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -96,7 +96,11 @@ export interface Field {
 
 // Type alias for allowed customization types
 type CustomizationType =
-  "regular" | "scientificMetadata" | "datasetJsonView" | "attachments";
+  | "regular"
+  | "scientificMetadata"
+  | "datasetJsonView"
+  | "attachments"
+  | "statusBanner";
 
 // Type alias for allowed field types
 type FieldType = "text" | "copy" | "linky" | "tag" | "date";

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -80,6 +80,17 @@
   "notificationInterceptorEnabled": true,
   "metadataEditingUnitListDisabled": true,
   "hideEmptyMetadataTable": false,
+  "datasetStatusBanner": {
+    "enabled": true,
+    "markedForDeletion": {
+      "message": "This dataset is marked for deletion.",
+      "code": "WARN"
+    },
+    "deleted": {
+      "message": "This dataset has been deleted.",
+      "code": "WARN"
+    }
+  },
   "datafilesActionsEnabled": true,
   "datafilesActions": [
     {
@@ -732,6 +743,13 @@
   "datasetDetailComponent": {
     "enableCustomizedComponent": false,
     "customization": [
+      {
+        "type": "statusBanner",
+        "label": "Status Banner",
+        "order": -1,
+        "row": 1,
+        "col": 10
+      },
       {
         "type": "regular",
         "label": "General Information",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -82,14 +82,20 @@
   "hideEmptyMetadataTable": false,
   "datasetStatusBanner": {
     "enabled": true,
-    "markedForDeletion": {
-      "message": "This dataset is marked for deletion.",
-      "code": "WARN"
-    },
-    "deleted": {
-      "message": "This dataset has been deleted.",
-      "code": "WARN"
-    }
+    "rules": [
+      {
+        "field": "datasetlifecycle.archiveStatusMessage",
+        "value": "deleted",
+        "message": "This dataset has been deleted.",
+        "code": "WARN"
+      },
+      {
+        "field": "datasetlifecycle.archiveStatusMessage",
+        "value": "markedForDeletion",
+        "message": "This dataset is marked for deletion.",
+        "code": "WARN"
+      }
+    ]
   },
   "datafilesActionsEnabled": true,
   "datafilesActions": [


### PR DESCRIPTION
## Description
It introduces a configurable dataset banner to be displayed in the details page at the top

<img width="2538" height="443" alt="image" src="https://github.com/user-attachments/assets/08f2efd3-c4c1-45f6-ae96-b7a406eb3fb1" />

It is an opt-in feature, available both in dynamic-details and in the legacy one

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Add configurable per-dataset status banners to communicate dataset states on detail pages.

New Features:
- Add an opt-in, rule-based dataset status banner configurable through frontend settings and rendered on dataset detail pages.
- Support configurable banner messages and INFO/WARN severity based on matching dataset field values, including customizable placement in the dynamic detail layout.

Documentation:
- Document dataset status banner configuration, rule matching, placement, and usage.

Tests:
- Add unit coverage for disabled banners, unmatched rules, rule precedence, severity defaults, and nested field matching.