### PR TITLE
feat: configurable actions iframe target support

### DIFF
--- a/src/app/shared/modules/configurable-actions/configurable-action.component.html
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.html
@@ -17,3 +17,73 @@
     {{ actionConfig.label }}
   </button>
 </ng-template>
+
+<ng-container *ngIf="iframeEnabled">
+  <div
+    *ngIf="iframeVisible"
+    class="configurable-action-iframe-backdrop"
+    (click)="closeIframe()"
+  ></div>
+
+  <section
+    *ngIf="iframeVisible"
+    class="configurable-action-iframe-panel mat-elevation-z8"
+    [style.width]="iframeWidth"
+    [style.height]="iframeHeight"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-label]="iframeTitle"
+  >
+    <header class="configurable-action-iframe-header">
+      <span class="configurable-action-iframe-title">{{ iframeTitle }}</span>
+      <div class="configurable-action-iframe-actions">
+        <button
+          mat-icon-button
+          type="button"
+          aria-label="Open iframe in a new tab"
+          title="Open in new tab"
+          (click)="openIframeInNewTab()"
+        >
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+        <button
+          mat-icon-button
+          type="button"
+          aria-label="Close iframe"
+          title="Close"
+          (click)="closeIframe()"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+    </header>
+    <div class="configurable-action-iframe-content">
+      <iframe
+        class="configurable-action-iframe"
+        [attr.name]="iframeName"
+        [attr.title]="iframeTitle"
+        (load)="onIframeLoad($event)"
+      ></iframe>
+
+      <div
+        *ngIf="iframeLoading"
+        class="configurable-action-iframe-loading"
+        aria-live="polite"
+      >
+        <mat-progress-spinner
+          color="primary"
+          diameter="40"
+          mode="indeterminate"
+        ></mat-progress-spinner>
+        <span>Loading...</span>
+      </div>
+    </div>
+  </section>
+
+  <iframe
+    *ngIf="!iframeVisible"
+    class="configurable-action-hidden-iframe"
+    [attr.name]="iframeName"
+    [attr.title]="iframeTitle"
+  ></iframe>
+</ng-container>

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.html
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.html
@@ -1,17 +1,22 @@
 <ng-template [ngIf]="visible">
   <button
-    *ngIf="buttonStyle.raised" 
+    *ngIf="buttonStyle.raised"
     mat-raised-button
     (click)="performAction()"
-    [color]="buttonStyle.color" 
-    [disabled]="disabled">
+    [color]="buttonStyle.color"
+    [disabled]="disabled"
+  >
     <mat-icon *ngIf="useMatIcon">{{ actionConfig.mat_icon }}</mat-icon>
     <img *ngIf="useIcon" src="{{ actionConfig.icon }}" />
     {{ actionConfig.label }}
   </button>
-  <button *ngIf="!buttonStyle.raised" mat-button
-    [color]="buttonStyle.color" (click)="performAction()"
-    [disabled]="disabled">
+  <button
+    *ngIf="!buttonStyle.raised"
+    mat-button
+    (click)="performAction()"
+    [color]="buttonStyle.color"
+    [disabled]="disabled"
+  >
     <mat-icon *ngIf="useMatIcon">{{ actionConfig.mat_icon }}</mat-icon>
     <img *ngIf="useIcon" src="{{ actionConfig.icon }}" />
     {{ actionConfig.label }}
@@ -26,15 +31,20 @@
   ></div>
 
   <section
-    *ngIf="iframeVisible"
-    class="configurable-action-iframe-panel mat-elevation-z8"
+    class="configurable-action-iframe-host"
+    [class.configurable-action-iframe-panel]="iframeVisible"
+    [class.configurable-action-iframe-hidden-host]="!iframeVisible"
+    [class.mat-elevation-z8]="iframeVisible"
     [style.width]="iframeWidth"
     [style.height]="iframeHeight"
-    role="dialog"
-    aria-modal="true"
+    [attr.role]="iframeVisible ? 'dialog' : null"
+    [attr.aria-modal]="iframeVisible ? 'true' : null"
     [attr.aria-label]="iframeTitle"
   >
