### PR TITLE
fix: return generated JWT token for configurable actions

### DIFF
--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -12,6 +12,7 @@ import { DatePipe } from "@angular/common";
 import {
   Configuration as ApiConfiguration,
   DatasetClass,
+  UsersService,
 } from "@scicatproject/scicat-sdk-ts-angular";
 import {
   ActionButtonStyle,
@@ -81,6 +82,7 @@ export class ConfigurableActionComponent
   form: HTMLFormElement | null = null;
 
   constructor(
+    private usersService: UsersService,
     private authService: AuthService,
     private configService: AppConfigService,
     private store: Store,
@@ -574,7 +576,9 @@ export class ConfigurableActionComponent
   }
 
   ngOnInit() {
-    this.jwt = this.authService.getAccessTokenId() || "";
+    this.usersService.usersControllerGetUserJWTV3().subscribe((jwt) => {
+      this.jwt = jwt.jwt ?? "";
+    });
     this.subscriptions.push(
       this.userProfile$.subscribe(
         (up) => up && (this.userProfile = up as Record<string, unknown>),


### PR DESCRIPTION
## Description
Replace the JWT sdk token, with a freshly generated JWT that contains information from the User Profile.

## Motivation
The `#token` already returns the jwt sdk token, the generated `#jwt` is supposed to include profile information (e.g AccessGroups)
```ts
private authorizationTokens = {
    "#jwt": () => this.jwt,
    "#token": () => this.authService.getToken()?.id,
    "#tokenSimple": () => this.authService.getToken()?.id,
    "#tokenBearer": () => `Bearer ${this.authService.getToken()?.id}`,
    "#uuid": () => uuidv4(),
  };
```


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Bug Fixes:
- Return the freshly generated user JWT for configurable action `#jwt` substitutions instead of the SDK access-token JWT.