### PR TITLE
feat: custom dynamic dataset detail appearence

### DIFF
--- a/docs/dataset-detail-section-appearance.md
+++ b/docs/dataset-detail-section-appearance.md
@@ -1,0 +1,61 @@
+# Dataset Detail Section Appearance
+
+## Overview
+
+Each section (tile) of the customized dataset detail page renders a header with
+an icon and a background color. Both can be configured per section through the
+`icon` and `headerColor` properties of a `datasetDetailComponent.customization`
+entry, either in the configuration file or through the Admin Dashboard at
+`/admin/config-edit`.
+
+Both properties are optional and fully backward compatible: sections without
+them keep the default icon (`description`) and the default header color (`header-5`).
+
+## Configuration Options
+
+| Property      | Type   | Description                                                       |
+| ------------- | ------ | ------------------------------------------------------------------|
+| `icon`        | string | Material icon name displayed in the section header, e.g. `science`|
+| `headerColor` | string | Section header background color: a theme palette name             |
+
+The `statusBanner` section type has no header, so both properties are ignored
+for it.
+
+### Icons
+
+`icon` accepts any [Material icon](https://fonts.google.com/icons) ligature
+name. When it is not set, the icon is defaulted to `description`
+
+### Header colors
+
+`headerColor` accepts a theme palette name.
+
+Palette names refer to the palettes of the active theme, so the header follows
+the deployment theme and also gets a matching text color:
+
+`primary`, `accent`, `warn`, `header-1`, `header-2`, `header-3`,
+`header-4`, `header-5`
+
+## Usage Examples
+
+Section with a custom icon and a theme palette color:
+
+```json
+{
+  "type": "regular",
+  "label": "Contact Information",
+  "order": 2,
+  "col": 2,
+  "row": 1,
+  "icon": "contact_mail",
+  "headerColor": "header-2",
+  "fields": [
+    { "element": "text", "source": "principalInvestigator", "order": 0 },
+    { "element": "linky", "source": "contactEmail", "order": 1 }
+  ]
+}
+```
+
+## Related Documentation
+
+- [Dataset Detail Tile Authorization](dataset-detail-tile-authorization.md)

--- a/docs/dataset-detail-tile-authorization.md
+++ b/docs/dataset-detail-tile-authorization.md
@@ -219,6 +219,8 @@ export interface CustomizationItem {
   authorization?: string[];  // Tile-specific authorization (empty array means no restriction)
   visible?: boolean;  // Controls visibility (defaults to true)
   restrictedIconVisible?: boolean;  // Computed at runtime, indicates if lock icon should be shown
+  icon?: string;
+  headerColor?: themePalette;
 }
 ```
 

--- a/src/app/admin/schema/frontend.config.jsonforms.json
+++ b/src/app/admin/schema/frontend.config.jsonforms.json
@@ -392,6 +392,22 @@
                   "type": "string",
                   "enum": ["table", "json", "tree"]
                 },
+                "icon": {
+                  "type": "string"
+                },
+                "headerColor": {
+                  "type": "string",
+                  "enum": [
+                    "primary",
+                    "accent",
+                    "warn",
+                    "header-1",
+                    "header-2",
+                    "header-3",
+                    "header-4",
+                    "header-5"
+                  ]
+                },
                 "authorization": {
                   "type": "array",
                   "items": { "type": "string" }
@@ -871,6 +887,22 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "type": "HorizontalLayout",
+                    "elements": [
+                      { "type": "Control", "scope": "#/properties/icon" },
+                      { "type": "Control", "scope": "#/properties/headerColor" }
+                    ],
+                    "rule": {
+                      "effect": "HIDE",
+                      "condition": {
+                        "scope": "#/properties/type",
+                        "schema": {
+                          "const": "statusBanner"
+                        }
+                      }
+                    }
                   },
                   {
                     "type": "HorizontalLayout",

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.html
@@ -49,21 +49,10 @@
         >
           <mat-card>
             <!-- Section Header -->
-            <mat-card-header
-              class="dynamic-template-tile-header sticky-header"
-              data-cy="section-label"
-            >
-              <div mat-card-avatar class="section-icon">
-                <mat-icon>description</mat-icon>
-              </div>
-              <span>{{ section.label | translate: localization }}</span>
-              <span
-                *ngIf="section.restrictedIconVisible"
-                class="restricted-indicator"
-              >
-                <mat-icon [matTooltip]="formatAuthorizedGroups(section.authorization)">lock_outline</mat-icon>
-              </span>
-            </mat-card-header>
+            <ng-container
+              [ngTemplateOutlet]="sectionHeader"
+              [ngTemplateOutletContext]="{ section: section }"
+            ></ng-container>
             <!-- Section Content -->
             <mat-card-content>
               <table>
@@ -175,21 +164,10 @@
         >
           <ng-container *ngIf="emptyMetadataTable()">
             <mat-card>
-              <mat-card-header
-                class="dynamic-template-tile-header sticky-header"
-                data-cy="section-label"
-              >
-                <div mat-card-avatar class="section-icon">
-                  <mat-icon>science</mat-icon>
-                </div>
-                <span>{{ section.label | translate: localization }}</span>
-                <span
-                  *ngIf="section.restrictedIconVisible"
-                  class="restricted-indicator"
-                >
-                  <mat-icon [matTooltip]="formatAuthorizedGroups(section.authorization)">lock_outline</mat-icon>
-                </span>
-              </mat-card-header>
+              <ng-container
+                [ngTemplateOutlet]="sectionHeader"
+                [ngTemplateOutletContext]="{ section: section }"
+              ></ng-container>
               <mat-card-content class="scientific-metadata-content">
                 <ng-container *ngIf="appConfig.tableSciDataEnabled">
                   <ng-container
@@ -239,21 +217,10 @@
           [style.gridRow]="'span ' + (section.row || 1)"
         >
           <mat-card>
-            <mat-card-header
-              class="dynamic-template-tile-header sticky-header"
-              data-cy="section-label"
-            >
-              <div mat-card-avatar class="section-icon">
-                <mat-icon>photo_library</mat-icon>
-              </div>
-              <span>{{ section.label | translate: localization }}</span>
-              <span
-                *ngIf="section.restrictedIconVisible"
-                class="restricted-indicator"
-              >
-                <mat-icon [matTooltip]="formatAuthorizedGroups(section.authorization)">lock_outline</mat-icon>
-              </span>
-            </mat-card-header>
+            <ng-container
+              [ngTemplateOutlet]="sectionHeader"
+              [ngTemplateOutletContext]="{ section: section }"
+            ></ng-container>
             <mat-card-content>
               <ng-container *ngIf="attachments$ | async as attachments">
                 <!-- TOP: thumbnails -->
@@ -312,21 +279,10 @@
           [style.gridRow]="'span ' + (section.row || 1)"
         >
           <mat-card>
-            <mat-card-header
-              class="dynamic-template-tile-header sticky-header"
-              data-cy="section-label"
-            >
-              <div mat-card-avatar class="section-icon">
-                <mat-icon>data_object</mat-icon>
-              </div>
-              <span>{{ section.label | translate: localization }}</span>
-              <span
-                *ngIf="section.restrictedIconVisible"
-                class="restricted-indicator"
-              >
-                <mat-icon [matTooltip]="formatAuthorizedGroups(section.authorization)">lock_outline</mat-icon>
-              </span>
-            </mat-card-header>
+            <ng-container
+              [ngTemplateOutlet]="sectionHeader"
+              [ngTemplateOutletContext]="{ section: section }"
+            ></ng-container>
             <mat-card-content>
               <ng-container *ngIf="appConfig.jsonMetadataEnabled">
                 <button
@@ -354,4 +310,24 @@
       </ng-container>
     </ng-container>
   </div>
+
+  <!-- Details Header Section Template -->
+  <ng-template #sectionHeader let-section="section">
+    <mat-card-header
+      class="dynamic-template-tile-header sticky-header"
+      data-cy="section-label"
+      [style.background-color]="getHeaderColor(section)"
+    >
+      <div mat-card-avatar class="section-icon">
+        <mat-icon>{{ section.icon || "description" }}</mat-icon>
+      </div>
+      <span>{{ section.label | translate: localization }}</span>
+      <span 
+        *ngIf="section.restrictedIconVisible" 
+        class="restricted-indicator"
+      >
+        <mat-icon [matTooltip]="formatAuthorizedGroups(section.authorization)">lock_outline</mat-icon>
+      </span>
+    </mat-card-header>
+  </ng-template>
 </ng-template>

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.spec.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.spec.ts
@@ -232,6 +232,21 @@ describe("DatasetDetailDynamicComponent", () => {
     });
   });
 
+  describe("getHeaderColor", () => {
+    it("should return header-5 when no color is configured", () => {
+      expect(component.getHeaderColor({ type: "regular" } as any)).toBe(
+        "var(--theme-header-5-lighter)",
+      );
+    });
+
+    it("should resolve a theme palette name to the palette css variable", () => {
+      const section = { type: "regular", headerColor: "header-2" } as any;
+      expect(component.getHeaderColor(section)).toBe(
+        "var(--theme-header-2-lighter)",
+      );
+    });
+  });
+
   describe("getScientificMetadata", () => {
     type TestCase = {
       desc: string;

--- a/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
+++ b/src/app/datasets/dataset-detail/dataset-detail-dynamic/dataset-detail-dynamic.component.ts
@@ -229,6 +229,10 @@ export class DatasetDetailDynamicComponent implements OnInit, OnDestroy {
     return groups.join(", ");
   }
 
+  getHeaderColor(section: CustomizationItem): string {
+    return `var(--theme-${section.headerColor || "header-5"}-lighter)`;
+  }
+
   onCopy(value: string) {
     navigator.clipboard.writeText(value).then(
       () => {

--- a/src/app/state-management/models/index.ts
+++ b/src/app/state-management/models/index.ts
@@ -77,6 +77,16 @@ interface AttachmentOptions {
 }
 type viewModeOptions = "table" | "json" | "tree";
 
+type themePalette =
+  | "primary"
+  | "accent"
+  | "warn"
+  | "header-1"
+  | "header-2"
+  | "header-3"
+  | "header-4"
+  | "header-5";
+
 export interface CustomizationItem {
   type: CustomizationType;
   label: string;
@@ -90,6 +100,8 @@ export interface CustomizationItem {
   authorization?: string[];
   visible?: boolean;
   restrictedIconVisible?: boolean;
+  icon?: string;
+  headerColor?: themePalette;
 }
 
 export interface Field {


### PR DESCRIPTION
## Description
Added `icon` and `headerColor` options for custom appearence in Dynamic Dataset Details components.
Both fields are **Optional**

## Motivation
The option to customize the appearance for each instance   

## Changes:
- Configuration update

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [x] official documentation updated \[nice-to-have\]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

## Summary by Sourcery

Customize the appearance of dynamic dataset detail sections with optional icons and theme palette header colors.

New Features:
- Add optional per-section icons and theme-based header colors to dynamic dataset detail components.

Enhancements:
- Centralize dynamic dataset detail section header rendering while preserving default appearance and authorization indicators.

Documentation:
- Document the new dataset detail section appearance options and supported theme palettes.

Tests:
- Add coverage for default and configured section header colors.