-    <header class="configurable-action-iframe-header">
+    <header
+      *ngIf="iframeVisible"
+      class="configurable-action-iframe-header"
+    >
       <span class="configurable-action-iframe-title">{{ iframeTitle }}</span>
       <div class="configurable-action-iframe-actions">
         <button
@@ -57,16 +67,20 @@
         </button>
       </div>
     </header>
-    <div class="configurable-action-iframe-content">
+    <div
+      class="configurable-action-iframe-content"
+      [class.configurable-action-iframe-hidden-content]="!iframeVisible"
+    >
       <iframe
         class="configurable-action-iframe"
-        [attr.name]="iframeName"
-        [attr.title]="iframeTitle"
-        (load)="onIframeLoad($event)"
+        [class.configurable-action-hidden-iframe]="!iframeVisible"
+        [name]="iframeName"
+        [id]="iframeName"
+        [title]="iframeTitle"
+        (load)="onIframeLoad()"
       ></iframe>
-
       <div
-        *ngIf="iframeLoading"
+        *ngIf="iframeVisible && iframeLoading"
         class="configurable-action-iframe-loading"
         aria-live="polite"
       >
@@ -79,11 +93,4 @@
       </div>
     </div>
   </section>
-
-  <iframe
-    *ngIf="!iframeVisible"
-    class="configurable-action-hidden-iframe"
-    [attr.name]="iframeName"
-    [attr.title]="iframeTitle"
-  ></iframe>
 </ng-container>

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.scss
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.scss
@@ -8,3 +8,87 @@ button {
     vertical-align: middle;
   }
 }
