### PR TITLE
refactor(services): add shared copy-to-clipboard service

### DIFF
--- a/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail/dataset-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, Inject } from "@angular/core";
+import { Component, OnInit, OnDestroy } from "@angular/core";
 import { ENTER, COMMA, SPACE } from "@angular/cdk/keycodes";
 import { MatChipInputEvent } from "@angular/material/chips";
 
@@ -7,7 +7,6 @@ import { DialogComponent } from "shared/modules/dialog/dialog.component";
 import { combineLatest, Observable, Subscription } from "rxjs";
 import { Store } from "@ngrx/store";
 
-import { showMessageAction } from "state-management/actions/user.actions";
 import {
   selectCurrentAttachments,
   selectCurrentDataset,
@@ -38,8 +37,6 @@ import {
   FormGroup,
   Validators,
 } from "@angular/forms";
-import { Message, MessageType } from "state-management/models";
-import { DOCUMENT } from "@angular/common";
 import {
   Instrument,
   OutputDatasetObsoleteDto,
@@ -48,6 +45,7 @@ import {
   OutputSampleDto,
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { AttachmentService } from "shared/services/attachment.service";
+import { ClipboardService } from "shared/services/clipboard.service";
 
 /**
  * Component to show details for a data set, using the
@@ -88,13 +86,13 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
   readonly separatorKeyCodes: number[] = [ENTER, COMMA, SPACE];
 
   constructor(
-    @Inject(DOCUMENT) private document: Document,
     public appConfigService: AppConfigService,
     public dialog: MatDialog,
     private attachmentService: AttachmentService,
     private store: Store,
     private router: Router,
     private fb: FormBuilder,
+    private clipboardService: ClipboardService,
   ) {}
 
   ngOnInit() {
@@ -272,24 +270,11 @@ export class DatasetDetailComponent implements OnInit, OnDestroy {
   }
 
   onCopy(pid: string) {
-    const selectionBox = this.document.createElement("textarea");
-    selectionBox.style.position = "fixed";
-    selectionBox.style.left = "0";
-    selectionBox.style.top = "0";
-    selectionBox.style.opacity = "0";
-    selectionBox.value = pid;
-    this.document.body.appendChild(selectionBox);
-    selectionBox.focus();
-    selectionBox.select();
-    this.document.execCommand("copy");
-    this.document.body.removeChild(selectionBox);
-
-    const message = new Message(
+    this.clipboardService.copyToClipboard(
+      pid,
       "Dataset PID has been copied to your clipboard",
-      MessageType.Success,
       5000,
     );
-    this.store.dispatch(showMessageAction({ message }));
   }
   base64MimeType(encoded: string): string {
     return this.attachmentService.base64MimeType(encoded);

--- a/src/app/jobs/jobs-detail/jobs-detail.component.ts
+++ b/src/app/jobs/jobs-detail/jobs-detail.component.ts
@@ -1,13 +1,11 @@
-import { Component, OnDestroy, OnInit, Inject } from "@angular/core";
-import { DOCUMENT } from "@angular/common";
+import { Component, OnDestroy, OnInit } from "@angular/core";
 import { fetchJobAction } from "state-management/actions/jobs.actions";
 import { Store } from "@ngrx/store";
 import { ActivatedRoute } from "@angular/router";
 import { selectCurrentJob } from "state-management/selectors/jobs.selectors";
 import { Observable, Subscription } from "rxjs";
 import { OutputJobV3Dto } from "@scicatproject/scicat-sdk-ts-angular";
-import { Message, MessageType } from "state-management/models";
-import { showMessageAction } from "state-management/actions/user.actions";
+import { ClipboardService } from "shared/services/clipboard.service";
 
 @Component({
   selector: "app-jobs-detail",
@@ -24,9 +22,9 @@ export class JobsDetailComponent implements OnInit, OnDestroy {
   hasJobResultObject = false;
 
   constructor(
-    @Inject(DOCUMENT) private document: Document,
     private route: ActivatedRoute,
     private store: Store,
+    private clipboardService: ClipboardService,
   ) {}
 
   ngOnInit() {
@@ -44,23 +42,10 @@ export class JobsDetailComponent implements OnInit, OnDestroy {
   }
 
   onCopy(pid: string) {
-    const selectionBox = this.document.createElement("textarea");
-    selectionBox.style.position = "fixed";
-    selectionBox.style.left = "0";
-    selectionBox.style.top = "0";
-    selectionBox.style.opacity = "0";
-    selectionBox.value = pid;
-    this.document.body.appendChild(selectionBox);
-    selectionBox.focus();
-    selectionBox.select();
-    this.document.execCommand("copy");
-    this.document.body.removeChild(selectionBox);
-
-    const message = new Message(
+    this.clipboardService.copyToClipboard(
+      pid,
       "Job ID has been copied to your clipboard",
-      MessageType.Success,
       2000,
     );
-    this.store.dispatch(showMessageAction({ message }));
   }
 }

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.html
@@ -75,7 +75,17 @@
           </tr>
           <tr *ngIf="publishedData.doi as value" id="doiRow">
             <th>DOI</th>
-            <td>{{ value }}</td>
+            <td>
+              {{ value }}
+              <button
+                mat-icon-button
+                aria-label="Copy DOI"
+                data-cy="copyDoiButton"
+                (click)="onCopyClick(value)"
+              >
+                <mat-icon class="copy-button">content_copy</mat-icon>
+              </button>
+            </td>
           </tr>
           <tr *ngIf="landingPageUrl">
             <th>URL</th>

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
@@ -11,6 +11,7 @@ import {
   registerPublishedDataAction,
 } from "state-management/actions/published-data.actions";
 import { Subscription } from "rxjs";
+import { ClipboardService } from "shared/services/clipboard.service";
 import { pluck } from "rxjs/operators";
 import { selectCurrentPublishedData } from "state-management/selectors/published-data.selectors";
 import { AppConfigService } from "app-config.service";
@@ -41,6 +42,7 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
     private store: Store,
+    private clipboardService: ClipboardService,
   ) {}
 
   ngOnInit() {
@@ -104,6 +106,12 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
         datasetPids: this.publishedData.datasetPids,
         publishedDataDoi: this.publishedData.doi,
       }),
+    );
+  }
+  onCopy(doi: string): void {
+    this.clipboardService.copyToClipboard(
+      doi,
+      "Published data DOI has been copied to your clipboard",
     );
   }
 

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
@@ -108,10 +108,11 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
       }),
     );
   }
-  onCopy(doi: string): void {
+
+  onCopyClick(doi: string): void {
     this.clipboardService.copyToClipboard(
       doi,
-      "Published data DOI has been copied to your clipboard",
+      "copied to your clipboard.",
     );
   }
 

--- a/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
+++ b/src/app/publisheddata/publisheddata-details/publisheddata-details.component.ts
@@ -110,10 +110,7 @@ export class PublisheddataDetailsComponent implements OnInit, OnDestroy {
   }
 
   onCopyClick(doi: string): void {
-    this.clipboardService.copyToClipboard(
-      doi,
-      "copied to your clipboard.",
-    );
+    this.clipboardService.copyToClipboard(doi, "copied to your clipboard.");
   }
 
   isUrl(dataDescription: string): boolean {

--- a/src/app/shared/services/clipboard.service.ts
+++ b/src/app/shared/services/clipboard.service.ts
@@ -18,8 +18,8 @@ export class ClipboardService {
    */
   copyToClipboard(
     text: string,
-    successMessage: string = "Copied to clipboard",
-    duration: number = 5000,
+    successMessage = "Copied to clipboard",
+    duration = 5000,
   ): void {
     navigator.clipboard.writeText(text).then(
       () => {

--- a/src/app/shared/services/clipboard.service.ts
+++ b/src/app/shared/services/clipboard.service.ts
@@ -1,0 +1,44 @@
+// src/app/shared/services/clipboard.service.ts
+import { Injectable } from "@angular/core";
+import { Store } from "@ngrx/store";
+import { Message, MessageType } from "state-management/models";
+import { showMessageAction } from "state-management/actions/user.actions";
+
+@Injectable({
+  providedIn: "root",
+})
+export class ClipboardService {
+  constructor(private store: Store) {}
+
+  /**
+   * Copies text to clipboard and displays a success/error message
+   * @param text - The text to copy
+   * @param successMessage - Custom success message (optional)
+   * @param duration - How long to show the message (default: 5000ms)
+   */
+  copyToClipboard(
+    text: string,
+    successMessage: string = "Copied to clipboard",
+    duration: number = 5000,
+  ): void {
+    navigator.clipboard.writeText(text).then(
+      () => {
+        const message = new Message(
+          successMessage,
+          MessageType.Success,
+          duration,
+        );
+        this.store.dispatch(showMessageAction({ message }));
+      },
+      (err) => {
+        const errorMessage = new Message(
+          "Failed to copy to clipboard",
+          MessageType.Error,
+          duration,
+        );
+        this.store.dispatch(showMessageAction({ message: errorMessage }));
+        console.error("Could not copy text: ", err);
+      },
+    );
+  }
+}

--- a/src/app/shared/services/clipboard.service.ts
+++ b/src/app/shared/services/clipboard.service.ts
@@ -21,6 +21,16 @@ export class ClipboardService {
     successMessage = "Copied to clipboard",
     duration = 5000,
   ): void {
+    if (!navigator.clipboard?.writeText) {
+      const errorMessage = new Message(
+        "Clipboard not supported",
+        MessageType.Error,
+        duration,
+      );
+      this.store.dispatch(showMessageAction({ message: errorMessage }));
+      return;
+    }
+
     navigator.clipboard.writeText(text).then(
       () => {
         const message = new Message(

--- a/src/app/shared/services/index.ts
+++ b/src/app/shared/services/index.ts
@@ -1,1 +1,2 @@
 export * from "./config.service";
+export * from "./clipboard.service";

--- a/src/app/users/user-settings/user-settings.component.spec.ts
+++ b/src/app/users/user-settings/user-settings.component.spec.ts
@@ -12,8 +12,7 @@ import { AppConfigService } from "app-config.service";
 
 import { UserSettingsComponent } from "./user-settings.component";
 import { SharedScicatFrontendModule } from "shared/shared.module";
-import { Message, MessageType } from "state-management/models";
-import { showMessageAction } from "state-management/actions/user.actions";
+import { ClipboardService } from "shared/services/clipboard.service";
 import { FlexLayoutModule } from "@ngbracket/ngx-layout";
 import { MatCardModule } from "@angular/material/card";
 import { MatIconModule } from "@angular/material/icon";
@@ -26,6 +25,7 @@ describe("UserSettingsComponent", () => {
 
   let store: MockStore;
   let dispatchSpy;
+  let clipboardService: jasmine.SpyObj<ClipboardService>;
 
   const getConfig = () => ({});
 
@@ -46,7 +46,15 @@ describe("UserSettingsComponent", () => {
     });
     TestBed.overrideComponent(UserSettingsComponent, {
       set: {
-        providers: [{ provide: AppConfigService, useValue: { getConfig } }],
+        providers: [
+          { provide: AppConfigService, useValue: { getConfig } },
+          {
+            provide: ClipboardService,
+            useValue: jasmine.createSpyObj("ClipboardService", [
+              "copyToClipboard",
+            ]),
+          },
+        ],
       },
     });
     TestBed.compileComponents();
@@ -55,6 +63,9 @@ describe("UserSettingsComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(UserSettingsComponent);
     component = fixture.componentInstance;
+    clipboardService = TestBed.inject(
+      ClipboardService,
+    ) as jasmine.SpyObj<ClipboardService>;
     fixture.detectChanges();
   });
 
@@ -72,21 +83,14 @@ describe("UserSettingsComponent", () => {
 
   describe("#onCopy()", () => {
     it("should copy the token to the users clipboard and dispatch a showMessageAction", () => {
-      const commandSpy = spyOn(document, "execCommand");
-      dispatchSpy = spyOn(store, "dispatch");
-
-      const message = new Message(
-        "SciCat token has been copied to your clipboard",
-        MessageType.Success,
-        5000,
-      );
-
       component.onCopy("test");
 
-      expect(commandSpy).toHaveBeenCalledTimes(1);
-      expect(commandSpy).toHaveBeenCalledWith("copy");
-      expect(dispatchSpy).toHaveBeenCalledTimes(1);
-      expect(dispatchSpy).toHaveBeenCalledWith(showMessageAction({ message }));
+      expect(clipboardService.copyToClipboard).toHaveBeenCalledTimes(1);
+      expect(clipboardService.copyToClipboard).toHaveBeenCalledWith(
+        "test",
+        "SciCat token has been copied to your clipboard",
+        5000,
+      );
     });
   });
 

--- a/src/app/users/user-settings/user-settings.component.spec.ts
+++ b/src/app/users/user-settings/user-settings.component.spec.ts
@@ -43,18 +43,18 @@ describe("UserSettingsComponent", () => {
         }),
       ],
       declarations: [UserSettingsComponent],
+      providers: [
+        {
+          provide: ClipboardService,
+          useValue: jasmine.createSpyObj("ClipboardService", [
+            "copyToClipboard",
+          ]),
+        },
+      ],
     });
     TestBed.overrideComponent(UserSettingsComponent, {
       set: {
-        providers: [
-          { provide: AppConfigService, useValue: { getConfig } },
-          {
-            provide: ClipboardService,
-            useValue: jasmine.createSpyObj("ClipboardService", [
-              "copyToClipboard",
-            ]),
-          },
-        ],
+        providers: [{ provide: AppConfigService, useValue: { getConfig } }],
       },
     });
     TestBed.compileComponents();

--- a/src/app/users/user-settings/user-settings.component.ts
+++ b/src/app/users/user-settings/user-settings.component.ts
@@ -1,16 +1,14 @@
-import { Component, OnInit, Inject } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { Store } from "@ngrx/store";
 import {
-  showMessageAction,
   fetchCurrentUserAction,
   fetchScicatTokenAction,
 } from "state-management/actions/user.actions";
-import { Message, MessageType } from "state-management/models";
 import {
   selectIsAdmin,
   selectUserSettingsPageViewModel,
 } from "state-management/selectors/user.selectors";
-import { DOCUMENT } from "@angular/common";
+import { ClipboardService } from "shared/services/clipboard.service";
 import packageJson from "../../../../package.json";
 import { AppConfigService } from "app-config.service";
 
@@ -35,8 +33,8 @@ export class UserSettingsComponent implements OnInit {
 
   constructor(
     public appConfigService: AppConfigService,
-    @Inject(DOCUMENT) private document: Document,
     private store: Store,
+    private clipboardService: ClipboardService,
   ) {
     // TODO handle service and endpoint for user settings
   }
@@ -51,24 +49,11 @@ export class UserSettingsComponent implements OnInit {
   }
 
   onCopy(token: string) {
-    const selectionBox = this.document.createElement("textarea");
-    selectionBox.style.position = "fixed";
-    selectionBox.style.left = "0";
-    selectionBox.style.top = "0";
-    selectionBox.style.opacity = "0";
-    selectionBox.value = token;
-    this.document.body.appendChild(selectionBox);
-    selectionBox.focus();
-    selectionBox.select();
-    this.document.execCommand("copy");
-    this.document.body.removeChild(selectionBox);
-
-    const message = new Message(
+    this.clipboardService.copyToClipboard(
+      token,
       "SciCat token has been copied to your clipboard",
-      MessageType.Success,
       5000,
     );
-    this.store.dispatch(showMessageAction({ message }));
   }
   toggleShowConfig(event: MouseEvent | KeyboardEvent, config: string) {
     const isMouseEvent = event instanceof MouseEvent;


### PR DESCRIPTION
## Description
a new copy service is introduced as shared service and used in published data details. 

## Motivation
More convenience: Goal was to make the doi copyable just like the pids in dataset details. 


## Changes:
introduce new service at central place (app/shared/service) to use in published data for doi field. 


* changes made:
* added files as was suggested by AI: introduce a new service in shared/service, also in index.ts to export the function then where it is used in publisheddata-details.components.ts and its html.

## Other
For maintainability reasons one can follow up replacements of other places (see screenshot) where this functionality was used. Main bottleneck is testing that functionality remains in all cases the same.

Screenshot from github bot
<img width="828" height="266" alt="Screenshot 2026-08-21 at 09 02 07" src="https://github.com/user-attachments/assets/6ca8779b-3cfc-463f-9847-1aa11fdd11c5" />

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 


## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: not needed

## Summary by Sourcery

Centralize clipboard functionality and make published data DOIs copyable from their details view.

New Features:
- Add a copy-to-clipboard action for DOI values in published data details.

Enhancements:
- Centralize clipboard copying and user feedback in a shared service.
- Update existing dataset, job, and user-settings copy actions to use the shared clipboard service with support for unavailable or failed clipboard operations.