### PR TITLE
fix: hide paginator wrapper when pagination is not provided

### DIFF
--- a/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
+++ b/src/app/shared/modules/dynamic-material-table/table/dynamic-mat-table.component.html
@@ -49,7 +49,11 @@
       </button>
     </mat-form-field>
   </div>
-  <div class="paginator-container" [class.is-loading]="pagination?.isLoading">
+  <div
+    *ngIf="pagination"
+    class="paginator-container"
+    [class.is-loading]="pagination?.isLoading"
+  >
     <mat-paginator
       class="datasets-paginator datasets-header-paginator"
       [pageSizeOptions]="pagination.pageSizeOptions"
@@ -57,7 +61,6 @@
       [length]="pagination.length"
       [pageSize]="pagination.pageSize"
       (page)="pagination_onChange($event)"
-      *ngIf="pagination"
     ></mat-paginator>
   </div>
 </div>
@@ -469,7 +472,11 @@
     </app-empty-content>
   </ng-container>
 </div>
-<div class="paginator-container" [class.is-loading]="pagination?.isLoading">
+<div
+  *ngIf="pagination"
+  class="paginator-container"
+  [class.is-loading]="pagination?.isLoading"
+>
   <mat-paginator
     class="datasets-paginator datasets-footer-paginator"
     [pageSizeOptions]="pagination.pageSizeOptions"
@@ -477,7 +484,6 @@
     [length]="pagination.length"
     [pageSize]="pagination.pageSize"
     (page)="pagination_onChange($event)"
-    *ngIf="pagination"
   >
   </mat-paginator>
 </div>


### PR DESCRIPTION
## Description

remove top gap in the scientificMetadata widget
before:
<img width="833" height="110" alt="image" src="https://github.com/user-attachments/assets/fc340c68-aeba-4ff6-8825-447588ce26a3" />
after:
<img width="874" height="104" alt="image" src="https://github.com/user-attachments/assets/1bb61893-89c5-42d1-acd6-a9828d2c91ed" />

## Motivation
Background on use case, changes needed


## Fixes:
Please provide a list of the fixes implemented in this PR

* Items added


## Changes:
Please provide a list of the changes implemented by this PR

* changes made


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required: 