+
+.configurable-action-iframe-backdrop {
+  background: rgba(0, 0, 0, 0.32);
+  inset: 0;
+  position: fixed;
+  z-index: 9999;
+}
+
+.configurable-action-iframe-panel {
+  background: var(--mat-dialog-container-color, #fff);
+  border-radius: var(--mdc-dialog-container-shape, 4px);
+  color: var(--mat-dialog-supporting-text-color, rgba(0, 0, 0, 0.87));
+  display: flex;
+  flex-direction: column;
+  left: 50%;
+  max-height: calc(100vh - 96px);
+  max-width: calc(100vw - 32px);
+  overflow: hidden;
+  position: fixed;
+  top: 64px;
+  transform: translateX(-50%);
+  z-index: 10000;
+}
+
+.configurable-action-iframe-header {
+  align-items: center;
+  background: var(--theme-primary-default);
+  color: var(--theme-primary-default-contrast);
+  display: flex;
+  justify-content: space-between;
+  min-height: 48px;
+  padding: 0 8px 0 16px;
+
+  button {
+    color: inherit;
+    flex: 0 0 auto;
+  }
+}
+
+.configurable-action-iframe-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 2px;
+}
+
+.configurable-action-iframe-title {
+  font-size: 1.25rem;
+  flex: 1 1 auto;
+  font-weight: 400;
+  line-height: 1.5rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.configurable-action-iframe {
+  border: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.configurable-action-iframe-content {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.configurable-action-iframe-loading {
+  align-items: center;
+  background: var(--mat-dialog-container-color, #fff);
+  color: var(--mat-dialog-supporting-text-color, rgba(0, 0, 0, 0.87));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  inset: 0;
+  justify-content: center;
+  position: absolute;
+}
+
+.configurable-action-hidden-iframe {
+  display: none;
+}

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.scss
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.scss
@@ -9,6 +9,10 @@ button {
   }
 }
 
+.configurable-action-iframe-host {
+  box-sizing: border-box;
+}
+
 .configurable-action-iframe-backdrop {
   background: rgba(0, 0, 0, 0.32);
   inset: 0;
@@ -19,7 +23,10 @@ button {
 .configurable-action-iframe-panel {
   background: var(--mat-dialog-container-color, #fff);
   border-radius: var(--mdc-dialog-container-shape, 4px);
-  color: var(--mat-dialog-supporting-text-color, rgba(0, 0, 0, 0.87));
+  color: var(
+    --mat-dialog-supporting-text-color,
+    rgba(0, 0, 0, 0.87)
+  );
   display: flex;
   flex-direction: column;
   left: 50%;
@@ -30,6 +37,14 @@ button {
   top: 64px;
   transform: translateX(-50%);
   z-index: 10000;
+}
+
+.configurable-action-iframe-hidden-host {
+  border: 0;
+  height: 0;
+  overflow: hidden;
+  position: absolute;
+  width: 0;
 }
 
 .configurable-action-iframe-header {
@@ -55,8 +70,8 @@ button {
 }
 
 .configurable-action-iframe-title {
-  font-size: 1.25rem;
   flex: 1 1 auto;
+  font-size: 1.25rem;
   font-weight: 400;
   line-height: 1.5rem;
   min-width: 0;
@@ -65,30 +80,42 @@ button {
   white-space: nowrap;
 }
 
-.configurable-action-iframe {
-  border: 0;
-  height: 100%;
-  width: 100%;
-}
-
 .configurable-action-iframe-content {
   flex: 1;
   min-height: 0;
   position: relative;
 }
 
+.configurable-action-iframe-hidden-content {
+  height: 0;
+  overflow: hidden;
+  width: 0;
+}
+
+.configurable-action-iframe {
+  border: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.configurable-action-hidden-iframe {
+  border: 0;
+  height: 0;
+  visibility: hidden;
+  width: 0;
+}
+
 .configurable-action-iframe-loading {
   align-items: center;
   background: var(--mat-dialog-container-color, #fff);
-  color: var(--mat-dialog-supporting-text-color, rgba(0, 0, 0, 0.87));
+  color: var(
+    --mat-dialog-supporting-text-color,
+    rgba(0, 0, 0, 0.87)
+  );
   display: flex;
   flex-direction: column;
   gap: 12px;
   inset: 0;
   justify-content: center;
   position: absolute;
-}
-
-.configurable-action-hidden-iframe {
-  display: none;
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -67,8 +67,8 @@ import { buildDefaultBatchActions } from "./configurable-actions.defaults";
 describe("1000: ConfigurableActionComponent", () => {
   let component: ConfigurableActionComponent;
   let fixture: ComponentFixture<ConfigurableActionComponent>;
-  let htmlForm: HTMLFormElement;
   let htmlInput: HTMLInputElement;
+  let createNativeElement: (tagName: string) => HTMLElement;
 
   let store: MockStore;
 
@@ -97,8 +97,7 @@ describe("1000: ConfigurableActionComponent", () => {
   // });
 
   beforeAll(() => {
-    htmlForm = document.createElement("form");
-    (htmlForm as HTMLFormElement).submit = () => {};
+    createNativeElement = document.createElement.bind(document);
     htmlInput = document.createElement("input");
   });
 
@@ -648,13 +647,14 @@ describe("1000: ConfigurableActionComponent", () => {
 
     switch (elementType) {
       case "form":
-        element = htmlForm.cloneNode(true) as HTMLElement;
+        element = createNativeElement("form");
+        (element as HTMLFormElement).submit = () => {};
         break;
       case "input":
         element = htmlInput.cloneNode(true) as HTMLElement;
         break;
       default:
-        element = null;
+        element = createNativeElement(elementType);
     }
     return element;
   }
@@ -828,7 +828,8 @@ describe("1000: ConfigurableActionComponent", () => {
       ),
       id: "iframe-form",
       type: "form",
-      iframe: {
+      target: "iframe",
+      iframeConfig: {
         name: "download-frame",
         hidden: false,
         width: "50%",
@@ -841,6 +842,7 @@ describe("1000: ConfigurableActionComponent", () => {
     component.performAction();
 
     expect(component.form.target).toBe("download-frame");
+    expect(component.form.parentNode).toBe(document.body);
     expect(component.iframeEnabled).toBeTrue();
     expect(component.iframeVisible).toBeTrue();
     expect(component.iframeName).toBe("download-frame");
@@ -848,28 +850,14 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(component.iframeWidth).toBe("50%");
     expect(component.iframeHeight).toBe("300px");
     expect(component.iframeLoading).toBeTrue();
+    const iframe = document.getElementById(
+      "download-frame",
+    ) as HTMLIFrameElement;
+    expect(iframe).not.toBeNull();
+    expect(iframe.name).toBe("download-frame");
+    expect(iframe.contentWindow?.name).toBe("download-frame");
 
-    component.onIframeLoad({
-      target: {
-        contentWindow: {
-          location: {
-            href: "about:blank",
-          },
-        },
-      },
-    } as unknown as Event);
-
-    expect(component.iframeLoading).toBeTrue();
-
-    component.onIframeLoad({
-      target: {
-        contentWindow: {
-          location: {
-            href: "https://example.com/viewer",
-          },
-        },
-      },
-    } as unknown as Event);
+    component.onIframeLoad();
 
     expect(component.iframeLoading).toBeFalse();
 
@@ -883,6 +871,83 @@ describe("1000: ConfigurableActionComponent", () => {
 
     expect(submitSpy).toHaveBeenCalledTimes(1);
     expect(component.form.target).toBe("download-frame");
+  });
+
+  it("1066: Hidden iframe form submission should still create a targetable iframe", () => {
+    const iframeFormConfig: ActionConfig = {
+      ...mockActionsConfig.find(
+        (a) => a.id === actionSelectorType.download_all,
+      ),
+      id: "hidden-iframe-form",
+      type: "form",
+      target: "iframe",
+      iframeConfig: {
+        name: "hidden-download-frame",
+        hidden: true,
+      },
+    } as ActionConfig;
+    createComponent(iframeFormConfig, mockActionItemsDatafilesNofiles);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+
+    component.performAction();
+
+    expect(component.form.target).toBe("hidden-download-frame");
+    expect(component.iframeEnabled).toBeTrue();
+    expect(component.iframeVisible).toBeFalse();
+    expect(component.iframeLoading).toBeFalse();
+    expect(document.getElementById("hidden-download-frame")).not.toBeNull();
+  });
+
+  it("1067: Repeated iframe form submissions should clean up the previous form", () => {
+    const iframeFormConfig: ActionConfig = {
+      ...mockActionsConfig.find(
+        (a) => a.id === actionSelectorType.download_all,
+      ),
+      id: "repeat-iframe-form",
+      type: "form",
+      target: "iframe",
+      iframeConfig: {
+        name: "repeat-download-frame",
+        hidden: false,
+      },
+    } as ActionConfig;
+    createComponent(iframeFormConfig, mockActionItemsDatafilesNofiles);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+
+    component.performAction();
+    const firstForm = component.form;
+
+    expect(() => component.performAction()).not.toThrow();
+    expect(firstForm.parentNode).toBeNull();
+    expect(component.form.parentNode).toBe(document.body);
+    expect(component.form.target).toBe("repeat-download-frame");
+  });
+
+  it("1068: Form submission should interpolate configured URL", () => {
+    const iframeFormConfig: ActionConfig = {
+      ...mockActionsConfig.find(
+        (a) => a.id === actionSelectorType.download_all,
+      ),
+      id: "iframe-form-url",
+      type: "form",
+      url: "https://example.com/notebook/{{ @pid }}",
+      variables: {
+        pid: "#Dataset0Pid",
+      },
+      target: "iframe",
+      iframeConfig: {
+        name: "download-frame",
+        hidden: false,
+      },
+    } as ActionConfig;
+    createComponent(iframeFormConfig, mockActionItems);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+
+    component.performAction();
+
+    expect(component.form.action).toBe(
+      "https://example.com/notebook/40f3beec-bee2-11f0-8c47-4b68a24470e0",
+    );
   });
 
   it("1070: Download All action button should contain the correct label", () => {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.spec.ts
@@ -30,6 +30,7 @@ import {
 } from "@scicatproject/scicat-sdk-ts-angular";
 import { AuthService } from "shared/services/auth/auth.service";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 //import { DataFiles_File } from "datasets/datafiles/datafiles.interfaces";
 import { AppConfigService } from "app-config.service";
 //import { boolean } from "mathjs";
@@ -114,6 +115,7 @@ describe("1000: ConfigurableActionComponent", () => {
         ReactiveFormsModule,
         MatDialogModule,
         MatSnackBarModule,
+        MatProgressSpinnerModule,
         RouterModule,
         RouterModule.forRoot([]),
         StoreModule.forRoot({}),
@@ -817,6 +819,70 @@ describe("1000: ConfigurableActionComponent", () => {
     expect(selectedFiles.length).toEqual(1);
     const selectedFilePath = selectedFiles[0].path;
     expect(formFilePath).toEqual(selectedFilePath);
+  });
+
+  it("1065: Form submission should target a configured iframe", () => {
+    const iframeFormConfig: ActionConfig = {
+      ...mockActionsConfig.find(
+        (a) => a.id === actionSelectorType.download_all,
+      ),
+      id: "iframe-form",
+      type: "form",
+      iframe: {
+        name: "download-frame",
+        hidden: false,
+        width: "50%",
+        height: "300px",
+      },
+    } as ActionConfig;
+    createComponent(iframeFormConfig, mockActionItemsDatafilesNofiles);
+    spyOn(document, "createElement").and.callFake(createFakeElement);
+
+    component.performAction();
+
+    expect(component.form.target).toBe("download-frame");
+    expect(component.iframeEnabled).toBeTrue();
+    expect(component.iframeVisible).toBeTrue();
+    expect(component.iframeName).toBe("download-frame");
+    expect(component.iframeTitle).toBe("download-frame");
+    expect(component.iframeWidth).toBe("50%");
+    expect(component.iframeHeight).toBe("300px");
+    expect(component.iframeLoading).toBeTrue();
+
+    component.onIframeLoad({
+      target: {
+        contentWindow: {
+          location: {
+            href: "about:blank",
+          },
+        },
+      },
+    } as unknown as Event);
+
+    expect(component.iframeLoading).toBeTrue();
+
+    component.onIframeLoad({
+      target: {
+        contentWindow: {
+          location: {
+            href: "https://example.com/viewer",
+          },
+        },
+      },
+    } as unknown as Event);
+
+    expect(component.iframeLoading).toBeFalse();
+
+    const submitSpy = spyOn(component.form, "submit").and.callFake(function (
+      this: HTMLFormElement,
+    ) {
+      expect(this.target).toBe("_blank");
+    });
+
+    component.openIframeInNewTab();
+
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+    expect(component.form.target).toBe("download-frame");
   });
 
   it("1070: Download All action button should contain the correct label", () => {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -7,6 +7,7 @@ import {
   Output,
   SimpleChanges,
   OnDestroy,
+  ChangeDetectorRef,
 } from "@angular/core";
 import { DatePipe } from "@angular/common";
 import {
@@ -80,6 +81,14 @@ export class ConfigurableActionComponent
   isAdmin = false;
   subscriptions: Subscription[] = [];
   form: HTMLFormElement | null = null;
+  iframeEnabled = false;
+  iframeVisible = false;
+  iframeName = "";
+  iframeTitle = "";
+  iframeWidth = "100%";
+  iframeHeight = "400px";
+  iframeLoading = false;
+  private iframeLoadArmed = false;
 
   constructor(
     private usersService: UsersService,
@@ -87,6 +96,7 @@ export class ConfigurableActionComponent
     private configService: AppConfigService,
     private store: Store,
     private datePipe: DatePipe,
+    private cdRef: ChangeDetectorRef,
     public dialog: MatDialog,
     private apiConfiguration: ApiConfiguration,
   ) {}
@@ -392,7 +402,7 @@ export class ConfigurableActionComponent
   private typeForm() {
     if (this.form) document.body.removeChild(this.form);
     this.form = document.createElement("form");
-    this.form.target = this.actionConfig.target || "_self";
+    this.form.target = this.getFormTarget();
     this.form.method = this.actionConfig.method || "POST";
     this.form.action = this.actionConfig.url;
     this.form.style.display = "none";
@@ -413,8 +423,71 @@ export class ConfigurableActionComponent
     });
 
     document.body.appendChild(this.form);
+    this.iframeLoadArmed = this.iframeVisible;
     this.form.submit();
     return true;
+  }
+
+  private getFormTarget(): string {
+    if (!this.actionConfig.iframe) return this.actionConfig.target || "_self";
+
+    return this.ensureIframeTarget();
+  }
+
+  private ensureIframeTarget(): string {
+    const config =
+      typeof this.actionConfig.iframe === "object"
+        ? this.actionConfig.iframe
+        : {};
+    const name = config.name || `configurable-action-${this.actionConfig.id}`;
+
+    this.iframeEnabled = true;
+    this.iframeVisible = config.hidden === false;
+    this.iframeName = name;
+    this.iframeTitle = name;
+    this.iframeWidth = config.width || (this.iframeVisible ? "90vw" : "100%");
+    this.iframeHeight =
+      config.height || (this.iframeVisible ? "70vh" : "400px");
+    this.iframeLoading = this.iframeVisible;
+    this.iframeLoadArmed = false;
+    this.cdRef.detectChanges();
+
+    return name;
+  }
+
+  closeIframe() {
+    this.iframeVisible = false;
+    this.iframeLoading = false;
+    this.iframeLoadArmed = false;
+  }
+
+  openIframeInNewTab() {
+    if (!this.form) return;
+
+    const currentTarget = this.form.target;
+    this.form.target = "_blank";
+    try {
+      this.form.submit();
+    } finally {
+      this.form.target = currentTarget;
+    }
+  }
+
+  onIframeLoad(event: Event) {
+    if (!this.iframeLoadArmed) return;
+    if (this.isIframeAboutBlank(event.target as HTMLIFrameElement | null))
+      return;
+
+    this.iframeLoading = false;
+    this.iframeLoadArmed = false;
+  }
+
+  private isIframeAboutBlank(iframe: HTMLIFrameElement | null): boolean {
+    try {
+      return iframe?.contentWindow?.location.href === "about:blank";
+    } catch {
+      return false;
+    }
   }
 
   private preparePayload(): string {
@@ -608,6 +681,7 @@ export class ConfigurableActionComponent
 
   ngOnDestroy() {
     this.subscriptions.forEach((s) => s.unsubscribe());
+    if (this.form?.parentNode) this.form.parentNode.removeChild(this.form);
   }
 
   performAction() {

--- a/src/app/shared/modules/configurable-actions/configurable-action.component.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.component.ts
@@ -22,6 +22,7 @@ import {
   ActionItems,
   ActionType,
   DialogField,
+  IframeConfig,
 } from "./configurable-action.interfaces";
 import { AuthService } from "shared/services/auth/auth.service";
 import { v4 as uuidv4 } from "uuid";
@@ -49,6 +50,7 @@ import {
 export class ConfigurableActionComponent
   implements OnInit, OnChanges, OnDestroy
 {
+  private iframeLoadArmed = false;
   private authorizationTokens = {
     "#jwt": () => this.jwt,
     "#token": () => this.authService.getToken()?.id,
@@ -88,7 +90,6 @@ export class ConfigurableActionComponent
   iframeWidth = "100%";
   iframeHeight = "400px";
   iframeLoading = false;
-  private iframeLoadArmed = false;
 
   constructor(
     private usersService: UsersService,
@@ -400,11 +401,17 @@ export class ConfigurableActionComponent
   }
 
   private typeForm() {
-    if (this.form) document.body.removeChild(this.form);
+    if (this.actionConfig.target === "iframe") {
+      this.prepareIframe();
+      this.cdRef.detectChanges();
+    }
+    if (this.form?.parentNode) this.form.parentNode.removeChild(this.form);
     this.form = document.createElement("form");
-    this.form.target = this.getFormTarget();
+    this.form.id = this.actionConfig.id;
+    this.form.name = this.actionConfig.id;
+    this.form.target = this.getTarget();
     this.form.method = this.actionConfig.method || "POST";
-    this.form.action = this.actionConfig.url;
+    this.form.action = this.interpolate(this.actionConfig.url);
     this.form.style.display = "none";
 
     Object.entries(this.actionConfig.inputs || {}).forEach(([input, def]) => {
@@ -421,72 +428,48 @@ export class ConfigurableActionComponent
         this.form!.appendChild(this.addInputElement(input, String(value)));
       }
     });
-
     document.body.appendChild(this.form);
-    this.iframeLoadArmed = this.iframeVisible;
+    if (this.actionConfig.target === "iframe") {
+      this.iframeLoadArmed = this.iframeVisible;
+      this.syncIframeTargetWindowName();
+    }
     this.form.submit();
     return true;
   }
 
-  private getFormTarget(): string {
-    if (!this.actionConfig.iframe) return this.actionConfig.target || "_self";
+  private getTarget(): string {
+    // pre-defined target (default: new tab)
+    if (this.actionConfig.target !== "iframe")
+      return this.actionConfig.target || "_self";
 
-    return this.ensureIframeTarget();
+    // Iframe target
+    return this.iframeName;
   }
 
-  private ensureIframeTarget(): string {
-    const config =
-      typeof this.actionConfig.iframe === "object"
-        ? this.actionConfig.iframe
-        : {};
-    const name = config.name || `configurable-action-${this.actionConfig.id}`;
-
+  private prepareIframe() {
+    const config = this.actionConfig.iframeConfig || {
+      name: `configurable-action-${this.actionConfig.id}`,
+    };
     this.iframeEnabled = true;
-    this.iframeVisible = config.hidden === false;
-    this.iframeName = name;
-    this.iframeTitle = name;
-    this.iframeWidth = config.width || (this.iframeVisible ? "90vw" : "100%");
-    this.iframeHeight =
-      config.height || (this.iframeVisible ? "70vh" : "400px");
+    this.iframeVisible = (config.hidden ?? true) === false;
+    this.iframeName = config.name;
+    this.iframeTitle = config.title || config.name;
+    this.iframeWidth = config.width || "90vw";
+    this.iframeHeight = config.height || "70vh";
     this.iframeLoading = this.iframeVisible;
     this.iframeLoadArmed = false;
-    this.cdRef.detectChanges();
 
-    return name;
+    return config.name;
   }
 
-  closeIframe() {
-    this.iframeVisible = false;
-    this.iframeLoading = false;
-    this.iframeLoadArmed = false;
-  }
-
-  openIframeInNewTab() {
-    if (!this.form) return;
-
-    const currentTarget = this.form.target;
-    this.form.target = "_blank";
-    try {
-      this.form.submit();
-    } finally {
-      this.form.target = currentTarget;
-    }
-  }
-
-  onIframeLoad(event: Event) {
-    if (!this.iframeLoadArmed) return;
-    if (this.isIframeAboutBlank(event.target as HTMLIFrameElement | null))
-      return;
-
-    this.iframeLoading = false;
-    this.iframeLoadArmed = false;
-  }
-
-  private isIframeAboutBlank(iframe: HTMLIFrameElement | null): boolean {
-    try {
-      return iframe?.contentWindow?.location.href === "about:blank";
-    } catch {
-      return false;
+  private syncIframeTargetWindowName() {
+    // Make sure iframe target is correctly set
+    if (!this.form || this.actionConfig.target !== "iframe") return;
+    const iframe = document.getElementById(
+      this.iframeName,
+    ) as HTMLIFrameElement | null;
+    if (iframe?.contentWindow) {
+      iframe.contentWindow.name = this.form.target;
     }
   }
 
@@ -530,10 +513,7 @@ export class ConfigurableActionComponent
   }
 
   private typeLink() {
-    window.open(
-      this.interpolate(this.actionConfig.url),
-      this.actionConfig.target || "_self",
-    );
+    window.open(this.interpolate(this.actionConfig.url), this.getTarget());
   }
 
   private typeDialog() {
@@ -620,6 +600,50 @@ export class ConfigurableActionComponent
     });
   }
 
+  closeIframe() {
+    this.iframeVisible = false;
+    this.iframeLoading = false;
+    this.iframeLoadArmed = false;
+  }
+
+  openIframeInNewTab() {
+    if (this.form) {
+      const currentTarget = this.form.target;
+      this.form.target = "_blank";
+      try {
+        this.form.submit();
+      } finally {
+        this.form.target = currentTarget;
+      }
+    } else if (this.actionConfig.type === "link") {
+      window.open(this.interpolate(this.actionConfig.url), "_blank");
+    }
+  }
+
+  onIframeLoad() {
+    if (!this.iframeLoadArmed) return;
+    this.iframeLoading = false;
+    this.iframeLoadArmed = false;
+  }
+
+  performAction() {
+    this.resolveVariableContext();
+    const type = this.actionConfig.type || "form";
+    switch (type) {
+      case "json-download":
+        return this.typeJsonToDownload();
+      case "xhr":
+        return this.typeXhr();
+      case "link":
+        return this.typeLink();
+      case "dialog":
+        return this.typeDialog();
+      case "form":
+      default:
+        return this.typeForm();
+    }
+  }
+
   get visible(): boolean {
     try {
       this.resolveVariableContext();
@@ -682,23 +706,5 @@ export class ConfigurableActionComponent
   ngOnDestroy() {
     this.subscriptions.forEach((s) => s.unsubscribe());
     if (this.form?.parentNode) this.form.parentNode.removeChild(this.form);
-  }
-
-  performAction() {
-    this.resolveVariableContext();
-    const type = this.actionConfig.type || "form";
-    switch (type) {
-      case "json-download":
-        return this.typeJsonToDownload();
-      case "xhr":
-        return this.typeXhr();
-      case "link":
-        return this.typeLink();
-      case "dialog":
-        return this.typeDialog();
-      case "form":
-      default:
-        return this.typeForm();
-    }
   }
 }

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -6,7 +6,8 @@ import { OutputDatasetObsoleteDto } from "@scicatproject/scicat-sdk-ts-angular";
 export type DialogField = { key: string } & DynamicField;
 
 export interface IframeConfig {
-  name?: string;
+  name: string;
+  title?: string;
   hidden?: boolean;
   width?: string;
   height?: string;
@@ -43,8 +44,8 @@ export interface ActionConfig {
   icon?: string;
   type?: ActionType;
   url: string;
-  target?: "_blank" | "_self" | "_parent" | "_top";
-  iframe?: boolean | IframeConfig;
+  target?: "_blank" | "_self" | "_parent" | "_top" | "iframe";
+  iframeConfig?: IframeConfig;
   authorization: string[];
   method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
   enabled?: string | boolean;

--- a/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-action.interfaces.ts
@@ -5,6 +5,13 @@ import { OutputDatasetObsoleteDto } from "@scicatproject/scicat-sdk-ts-angular";
 
 export type DialogField = { key: string } & DynamicField;
 
+export interface IframeConfig {
+  name?: string;
+  hidden?: boolean;
+  width?: string;
+  height?: string;
+}
+
 export interface DialogConfig {
   title?: string;
   description?: string;
@@ -37,6 +44,7 @@ export interface ActionConfig {
   type?: ActionType;
   url: string;
   target?: "_blank" | "_self" | "_parent" | "_top";
+  iframe?: boolean | IframeConfig;
   authorization: string[];
   method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
   enabled?: string | boolean;

--- a/src/app/shared/modules/configurable-actions/configurable-actions.module.ts
+++ b/src/app/shared/modules/configurable-actions/configurable-actions.module.ts
@@ -5,9 +5,15 @@ import { MatButtonModule } from "@angular/material/button";
 import { ConfigurableActionsComponent } from "./configurable-actions.component";
 import { ConfigurableActionComponent } from "./configurable-action.component";
 import { MatIconModule } from "@angular/material/icon";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 
 @NgModule({
-  imports: [CommonModule, MatIconModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+  ],
   declarations: [ConfigurableActionsComponent, ConfigurableActionComponent],
   exports: [ConfigurableActionsComponent, ConfigurableActionComponent],
 })


### PR DESCRIPTION
## Description
Support `iframe` target for `form` and `link` type configurable actions. 


## Motivation
- Provides a user friendly interface for external services while remaining on the same window:
- for example  (an HDF5 file viewer):
<img width="2371" height="1615" alt="Screenshot_2026-07-29_15-16-53" src="https://github.com/user-attachments/assets/bc80b16e-4dfd-4d9d-91b4-09b51d033fdb" />


## Changes:
- Updates the configurable-action component


## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Backend version
- [ ] Does it require a specific version of the backend
- which version of the backend is required:

## Summary by Sourcery

Enable configurable form and link actions to open external services in an embedded, configurable iframe while remaining on the current page.

New Features:
- Support configurable form and link actions targeting an embedded iframe with configurable name, title, size, and visibility.
- Provide an iframe panel with loading feedback, close controls, and an option to open the action in a new tab.

Bug Fixes:
- Ensure iframe-targeted form submissions use the configured interpolated action URL and clean up previously generated forms.

Enhancements:
- Extend configurable action definitions with iframe target and presentation settings while preserving existing targets.

Tests:
- Add coverage for visible and hidden iframe targets, repeated submissions, URL interpolation, loading state, and opening form actions in a new tab.